### PR TITLE
Added prometheus metrics funtionality

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 
 	appsv1 "github.com/azure/eviction-autoscaler/api/v1"
 	controllers "github.com/azure/eviction-autoscaler/internal/controller"
+	_ "github.com/azure/eviction-autoscaler/internal/metrics"
 	evictinwebhook "github.com/azure/eviction-autoscaler/internal/webhook"
 	// +kubebuilder:scaffold:imports
 )

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: eviction-autoscaler
+namespace: kube-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
@@ -25,7 +25,7 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-- ../prometheus
+#- ../prometheus
 # [METRICS] To enable the controller manager metrics service, uncomment the following line.
 - metrics_service.yaml
 
@@ -34,9 +34,9 @@ patches:
 # [METRICS] The following patch will enable the metrics endpoint. Ensure that you also protect this endpoint.
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.
-- path: manager_metrics_patch.yaml
-  target:
-    kind: Deployment
+#- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 
   # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
   # +kubebuilder:scaffold:defaultkustomizewebhookpatch

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -30,7 +30,7 @@ resources:
 - metrics_service.yaml
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
-patches:
+# patches:
 # [METRICS] The following patch will enable the metrics endpoint. Ensure that you also protect this endpoint.
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -25,18 +25,18 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 # [METRICS] To enable the controller manager metrics service, uncomment the following line.
-#- metrics_service.yaml
+- metrics_service.yaml
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
-#patches:
+patches:
 # [METRICS] The following patch will enable the metrics endpoint. Ensure that you also protect this endpoint.
 # More info: https://book.kubebuilder.io/reference/metrics
 # If you want to expose the metric endpoint of your controller-manager uncomment the following line.
-#- path: manager_metrics_patch.yaml
-#  target:
-#    kind: Deployment
+- path: manager_metrics_patch.yaml
+  target:
+    kind: Deployment
 
   # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
   # +kubebuilder:scaffold:defaultkustomizewebhookpatch

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -2,16 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
     app.kubernetes.io/name: eviction-autoscaler
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system
 spec:
   ports:
-  - name: http
+  - name: metrics
     port: 8080
     protocol: TCP
     targetPort: 8080
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: eviction-autoscaler

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
     app.kubernetes.io/name: eviction-autoscaler
     app.kubernetes.io/component: controller
     app.kubernetes.io/managed-by: kustomize
@@ -14,21 +13,19 @@ metadata:
   name: controller-manager
   namespace: default
   labels:
-    control-plane: controller-manager
     app.kubernetes.io/name: eviction-autoscaler
     app.kubernetes.io/component: controller
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: eviction-autoscaler
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
         app.kubernetes.io/name: eviction-autoscaler
         app.kubernetes.io/component: controller
     spec:
@@ -124,4 +121,4 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: eviction-autoscaler

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: eviction-autoscaler
+    app.kubernetes.io/component: controller
     app.kubernetes.io/managed-by: kustomize
   name: default
 ---
@@ -15,6 +16,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: eviction-autoscaler
+    app.kubernetes.io/component: controller
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
@@ -27,6 +29,8 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
+        app.kubernetes.io/name: eviction-autoscaler
+        app.kubernetes.io/component: controller
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.
@@ -63,14 +67,22 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
+          - --metrics-bind-address=:8080
         image: paulgmiller/k8s-pdb-autoscaler:latest
-        name: manager
+        name: eviction-autoscaler
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - "ALL"
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: health
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz

