### PR TITLE
Add surge-to-ready duration metric with success/timeout tracking

### DIFF
--- a/api/v1/evictionautoscaler_types.go
+++ b/api/v1/evictionautoscaler_types.go
@@ -20,9 +20,10 @@ type EvictionAutoScalerSpec struct {
 
 // EvictionAutoScalerStatus defines the observed state of EvictionAutoScaler
 type EvictionAutoScalerStatus struct {
-	LastEviction     Eviction           `json:"lastEviction,omitempty"` //this is the last one the controller has processed.
-	MinReplicas      int32              `json:"minReplicas"`            // Minimum number of replicas to maintain
-	TargetGeneration int64              `json:"deploymentGeneration"`   // generation (spec hash) of deployment or statefulse
+	LastEviction     Eviction           `json:"lastEviction,omitempty"`   //this is the last one the controller has processed.
+	MinReplicas      int32              `json:"minReplicas"`              // Minimum number of replicas to maintain
+	TargetGeneration int64              `json:"deploymentGeneration"`     // generation (spec hash) of deployment or statefulse
+	SurgeStartTime   *metav1.Time       `json:"surgeStartTime,omitempty"` // Time when surge scale-up was initiated
 	Conditions       []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -116,6 +116,10 @@ func (in *EvictionAutoScalerSpec) DeepCopy() *EvictionAutoScalerSpec {
 func (in *EvictionAutoScalerStatus) DeepCopyInto(out *EvictionAutoScalerStatus) {
 	*out = *in
 	in.LastEviction.DeepCopyInto(&out.LastEviction)
+	if in.SurgeStartTime != nil {
+		in, out := &in.SurgeStartTime, &out.SurgeStartTime
+		*out = (*in).DeepCopy()
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]metav1.Condition, len(*in))

--- a/config/crd/bases/eviction-autoscaler.azure.com_evictionautoscalers.yaml
+++ b/config/crd/bases/eviction-autoscaler.azure.com_evictionautoscalers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: evictionautoscalers.eviction-autoscaler.azure.com
 spec:
   group: eviction-autoscaler.azure.com
@@ -64,16 +64,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -114,12 +106,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -146,6 +133,9 @@ spec:
               minReplicas:
                 format: int32
                 type: integer
+              surgeStartTime:
+                format: date-time
+                type: string
             required:
             - deploymentGeneration
             - minReplicas

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,51 +5,10 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
+  - nodes
   - pods
   verbs:
   - get
@@ -61,6 +20,17 @@ rules:
   - pods/status
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - eviction-autoscaler.azure.com
   resources:
@@ -93,7 +63,6 @@ rules:
   - poddisruptionbudgets
   verbs:
   - create
-  - delete
   - get
   - list
   - update

--- a/helm/eviction-autoscaler/templates/crd.yaml
+++ b/helm/eviction-autoscaler/templates/crd.yaml
@@ -148,6 +148,9 @@ spec:
               minReplicas:
                 format: int32
                 type: integer
+              surgeStartTime:
+                format: date-time
+                type: string
             required:
             - deploymentGeneration
             - minReplicas

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -176,6 +176,9 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
 		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
 		//Do not update EvictionAutoScaler.Status.LastEviction because we need to keep reconciling till scale down
+		// Record surge start time for surge-to-ready metric
+		now := metav1.Now()
+		EvictionAutoScaler.Status.SurgeStartTime = &now
 		ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "eviction with scale up")
 		return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
 	}
@@ -186,6 +189,26 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	//Cool down time makes sure we're not still getting more evictions
 	//we could substantially reduce this if we looked at pods and knew that none remaining (not already evicted) had been an eviction target but that means tracking more data in EvictionAutoScaler
 	// or using pod conditons which we're not doing.....yet
+
+	// Observe surge-to-ready time: surge is complete when all desired replicas are ready
+	// AND the PDB allows disruptions again (drain is truly unblocked).
+	if EvictionAutoScaler.Status.SurgeStartTime != nil && target.GetReadyReplicas() >= target.GetReplicas() && pdb.Status.DisruptionsAllowed > 0 {
+		surgeToReadySecs := time.Since(EvictionAutoScaler.Status.SurgeStartTime.Time).Seconds()
+		metrics.SurgeToReadyDuration.WithLabelValues(
+			EvictionAutoScaler.Namespace,
+			EvictionAutoScaler.Spec.TargetName,
+			EvictionAutoScaler.Spec.TargetKind,
+			metrics.SurgeResultSuccess,
+		).Observe(surgeToReadySecs)
+		logger.Info("Surge-to-ready observed",
+			"targetName", EvictionAutoScaler.Spec.TargetName,
+			"durationSeconds", surgeToReadySecs)
+		EvictionAutoScaler.Status.SurgeStartTime = nil
+		// Best-effort persist; if it fails, the success block may re-fire on next requeue
+		// but the metric double-count is acceptable vs. blocking the reconcile.
+		_ = r.Status().Update(ctx, EvictionAutoScaler)
+	}
+
 	if time.Since(EvictionAutoScaler.Spec.LastEviction.EvictionTime.Time) < cooldown {
 		logger.Info(fmt.Sprintf("Giving %s/%s cooldown of  %s after last eviction %s ", target.Obj().GetNamespace(), target.Obj().GetName(), cooldown, EvictionAutoScaler.Spec.LastEviction.EvictionTime))
 		return ctrl.Result{RequeueAfter: cooldown}, nil
@@ -196,6 +219,10 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		// Track scaling opportunity
 		metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleDownAction, metrics.CooldownElapsedSignal).Inc()
+
+		// Capture surged replica count before SetReplicas overwrites it,
+		// so the timeout check below compares against the actual surged target.
+		surgedReplicas := target.GetReplicas()
 
 		//okay we aren't at allowed disruptions Revert Target to the original state
 		target.SetReplicas(EvictionAutoScaler.Status.MinReplicas)
@@ -214,6 +241,25 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
 		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
 		EvictionAutoScaler.Status.LastEviction = EvictionAutoScaler.Spec.LastEviction //we could still keep a log here if thats useful
+		// If surge never completed (pods never became Ready / PDB never unblocked), record as timeout
+		if EvictionAutoScaler.Status.SurgeStartTime != nil && target.GetReadyReplicas() < surgedReplicas {
+			surgeToTimeoutSecs := time.Since(EvictionAutoScaler.Status.SurgeStartTime.Time).Seconds()
+			metrics.SurgeToReadyDuration.WithLabelValues(
+				EvictionAutoScaler.Namespace,
+				EvictionAutoScaler.Spec.TargetName,
+				EvictionAutoScaler.Spec.TargetKind,
+				metrics.SurgeResultTimeout,
+			).Observe(surgeToTimeoutSecs)
+			metrics.SurgeTimeoutCounter.WithLabelValues(
+				EvictionAutoScaler.Namespace,
+				EvictionAutoScaler.Spec.TargetName,
+				EvictionAutoScaler.Spec.TargetKind,
+			).Inc()
+			logger.Info("Surge timed out before pods became Ready",
+				"targetName", EvictionAutoScaler.Spec.TargetName,
+				"durationSeconds", surgeToTimeoutSecs)
+		}
+		EvictionAutoScaler.Status.SurgeStartTime = nil
 		logger.Info(fmt.Sprintf("Handled eviction %s", EvictionAutoScaler.Spec.LastEviction))
 
 		ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "evictions hit cooldown so scaled down")

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -190,8 +190,8 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	//we could substantially reduce this if we looked at pods and knew that none remaining (not already evicted) had been an eviction target but that means tracking more data in EvictionAutoScaler
 	// or using pod conditons which we're not doing.....yet
 
