### PR TITLE
Additional labeling for scale up determination

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -63,13 +63,13 @@ var (
 	)
 
 	// ScalingOpportunityCounter tracks how often the controller thinks it could have scaled a deployment
-	// Labels: namespace, deployment_name, action (scale_up/scale_down)
+	// Labels: namespace, deployment_name, action (scale_up/scale_down), signal
 	ScalingOpportunityCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "eviction_autoscaler_scaling_opportunities_total",
 			Help: "Total number of times the controller identified scaling opportunities",
 		},
-		[]string{"namespace", "deployment_name", "action"},
+		[]string{"namespace", "deployment_name", "action", "signal"},
 	)
 
 	// ActualScalingCounter tracks actual scaling actions performed
@@ -157,6 +157,15 @@ const (
 const (
 	ScaleUpAction   = "scale_up"
 	ScaleDownAction = "scale_down"
+)
+
+// Constants for scaling opportunity signals
+const (
+	PDBBlockedSignal                = "pdb_blocked"
+	MinAvailableEqualsDesiredSignal = "min_available_equals_desired_healthy"
+	CooldownElapsedSignal           = "cooldown_elapsed"
+	OldNotReadyPodsSignal           = "old_not_ready_pods"
+	WouldExceedMinAvailableSignal   = "would_exceed_min_available"
 )
 
 // GetPDBCreatedByUsLabel returns the appropriate label value based on PDB annotations


### PR DESCRIPTION
This pull request introduces enhancements to the metrics tracking system for the eviction autoscaler and adds an end-to-end (e2e) test to scrape controller metrics. The changes improve observability by adding signal labels to scaling opportunity metrics and ensure the metrics can be verified during testing.

### Metrics tracking enhancements:
* [`internal/controller/evictionautoscaler_controller.go`](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddL140-R147): Updated `ScalingOpportunityCounter` to include signal labels (`PDBBlockedSignal`, `MinAvailableEqualsDesiredSignal`, `CooldownElapsedSignal`)  Added a new `signal` label to `ScalingOpportunityCounter` and introduced constants for signal types, such as `PDBBlockedSignal` and `CooldownElapsedSignal`.
### End-to-end testing improvements:
Added a function to scrape controller metrics at the end of the e2e test. 