--- a/internal/controller/deployment_to_pdb_controller.go
+++ b/internal/controller/deployment_to_pdb_controller.go
@@ -60,12 +60,12 @@ func (r *DeploymentToPDBReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 // handleDeploymentReconcile creates a PodDisruptionBudget when a Deployment is created or updated.
 func (r *DeploymentToPDBReconciler) handleDeploymentReconcile(ctx context.Context, deployment *v1.Deployment) (reconcile.Result, error) {
 	log := log.FromContext(ctx)
-	
+
 	// Check if we've already counted this deployment
 	if _, counted := deployment.Annotations[deploymentCountedAnnotation]; !counted {
 		// First time seeing this deployment (increment)
 		metrics.IncrementDeploymentCount(deployment.Namespace, metrics.CanCreatePDB)
-		
+
 		// Mark it as counted
 		if deployment.Annotations == nil {
 			deployment.Annotations = make(map[string]string)

--- a/internal/controller/deployment_to_pdb_controller.go
+++ b/internal/controller/deployment_to_pdb_controller.go
@@ -42,16 +42,16 @@ func (r *DeploymentToPDBReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err := r.Get(ctx, req.NamespacedName, &deployment); err != nil {
 		// todo: decrement? DeploymentGauge when deployment not found
 		// was deployment ever tracked? permanent vs temporary not found?
-		return reconcile.Result{}, client.IgnoreNotFound(err)
+		return reconcile.Result{}, err
 	}
 	log.Info("Found: ", "deployment", deployment.Name, "namespace", deployment.Namespace)
 
 	// check if deployment is being deleted:
-	if !deployment.DeletionTimestamp.IsZero() {
+	// if !deployment.DeletionTimestamp.IsZero() {
 		// Deployment is being deleted
-		metrics.DeploymentGauge.WithLabelValues(deployment.Namespace, metrics.CanCreatePDBStr).Dec()
-		return reconcile.Result{}, nil
-	}
+		//metrics.DeploymentGauge.WithLabelValues(deployment.Namespace, metrics.CanCreatePDBStr).Dec()
+		//return reconcile.Result{}, nil
+	//}
 
 	// If the Deployment is created, ensure a PDB exists
 	return r.handleDeploymentReconcile(ctx, &deployment)

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -97,23 +97,8 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	// Track the max unavailable value from the PDB
-	maxUnavailable := int32(0)
-	if pdb.Spec.MaxUnavailable != nil {
-		maxUnavailable = pdb.Spec.MaxUnavailable.IntVal
-	}
-	metrics.PDBInfoGauge.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name, target.GetName(), metrics.MaxUnavailableMetric).Set(float64(maxUnavailable))
-
-	// Check if minAvailable equals the total expected pods from the PDB
-	minAvailable := int32(0)
-	if pdb.Spec.MinAvailable != nil {
-		minAvailable = pdb.Spec.MinAvailable.IntVal
-	}
-	if minAvailable == pdb.Status.ExpectedPods {
-		metrics.PDBInfoGauge.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name, target.GetName(), metrics.MinAvailableEqualsReplicasMetric).Set(1)
-	} else {
-		metrics.PDBInfoGauge.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name, target.GetName(), metrics.MinAvailableEqualsReplicasMetric).Set(0)
-	}
+	// TODO: Move PDB configuration tracking to PDB controller with aggregate labels
+	// Consider tracking: maxUnavailable==0 and minAvailable==replicas as PDBGauge labels
 
 	// Check if the resource version has changed or if it's empty (initial state)
 	if EvictionAutoScaler.Status.TargetGeneration == 0 || EvictionAutoScaler.Status.TargetGeneration != target.Obj().GetGeneration() {

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -157,18 +157,13 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		// Log the scaling action
 		logger.Info(fmt.Sprintf("Scaled up %s  %s/%s to %d replicas", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), newReplicas))
-
-		// Fetch the updated deployment to get the correct generation after scaling
-		err = r.Get(ctx, types.NamespacedName{Name: EvictionAutoScaler.Spec.TargetName, Namespace: EvictionAutoScaler.Namespace}, target.Obj())
-		if err != nil {
-			logger.Error(err, "failed to fetch updated target after scaling")
-			return ctrl.Result{}, err
-		}
+		logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
 
 		// Save the correct ResourceVersion to EvictionAutoScaler status
 		// Storing the current generation prevents an immediate follow-up reconcile
 		// that would otherwise interpret our own scale operation as an out of band
 		// user change skewinh the scaling Oppurtunity and Actual scaling metrics.
+		// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
 		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
 		//EvictionAutoScaler.Status.LastEviction = EvictionAutoScaler.Spec.LastEviction //we could still keep a log here if thats useful
 		ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "eviction with scale up")
@@ -206,15 +201,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Log the scaling action
 		logger.Info(fmt.Sprintf("Reverted %s %s/%s to %d replicas", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), target.GetReplicas()))
 