-	// Observe surge-to-ready time: surge is complete when all desired replicas are ready
-	// AND the PDB allows disruptions again (drain is truly unblocked).
+	// Observe surge-to-drain-unblocked time: surge is complete when all desired replicas
+	// are ready AND the PDB allows disruptions again (drain is truly unblocked).
 	if EvictionAutoScaler.Status.SurgeStartTime != nil && target.GetReadyReplicas() >= target.GetReplicas() && pdb.Status.DisruptionsAllowed > 0 {
 		surgeToReadySecs := time.Since(EvictionAutoScaler.Status.SurgeStartTime.Time).Seconds()
 		metrics.SurgeToReadyDuration.WithLabelValues(
@@ -200,7 +200,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			EvictionAutoScaler.Spec.TargetKind,
 			metrics.SurgeResultSuccess,
 		).Observe(surgeToReadySecs)
-		logger.Info("Surge-to-ready observed",
+		logger.Info("Surge completed: drain unblocked",
 			"targetName", EvictionAutoScaler.Spec.TargetName,
 			"durationSeconds", surgeToReadySecs)
 		EvictionAutoScaler.Status.SurgeStartTime = nil
@@ -241,8 +241,14 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
 		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
 		EvictionAutoScaler.Status.LastEviction = EvictionAutoScaler.Spec.LastEviction //we could still keep a log here if thats useful
-		// If surge never completed (pods never became Ready / PDB never unblocked), record as timeout
-		if EvictionAutoScaler.Status.SurgeStartTime != nil && target.GetReadyReplicas() < surgedReplicas {
+		// If surge never completed (success path at line ~195 did not fire), record as timeout.
+		// This covers both pods not becoming Ready and PDB never allowing disruptions.
+		// We guard on readyReplicas < surgedReplicas to avoid double-counting: if the
+		// success path already observed the metric but the best-effort status update
+		// failed to clear SurgeStartTime, SurgeStartTime is still set here. The
+		// readyReplicas check ensures we only emit timeout when pods genuinely
+		// never became ready, not when success already fired.
+		if EvictionAutoScaler.Status.SurgeStartTime != nil && (pdb.Status.DisruptionsAllowed == 0 || target.GetReadyReplicas() < surgedReplicas) {
 			surgeToTimeoutSecs := time.Since(EvictionAutoScaler.Status.SurgeStartTime.Time).Seconds()
 			metrics.SurgeToReadyDuration.WithLabelValues(
 				EvictionAutoScaler.Namespace,
@@ -255,7 +261,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 				EvictionAutoScaler.Spec.TargetName,
 				EvictionAutoScaler.Spec.TargetKind,
 			).Inc()
-			logger.Info("Surge timed out before pods became Ready",
+			logger.Info("Surge timed out: drain still blocked at scale-down",
 				"targetName", EvictionAutoScaler.Spec.TargetName,
 				"durationSeconds", surgeToTimeoutSecs)
 		}

--- a/internal/controller/wrappers.go
+++ b/internal/controller/wrappers.go
@@ -11,6 +11,7 @@ import (
 type Surger interface {
 	//GetGeneration() int64
 	GetReplicas() int32
+	GetReadyReplicas() int32
 	SetReplicas(int32)
 	GetMaxSurge() intstr.IntOrString
 	Obj() client.Object
@@ -40,6 +41,10 @@ func (d *DeploymentWrapper) GetReplicas() int32 {
 		return 1 // Default value in Kubernetes if not set
 	}
 	return *d.obj.Spec.Replicas
+}
+
+func (d *DeploymentWrapper) GetReadyReplicas() int32 {
+	return d.obj.Status.ReadyReplicas
 }
 
 func (d *DeploymentWrapper) SetReplicas(replicas int32) {
@@ -85,6 +90,10 @@ func (s *StatefulSetWrapper) GetReplicas() int32 {
 		return 1 // Default value in Kubernetes if not set
 	}
 	return *s.obj.Spec.Replicas
+}
+
+func (s *StatefulSetWrapper) GetReadyReplicas() int32 {
+	return s.obj.Status.ReadyReplicas
 }
 
 func (s *StatefulSetWrapper) SetReplicas(replicas int32) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -132,6 +132,28 @@ var (
 		},
 		[]string{"namespace", "created_by_us"},
 	)
+
+	// SurgeToReadyDuration tracks the time from replica scale-up to all surge pods becoming Ready.
+	// This is used as the drain unblock time per workload.
+	// Labels: namespace, target_name, target_kind, result (success/timeout)
+	SurgeToReadyDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "eviction_autoscaler_surge_to_ready_seconds",
+			Help:    "Time in seconds from replica scale-up to surge pods becoming Ready (drain unblock time)",
+			Buckets: []float64{1, 2, 5, 10, 15, 30, 45, 60, 90, 120, 180, 300},
+		},
+		[]string{"namespace", "target_name", "target_kind", "result"},
+	)
+
+	// SurgeTimeoutCounter tracks surges that timed out without pods becoming Ready
+	// Labels: namespace, target_name, target_kind
+	SurgeTimeoutCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eviction_autoscaler_surge_timeouts_total",
+			Help: "Total number of surges that were scaled down before pods became Ready",
+		},
+		[]string{"namespace", "target_name", "target_kind"},
+	)
 )
 
 // Constants for PDB creation tracking
