### PR TITLE
demo yaml files for testing eviction autoscaler scenarios

### DIFF
--- a/demo/age-demo.yaml
+++ b/demo/age-demo.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: age-demo-script
+  namespace: demo
+data:
+  crash-oldest.sh: |
+    #!/bin/bash
+    echo "Pod starting - checking if I should crash..."
+    
+    # Get my own creation time
+    MY_NAME=$(hostname)
+    MY_CREATION=$(kubectl get pod $MY_NAME -n demo -o jsonpath='{.metadata.creationTimestamp}')
+    echo "My creation time: $MY_CREATION"
+    
+    # Get all pods in the same deployment and sort by age
+    DEPLOYMENT_PODS=$(kubectl get pods -n demo -l app=age-demo --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[*].metadata.name}')
+    echo "All pods: $DEPLOYMENT_PODS"
+    
+    # Check if I'm the oldest pod
+    OLDEST_POD=$(echo $DEPLOYMENT_PODS | awk '{print $1}')
+    echo "Oldest pod: $OLDEST_POD"
+    
+    if [ "$MY_NAME" = "$OLDEST_POD" ]; then
+        echo "I am the oldest pod! Starting crash loop after 30 seconds..."
+        sleep 30
+        echo "Crashing now as the oldest pod..."
+        exit 1
+    else
+        echo "I'm not the oldest pod, staying healthy..."
+        # Stay alive and healthy
+        while true; do
+            sleep 30
+            echo "Still healthy at $(date)"
+        done
+    fi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: age-demo-app
+  namespace: demo
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: age-demo
+  template:
+    metadata:
+      labels:
+        app: age-demo
+    spec:
+      serviceAccountName: pod-reader
+      containers:
+      - name: age-demo
+        image: bitnami/kubectl:latest
+        command: ["/bin/bash"]
+        args: ["/scripts/crash-oldest.sh"]
+        volumeMounts:
+        - name: script-volume
+          mountPath: /scripts
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
+          limits:
+            memory: "128Mi"
+            cpu: "200m"
+      volumes:
+      - name: script-volume
+        configMap:
+          name: age-demo-script
+          defaultMode: 0755

--- a/demo/newest-failure.yaml
+++ b/demo/newest-failure.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: newest-fail-script
+  namespace: demo
+data:
+  newest-fail.sh: |
+    #!/bin/bash
+    POD_NAME=$HOSTNAME
+    
+    echo "Pod $POD_NAME starting..."
+    
+    # New pods fail for first 5 minutes
+    STARTUP_TIME=$(date +%s)
+    
+    while true; do
+      CURRENT_TIME=$(date +%s)
+      ELAPSED=$((CURRENT_TIME - STARTUP_TIME))
+      
+      if [ $ELAPSED -lt 300 ]; then
+        echo "Pod is new (${ELAPSED}s old), failing health checks"
+        rm -f /tmp/healthy /tmp/ready
+      else
+        echo "Pod is mature (${ELAPSED}s old), becoming healthy"
+        touch /tmp/healthy
+        touch /tmp/ready
+      fi
+      
+      sleep 10
+    done
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: newest-fail-app
+  namespace: demo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: newest-fail
+  template:
+    metadata:
+      labels:
+        app: newest-fail
+    spec:
+      containers:
+      - name: app
+        image: busybox
+        command: ["/bin/sh", "/scripts/newest-fail.sh"]
+        volumeMounts:
+        - name: script
+          mountPath: /scripts
+        livenessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: script
+        configMap:
+          name: newest-fail-script
+          defaultMode: 0755

--- a/demo/oldest-failure.yaml
+++ b/demo/oldest-failure.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oldest-fail-script
+  namespace: demo
+data:
+  oldest-fail.sh: |
+    #!/bin/bash
+    POD_NAME=$HOSTNAME
+    POD_CREATION_TIME=$(stat -c %Y /proc/1)
+    
+    echo "Pod $POD_NAME started at $POD_CREATION_TIME"
+    
+    # Create health files initially
+    touch /tmp/healthy
+    touch /tmp/ready
+    
+    while true; do
+      # Get all pod creation times
+      OLDEST_TIME=$(kubectl get pods -n demo -l app=oldest-fail -o json | \
+        jq -r '.items | sort_by(.metadata.creationTimestamp) | .[0].metadata.name')
+      
+      if [ "$POD_NAME" == "$OLDEST_TIME" ]; then
+        echo "I am the oldest pod, failing health checks"
+        rm -f /tmp/healthy /tmp/ready
+      else
+        echo "Not the oldest pod, staying healthy"
+        touch /tmp/healthy
+        touch /tmp/ready
+      fi
+      
+      sleep 30
+    done
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oldest-fail-app
+  namespace: demo
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: oldest-fail
+  template:
+    metadata:
+      labels:
+        app: oldest-fail
+    spec:
+      serviceAccountName: pod-reader
+      containers:
+      - name: app
+        image: bitnami/kubectl:latest
+        command: ["/bin/bash", "/scripts/oldest-fail.sh"]
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        volumeMounts:
+        - name: script
+          mountPath: /scripts
+        livenessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 10
+          periodSeconds: 10
+      volumes:
+      - name: script
+        configMap:
+          name: oldest-fail-script
+          defaultMode: 0755
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-reader
+  namespace: demo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-reader
+  namespace: demo
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-reader
+  namespace: demo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-reader
+subjects:
+- kind: ServiceAccount
+  name: pod-reader
+  namespace: demo

--- a/demo/time-failure.yaml
+++ b/demo/time-failure.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: crash-script
+  namespace: demo
+data:
+  crash.sh: |
+    #!/bin/bash
+    echo "Pod starting up..."
+    
+    # Create health files initially
+    touch /tmp/healthy
+    touch /tmp/ready
+    
+    # Run for 10 minutes then fail
+    sleep 600
+    
+    echo "Simulating crash after 10 minutes"
+    rm -f /tmp/healthy /tmp/ready
+    exit 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: time-crash-app
+  namespace: demo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: time-crash
+  template:
+    metadata:
+      labels:
+        app: time-crash
+    spec:
+      containers:
+      - name: app
+        image: busybox
+        command: ["/bin/sh", "/scripts/crash.sh"]
+        volumeMounts:
+        - name: script
+          mountPath: /scripts
+        livenessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/healthy
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/ready
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: script
+        configMap:
+          name: crash-script
+          defaultMode: 0755


### PR DESCRIPTION
Created four different YAML files, each with its own deployment, ConfigMap containing a custom script. The main focus is on demonstrating pod health and readiness failures based on pod age, creation order, and uptime.

Pod failure scenario demos:

* **Oldest Pod Failure Demo**: Adds `demo/oldest-failure.yaml`, which deploys pods where the oldest pod continually fails health and readiness checks. Includes a service account and RBAC resources so pods can query their age relative to others.
* **Newest Pod Failure Demo**: Adds `demo/newest-failure.yaml`, which deploys pods that fail health and readiness checks for the first five minutes after startup, then become healthy.
* **Pod Uptime Failure Demo**: Adds `demo/time-failure.yaml`, which deploys pods that are healthy for ten minutes after startup and then simulate a crash by failing health and readiness checks and exiting.
* **Oldest Pod Crash Loop Demo**: Adds `demo/age-demo.yaml`, which deploys pods where only the oldest pod enters a crash loop after a delay, while others remain healthy.