-		// Fetch the updated deployment to get the correct generation after scaling
-		err = r.Get(ctx, types.NamespacedName{Name: EvictionAutoScaler.Spec.TargetName, Namespace: EvictionAutoScaler.Namespace}, target.Obj())
-		if err != nil {
-			logger.Error(err, "failed to fetch updated target after scaling")
-			return ctrl.Result{}, err
-		}
-
-		// Save the correct ResourceVersion to EvictionAutoScaler status
-		// (same rationale as the scale-up path)
+		// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
 		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
 		EvictionAutoScaler.Status.LastEviction = EvictionAutoScaler.Spec.LastEviction //we could still keep a log here if thats useful
 		ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "evictions hit cooldown so scaled down")

--- a/internal/controller/node_reconciler.go
+++ b/internal/controller/node_reconciler.go
@@ -55,7 +55,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	// Track node cordoning events
-	metrics.IncrementNodeCordoningCount(node.Name, true)
+	metrics.IncrementNodeCordoningCount(true)
 	logger.Info("Node is cordoned", "node", node.Name)
 
 	var podlist corev1.PodList
@@ -107,7 +107,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 
 		// Track eviction and node drain events
-		metrics.IncrementEvictionCount(pod.Namespace, pod.Name)
+		metrics.IncrementEvictionCount(pod.Namespace)
 
 		logger.Info("Found EvictionAutoScaler for pod", "name", applicableEvictionAutoScaler.Name, "namespace", pod.Namespace, "podname", pod.Name, "node", node.Name)
 		pod := pod.DeepCopy()

--- a/internal/controller/node_reconciler.go
+++ b/internal/controller/node_reconciler.go
@@ -108,7 +108,6 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 		// Track eviction and node drain events
 		metrics.IncrementEvictionCount(pod.Namespace, pod.Name)
-		metrics.IncrementNodeDrainCount(node.Name, pod.Name, pod.Namespace)
 
 		logger.Info("Found EvictionAutoScaler for pod", "name", applicableEvictionAutoScaler.Name, "namespace", pod.Namespace, "podname", pod.Name, "node", node.Name)
 		pod := pod.DeepCopy()