@@ -158,6 +180,12 @@ const (
 const (
 	ScaleUpAction   = "scale_up"
 	ScaleDownAction = "scale_down"
+)
+
+// Constants for surge result labels
+const (
+	SurgeResultSuccess = "success"
+	SurgeResultTimeout = "timeout"
 )
 
 // Constants for scaling opportunity signals
@@ -201,5 +229,7 @@ func init() {
 		NodeCordoningCounter,
 		PDBInfoGauge,
 		PDBCounter,
+		SurgeToReadyDuration,
+		SurgeTimeoutCounter,
 	)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -133,24 +133,24 @@ var (
 		[]string{"namespace", "created_by_us"},
 	)
 
-	// SurgeToReadyDuration tracks the time from replica scale-up to all surge pods becoming Ready.
-	// This is used as the drain unblock time per workload.
+	// SurgeToReadyDuration tracks the time from replica scale-up to drain being unblocked
+	// (all surge pods Ready AND PDB allows disruptions again).
 	// Labels: namespace, target_name, target_kind, result (success/timeout)
 	SurgeToReadyDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "eviction_autoscaler_surge_to_ready_seconds",
-			Help:    "Time in seconds from replica scale-up to surge pods becoming Ready (drain unblock time)",
+			Help:    "Time in seconds from replica scale-up to drain unblocked (all pods Ready and PDB allows disruptions)",
 			Buckets: []float64{1, 2, 5, 10, 15, 30, 45, 60, 90, 120, 180, 300},
 		},
 		[]string{"namespace", "target_name", "target_kind", "result"},
 	)
 