@@ -147,9 +146,9 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 }
 
 func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &corev1.Pod{}, NodeNameIndex, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(context.TODO(), &v1.Pod{}, NodeNameIndex, func(rawObj client.Object) []string {
 		// Extract the spec.nodeName field
-		pod := rawObj.(*corev1.Pod)
+		pod := rawObj.(*v1.Pod)
 		if pod.Spec.NodeName == "" {
 			return nil // Don't index Pods without a NodeName
 		}
@@ -159,7 +158,7 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Node{}).
+		For(&v1.Node{}).
 		WithEventFilter(predicate.Funcs{
 			// ignore status updates as we only care about cordon.
 			UpdateFunc: func(ue event.UpdateEvent) bool {

--- a/internal/controller/pdb_to_evictionautoscaler_controller.go
+++ b/internal/controller/pdb_to_evictionautoscaler_controller.go
@@ -48,10 +48,8 @@ func (r *PDBToEvictionAutoScalerReconciler) Reconcile(ctx context.Context, req r
 	}
 
 	// Update PDB metrics to check if this PDB was created by our deployment controller
-	createdByUsStr := metrics.PDBNotCreatedByUsStr
-	if ann, ok := pdb.Annotations["createdBy"]; ok && ann == "DeploymentToPDBController" {
-		createdByUsStr = metrics.PDBCreatedByUsStr
-	}
+	createdByUsStr := metrics.GetPDBCreatedByUsLabel(pdb.Annotations)
+	// Track PDB existence
 	metrics.PDBCounter.WithLabelValues(pdb.Namespace, createdByUsStr).Inc()
 
 	// If the PDB exists, create a corresponding EvictionAutoScaler if it does not exist

--- a/internal/controller/pdb_to_evictionautoscaler_controller.go
+++ b/internal/controller/pdb_to_evictionautoscaler_controller.go
@@ -48,11 +48,11 @@ func (r *PDBToEvictionAutoScalerReconciler) Reconcile(ctx context.Context, req r
 	}
 
 	// Update PDB metrics to check if this PDB was created by our deployment controller
-	createdByUs := metrics.PDBNotCreatedByUs
+	createdByUsStr := metrics.PDBNotCreatedByUsStr
 	if ann, ok := pdb.Annotations["createdBy"]; ok && ann == "DeploymentToPDBController" {
-		createdByUs = metrics.PDBCreatedByUs
+		createdByUsStr = metrics.PDBCreatedByUsStr
 	}
-	metrics.IncrementPDBProcessedCount(pdb.Namespace, createdByUs)
+	metrics.PDBCounter.WithLabelValues(pdb.Namespace, createdByUsStr).Inc()
 
 	// If the PDB exists, create a corresponding EvictionAutoScaler if it does not exist
 	var EvictionAutoScaler types.EvictionAutoScaler
@@ -110,7 +110,7 @@ func (r *PDBToEvictionAutoScalerReconciler) Reconcile(ctx context.Context, req r
 		}
 
 		// Track EvictionAutoScaler creation
-		metrics.IncrementEvictionAutoScalerCreationCount(pdb.Namespace, pdb.Name, deploymentName)
+		metrics.EvictionAutoScalerCreationCounter.WithLabelValues(pdb.Namespace, pdb.Name, deploymentName).Inc()
 
 		logger.Info("Created EvictionAutoScaler")
 	}

--- a/internal/controller/wrappers.go
+++ b/internal/controller/wrappers.go
@@ -70,6 +70,16 @@ func (d *DeploymentWrapper) RemoveAnnotation(status string) {
 	}
 }
 
+// GetSelector returns the label selector for the deployment
+func (d *DeploymentWrapper) GetSelector() *metav1.LabelSelector {
+	return d.obj.Spec.Selector
+}
+
+// GetName returns the name of the deployment
+func (d *DeploymentWrapper) GetName() string {
+	return d.obj.Name
+}
+
 type StatefulSetWrapper struct {
 	obj *v1.StatefulSet
 }
@@ -121,4 +131,14 @@ func (s *StatefulSetWrapper) RemoveAnnotation(status string) {
 	if s.obj.Annotations != nil {
 		delete(s.obj.Annotations, status)
 	}
+}
+
+// GetSelector returns the label selector for the statefulset
+func (s *StatefulSetWrapper) GetSelector() *metav1.LabelSelector {
+	return s.obj.Spec.Selector
+}
+
+// GetName returns the name of the statefulset
+func (s *StatefulSetWrapper) GetName() string {
+	return s.obj.Name
 }

--- a/internal/controller/wrappers.go
+++ b/internal/controller/wrappers.go
@@ -4,22 +4,17 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Surger interface {
-	//GetGeneration() int64
 	GetReplicas() int32
 	SetReplicas(int32)
 	GetMaxSurge() intstr.IntOrString
 	Obj() client.Object
-	//Update(ctx context.Context, obj Object, opts ...UpdateOption) error
 	AddAnnotation(string, string)
 	RemoveAnnotation(string)
-	// returns the label selector for the deployment or statefulset
-	GetSelector() *metav1.LabelSelector
 }
 
 // Todo change casing to match k8s?
@@ -73,11 +68,6 @@ func (d *DeploymentWrapper) RemoveAnnotation(status string) {
 	}
 }
 
-// GetSelector returns the label selector for the deployment
-func (d *DeploymentWrapper) GetSelector() *metav1.LabelSelector {
-	return d.obj.Spec.Selector
-}
-
 type StatefulSetWrapper struct {
 	obj *v1.StatefulSet
 }
@@ -112,7 +102,6 @@ func GetSurger(kind string) (Surger, error) {
 	} else {
 		return nil, fmt.Errorf("unknown target kind %s", kind) //be good to enforce this with admission policy
 	}
-
 }
 
 // AddAnnotation will reset and add new annotation map every time this func is called
@@ -129,9 +118,4 @@ func (s *StatefulSetWrapper) RemoveAnnotation(status string) {
 	if s.obj.Annotations != nil {
 		delete(s.obj.Annotations, status)
 	}
-}
-
-// GetSelector returns the label selector for the statefulset
-func (s *StatefulSetWrapper) GetSelector() *metav1.LabelSelector {
-	return s.obj.Spec.Selector
 }

--- a/internal/controller/wrappers.go
+++ b/internal/controller/wrappers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -17,6 +18,8 @@ type Surger interface {
 	//Update(ctx context.Context, obj Object, opts ...UpdateOption) error
 	AddAnnotation(string, string)
 	RemoveAnnotation(string)
+	GetName() string
+	GetSelector() *metav1.LabelSelector
 }
 
 // Todo change casing to match k8s?

--- a/internal/controller/wrappers.go
+++ b/internal/controller/wrappers.go
@@ -18,7 +18,7 @@ type Surger interface {
 	//Update(ctx context.Context, obj Object, opts ...UpdateOption) error
 	AddAnnotation(string, string)
 	RemoveAnnotation(string)
-	GetName() string
+	// returns the label selector for the deployment or statefulset
 	GetSelector() *metav1.LabelSelector
 }
 
@@ -78,11 +78,6 @@ func (d *DeploymentWrapper) GetSelector() *metav1.LabelSelector {
 	return d.obj.Spec.Selector
 }
 
-// GetName returns the name of the deployment
-func (d *DeploymentWrapper) GetName() string {
-	return d.obj.Name
-}
-
 type StatefulSetWrapper struct {
 	obj *v1.StatefulSet
 }
@@ -139,9 +134,4 @@ func (s *StatefulSetWrapper) RemoveAnnotation(status string) {
 // GetSelector returns the label selector for the statefulset
 func (s *StatefulSetWrapper) GetSelector() *metav1.LabelSelector {
 	return s.obj.Spec.Selector
-}
-
-// GetName returns the name of the statefulset
-func (s *StatefulSetWrapper) GetName() string {
-	return s.obj.Name
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -159,6 +159,12 @@ const (
 	PDBNotCreatedByUs = false
 )
 
+// Constants for deployment tracking
+const (
+	CanCreatePDB    = true
+	CannotCreatePDB = false
+)
+
 func init() {
 	// Register metrics with controller-runtime's registry
 	metrics.Registry.MustRegister(

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// DeploymentGauge tracks the number of deployments seen by the controller
+	// Labels: namespace, can_create_pdb (true/false)
+	DeploymentGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "eviction_autoscaler_deployments_total",
+			Help: "Total number of deployments seen by the eviction autoscaler",
+		},
+		[]string{"namespace", "can_create_pdb"},
+	)
+
+	// PDBGauge tracks the number of PDBs seen by the controller
+	// Labels: namespace, created_by_us (true/false)
+	PDBGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "eviction_autoscaler_pdbs_total",
+			Help: "Total number of PDBs seen by the eviction autoscaler",
+		},
+		[]string{"namespace", "created_by_us"},
+	)
+
+	// EvictionCounter tracks how often the eviction-autoscaler notices an eviction
+	// Labels: namespace, pod_name
+	EvictionCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eviction_autoscaler_evictions_total",
+			Help: "Total number of evictions noticed by the eviction autoscaler",
+		},
+		[]string{"namespace", "pod_name"},
+	)
+
+	// BlockedEvictionCounter tracks how often evictions are blocked by PDBs
+	// Labels: namespace, pdb_name, pod_name
+	BlockedEvictionCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eviction_autoscaler_blocked_evictions_total",
+			Help: "Total number of evictions blocked by PDBs",
+		},
+		[]string{"namespace", "pdb_name", "pod_name"},
+	)
+
+	// ScalingOpportunityCounter tracks how often the controller thinks it could have scaled a deployment
+	// Labels: namespace, deployment_name, action (scale_up/scale_down)
+	ScalingOpportunityCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eviction_autoscaler_scaling_opportunities_total",
+			Help: "Total number of times the controller identified scaling opportunities",
+		},
+		[]string{"namespace", "deployment_name", "action"},
+	)
+
+	// ActualScalingCounter tracks actual scaling actions performed
+	// Labels: namespace, deployment_name, action (scale_up/scale_down)
+	ActualScalingCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eviction_autoscaler_scaling_actions_total",
+			Help: "Total number of actual scaling actions performed by the controller",
+		},
+		[]string{"namespace", "deployment_name", "action"},
+	)
+
+	// PDBCreationCounter tracks PDB creation events
+	// Labels: namespace, deployment_name
+	PDBCreationCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eviction_autoscaler_pdb_creations_total",
+			Help: "Total number of PDBs created by the eviction autoscaler",
+		},
+		[]string{"namespace", "deployment_name"},
+	)
+
+	// EvictionAutoScalerCreationCounter tracks EvictionAutoScaler creation events
+	// Labels: namespace, pdb_name, target_deployment
+	EvictionAutoScalerCreationCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eviction_autoscaler_creation_total",
+			Help: "Total number of EvictionAutoScaler resources created",
+		},
+		[]string{"namespace", "pdb_name", "target_deployment"},
+	)
+
+	// NodeCordoningCounter tracks node cordoning events detected
+	// Labels: node_name, cordoned (true/false)
+	NodeCordoningCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eviction_autoscaler_node_cordoning_total",
+			Help: "Total number of node cordoning events detected by the eviction autoscaler",
+		},
+		[]string{"node_name", "cordoned"},
+	)
+
+	// NodeDrainCounter tracks node drain events detected (pods evicted from cordoned nodes)
+	// Labels: node_name, pod_name, namespace
+	NodeDrainCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eviction_autoscaler_node_drain_total",
+			Help: "Total number of pods evicted from nodes during drain operations",
+		},
+		[]string{"node_name", "pod_name", "namespace"},
+	)
+)
+
+func init() {
+	// Register metrics with controller-runtime's registry
+	// Use safe registration to prevent panics
+	collectors := []prometheus.Collector{
+		DeploymentGauge,
+		PDBGauge,
+		EvictionCounter,
+		BlockedEvictionCounter,
+		ScalingOpportunityCounter,
+		ActualScalingCounter,
+		PDBCreationCounter,
+		EvictionAutoScalerCreationCounter,
+		NodeCordoningCounter,
+		NodeDrainCounter,
+	}
+
+	for _, collector := range collectors {
+		if err := metrics.Registry.Register(collector); err != nil {
+			// Log error but don't crash - metrics are not critical for controller function
+			// In production, you might want to use a proper logger here
+			// For now, we'll just continue without that specific metric
+			continue
+		}
+	}
+}
+
+// Helper functions to update metrics
+
+// UpdateDeploymentCount updates the deployment gauge
+func UpdateDeploymentCount(namespace string, canCreatePDB bool, count float64) {
+	canCreatePDBStr := "false"
+	if canCreatePDB {
+		canCreatePDBStr = "true"
+	}
+	DeploymentGauge.WithLabelValues(namespace, canCreatePDBStr).Set(count)
+}
+
+// UpdatePDBCount updates the PDB gauge
+func UpdatePDBCount(namespace string, createdByUs bool, count float64) {
+	createdByUsStr := "false"
+	if createdByUs {
+		createdByUsStr = "true"
+	}
+	PDBGauge.WithLabelValues(namespace, createdByUsStr).Set(count)
+}
+
+// IncrementEvictionCount increments the eviction counter
+func IncrementEvictionCount(namespace, podName string) {
+	EvictionCounter.WithLabelValues(namespace, podName).Inc()
+}
+
+// IncrementBlockedEvictionCount increments the blocked eviction counter
+func IncrementBlockedEvictionCount(namespace, pdbName, podName string) {
+	BlockedEvictionCounter.WithLabelValues(namespace, pdbName, podName).Inc()
+}
+
+// IncrementScalingOpportunityCount increments the scaling opportunity counter
+func IncrementScalingOpportunityCount(namespace, deploymentName, action string) {
+	ScalingOpportunityCounter.WithLabelValues(namespace, deploymentName, action).Inc()
+}
+
+// IncrementActualScalingCount increments the actual scaling counter
+func IncrementActualScalingCount(namespace, deploymentName, action string) {
+	ActualScalingCounter.WithLabelValues(namespace, deploymentName, action).Inc()
+}
+
+// IncrementPDBCreationCount increments the PDB creation counter
+func IncrementPDBCreationCount(namespace, deploymentName string) {
+	PDBCreationCounter.WithLabelValues(namespace, deploymentName).Inc()
+}
+
+// IncrementEvictionAutoScalerCreationCount increments the EvictionAutoScaler creation counter
+func IncrementEvictionAutoScalerCreationCount(namespace, pdbName, targetDeployment string) {
+	EvictionAutoScalerCreationCounter.WithLabelValues(namespace, pdbName, targetDeployment).Inc()
+}
+
+// IncrementNodeCordoningCount increments the node cordoning counter
+func IncrementNodeCordoningCount(nodeName string, cordoned bool) {
+	cordonedStr := "false"
+	if cordoned {
+		cordonedStr = "true"
+	}
+	NodeCordoningCounter.WithLabelValues(nodeName, cordonedStr).Inc()
+}
+
+// IncrementNodeDrainCount increments the node drain counter
+func IncrementNodeDrainCount(nodeName, podName, namespace string) {
+	NodeDrainCounter.WithLabelValues(nodeName, podName, namespace).Inc()
+}