-	// SurgeTimeoutCounter tracks surges that timed out without pods becoming Ready
+	// SurgeTimeoutCounter tracks surges that timed out without drain being unblocked
 	// Labels: namespace, target_name, target_kind
 	SurgeTimeoutCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "eviction_autoscaler_surge_timeouts_total",
-			Help: "Total number of surges that were scaled down before pods became Ready",
+			Help: "Total number of surges scaled down before drain was unblocked (pods not Ready or PDB still blocking)",
 		},
 		[]string{"namespace", "target_name", "target_kind"},
 	)


### PR DESCRIPTION
This pull request introduces new metrics and supporting code to track the time from surge scale-up to all pods becoming ready (the "surge-to-ready" duration) and to record surges that time out before readiness. These metrics help monitor and diagnose the efficiency and reliability of surge scaling during evictions. The changes span metric definitions, controller logic, and type updates to support this observability.

**Metrics and Observability Enhancements:**

* Added new Prometheus metrics `SurgeToReadyDuration` (histogram) and `SurgeTimeoutCounter` (counter) to track the time from surge scale-up to all pods being ready, and to count surges that time out, respectively. Also added constants for result labels. (`internal/metrics/metrics.go`) [[1]](diffhunk://#diff-6e56d7c057f6a96124b78f2b669dd7dface2718c304aece205017d114b3a7088R135-R156) [[2]](diffhunk://#diff-6e56d7c057f6a96124b78f2b669dd7dface2718c304aece205017d114b3a7088R185-R190) [[3]](diffhunk://#diff-6e56d7c057f6a96124b78f2b669dd7dface2718c304aece205017d114b3a7088R232-R233)
* Updated the controller logic to record the start time of a surge in `EvictionAutoScaler.Status.SurgeStartTime`, and to observe and emit the new metrics when surges complete successfully or time out. (`internal/controller/evictionautoscaler_controller.go`) [[1]](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddR179-R181) [[2]](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddR192-R211) [[3]](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddR223-R226) [[4]](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddR244-R262)

**API and Type Updates:**

* Added the `SurgeStartTime` field to the `EvictionAutoScalerStatus` struct, and updated deepcopy logic to handle this new field. (`api/v1/evictionautoscaler_types.go`, `api/v1/zz_generated.deepcopy.go`) [[1]](diffhunk://#diff-411539eedea95e73fd65d9953bcc85fe7a4e1980ffbcdf9903396d705eb701ddR26) [[2]](diffhunk://#diff-4267a35009ae655a91fbca7770788673905c01d1aca230a644b4e76a66d994b8R119-R122)

**Controller and Interface Improvements:**

* Extended the `Surger` interface and its implementations (`DeploymentWrapper`, `StatefulSetWrapper`) to add a `GetReadyReplicas()` method, enabling the controller to check when all surge pods are ready. (`internal/controller/wrappers.go`) [[1]](diffhunk://#diff-aebea6569b5307364f39a174334732ae2cf1c61051387bb648fa41516b93d5edR14) [[2]](diffhunk://#diff-aebea6569b5307364f39a174334732ae2cf1c61051387bb648fa41516b93d5edR46-R49) [[3]](diffhunk://#diff-aebea6569b5307364f39a174334732ae2cf1c61051387bb648fa41516b93d5edR95-R98)

These changes collectively improve the system's ability to track and analyze the surge scaling process during evictions, providing valuable insights for debugging and optimization.