--- a/internal/webhook/eviction.go
+++ b/internal/webhook/eviction.go
@@ -7,7 +7,6 @@ import (
 	pdbautoscaler "github.com/azure/eviction-autoscaler/api/v1"
 	"github.com/azure/eviction-autoscaler/internal/podutil"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -85,9 +84,9 @@ func (e *EvictionHandler) Handle(ctx context.Context, req admission.Request) adm
 
 	logger.Info("Found EvictionAutoScaler", "name", applicableEvictionAutoScaler.Name)
 
-	updatedpod := podutil.UpdatePodCondition(&podObj.Status, &v1.PodCondition{
-		Type:    v1.DisruptionTarget,
-		Status:  v1.ConditionTrue,
+	updatedpod := podutil.UpdatePodCondition(&podObj.Status, &corev1.PodCondition{
+		Type:    corev1.DisruptionTarget,
+		Status:  corev1.ConditionTrue,
 		Reason:  "EvictionAttempt",
 		Message: "eviction attempt recorded by eviction webhook",
 	})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -174,8 +174,8 @@ var _ = Describe("controller", Ordered, func() {
 				return pods.Items[0].Spec.NodeName, nil
 			}
 			verifyControllerMgrPods := func() error {
-				_, e := verifyRunningPods(namespace, client.MatchingLabels{
-					"control-plane": "controller-manager",
+				_, e := verifyRunningPods("kube-system", client.MatchingLabels{
+					"app.kubernetes.io/name": "eviction-autoscaler",
 				}, 1)
 				return e
 			}


### PR DESCRIPTION
Created comprehensive metrics.go scraping file and added monitoring to eviction-autoscaler controller with descriptive labeling.
Added 11 custom Prometheus metrics (3 gauges, 8 counters).

### Gauges
- `eviction_autoscaler_deployments_total` - Total deployments seen by controller
  - Labels: namespace, can_create_pdb (true/false)
- `eviction_autoscaler_pdbs_total` - Total PDBs seen by controller
  - Labels: namespace, created_by_us (true/false), max_unavailable_zero, min_available_equals_replicas
- `eviction_autoscaler_pdb_info` - PDB configuration and status information
  - Labels: namespace, pdb_name, target_name, metric_type
  
### Counters
- `eviction_autoscaler_evictions_total` - Evictions noticed by controller
  - Labels: namespace
- `eviction_autoscaler_blocked_evictions_total` - Evictions blocked by PDBs
  - Labels: namespace, pdb_name
- `eviction_autoscaler_scaling_opportunities_total` - Scaling opportunities identified
  - Labels: namespace, deployment_name, action (scale_up/scale_down)
- `eviction_autoscaler_scaling_actions_total` - Actual scaling actions performed
  - Labels: namespace, deployment_name, action (scale_up/scale_down)
- `eviction_autoscaler_pdb_creations_total` - PDBs created by controller
  - Labels: namespace, deployment_name
- `eviction_autoscaler_creation_total` - EvictionAutoScaler resources created
  - Labels: namespace, pdb_name, target_deployment
- `eviction_autoscaler_node_cordoning_total` - Node cordoning events detected
  - Labels: (none)
- `eviction_autoscaler_pdb_count_total` - Total count of PDBs processed
  - Labels: namespace, created_by_us (true/false)
 
### Namespace and Labels
- Updated deployment namespace from `eviction-autoscaler` to `kube-system`
- Changed generic `control-plane: controller-manager` to:
  - `app.kubernetes.io/name: eviction-autoscaler`
  - `app.kubernetes.io/component: controller`

### Updated E2E test
- Modfied E2E test to use updated namespace and labels 

### Files modified
- Metrics.go(created)
- Main.go
- Kustomizaiton.yaml
- metrics.service.yaml
- manager.yaml
- deployment_to_pdb_controller.go
- eviction_autoscaler.go
- node_reconciller.go
- wrappers.go
- eviction.go
- e2e_test.go