### PR TITLE
Implement surge strategies for HPA and KEDA in Eviction Autoscaler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e:
-	go test ./test/e2e/ -v -ginkgo.v
+	go test ./test/e2e/ -v -ginkgo.v -timeout 20m
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -192,6 +192,16 @@ func main() {
 			os.Exit(1)
 		}
 		setupLog.Info("DeploymentToPDBReconciler setup completed")
+
+		if err = (&controllers.AutoscalerToPDBReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+			Filter: nsfilter,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "AutoscalerToPDBReconciler")
+			os.Exit(1)
+		}
+		setupLog.Info("AutoscalerToPDBReconciler setup completed")
 	}
 
 	if err = (&controllers.PDBToEvictionAutoScalerReconciler{

--- a/config/crd/bases/eviction-autoscaler.azure.com_evictionautoscalers.yaml
+++ b/config/crd/bases/eviction-autoscaler.azure.com_evictionautoscalers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: evictionautoscalers.eviction-autoscaler.azure.com
 spec:
   group: eviction-autoscaler.azure.com
@@ -64,16 +64,8 @@ spec:
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -114,12 +106,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,51 +5,10 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
+  - nodes
   - pods
   verbs:
   - get
@@ -61,6 +20,26 @@ rules:
   - pods/status
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
   - eviction-autoscaler.azure.com
   resources:
@@ -88,12 +67,20 @@ rules:
   - patch
   - update
 - apiGroups:
+  - keda.sh
+  resources:
+  - scaledobjects
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets
   verbs:
   - create
-  - delete
   - get
   - list
   - update

--- a/helm/eviction-autoscaler/templates/clusterrole.yaml
+++ b/helm/eviction-autoscaler/templates/clusterrole.yaml
@@ -87,6 +87,24 @@ rules:
   - list
   - update
   - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - keda.sh
+  resources:
+  - scaledobjects
+  verbs:
+  - get
+  - list
+  - watch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/internal/controller/autoscaler_helpers.go
+++ b/internal/controller/autoscaler_helpers.go
@@ -1,0 +1,150 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var errNotFound = errors.New("not found")
+
+// findScaledObjectForTarget looks for a KEDA ScaledObject targeting the given workload.
+// Returns nil, errNotFound if KEDA is not installed or no matching ScaledObject is found.
+func findScaledObjectForTarget(ctx context.Context, c client.Client, namespace, targetName, targetKind string) (*unstructured.Unstructured, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "keda.sh",
+		Version: "v1alpha1",
+		Kind:    "ScaledObjectList",
+	})
+
+	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, errNotFound
+		}
+		return nil, err
+	}
+
+	for i := range list.Items {
+		item := &list.Items[i]
+		scaleTargetRef, found, err := unstructured.NestedMap(item.Object, "spec", "scaleTargetRef")
+		if err != nil || !found {
+			continue
+		}
+		name, _ := scaleTargetRef["name"].(string)
+		kind, _ := scaleTargetRef["kind"].(string)
+		if kind == "" {
+			kind = "Deployment" // KEDA default
+		}
+		if name == targetName && strings.EqualFold(kind, targetKind) {
+			return item, nil
+		}
+	}
+
+	return nil, errNotFound
+}
+
+// findHPAForTarget looks for a standalone (non-KEDA-managed) HPA targeting the given workload.
+// KEDA-managed HPAs are filtered out because they are owned by the ScaledObject and should
+// be controlled via the KEDA strategy instead. This avoids accidentally modifying a KEDA-managed
+// HPA when the customer also has their own standalone HPA on a different deployment.
+// Returns nil, errNotFound if no matching standalone HPA is found.
+func findHPAForTarget(ctx context.Context, c client.Client, namespace, targetName, targetKind string) (*autoscalingv2.HorizontalPodAutoscaler, error) {
+	var hpaList autoscalingv2.HorizontalPodAutoscalerList
+	if err := c.List(ctx, &hpaList, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+
+	for i := range hpaList.Items {
+		hpa := &hpaList.Items[i]
+		if hpa.Spec.ScaleTargetRef.Name == targetName &&
+			strings.EqualFold(hpa.Spec.ScaleTargetRef.Kind, targetKind) {
+			if isKEDAManagedHPA(hpa) {
+				continue // skip KEDA-managed HPAs
+			}
+			return hpa, nil
+		}
+	}
+
+	return nil, errNotFound
+}
+
+// isKEDAManagedHPA returns true if the HPA is owned/managed by KEDA.
+// KEDA-managed HPAs have either an owner reference with kind "ScaledObject"
+// or the label "scaledobject.keda.sh/name".
+func isKEDAManagedHPA(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
+	// Check for KEDA label
+	if _, ok := hpa.Labels["scaledobject.keda.sh/name"]; ok {
+		return true
+	}
+	// Check for owner reference from a ScaledObject
+	for _, ref := range hpa.OwnerReferences {
+		if ref.Kind == "ScaledObject" {
+			return true
+		}
+	}
+	return false
+}
+
+// HasAutoscaler returns true if an HPA or KEDA ScaledObject targets this workload.
+// Returns an error on real API failures (not errNotFound) so the caller can retry.
+func HasAutoscaler(ctx context.Context, c client.Client, namespace, targetName, targetKind string) (bool, error) {
+	_, err := findScaledObjectForTarget(ctx, c, namespace, targetName, targetKind)
+	if err != nil && !errors.Is(err, errNotFound) {
+		return false, err
+	}
+	if err == nil {
+		return true, nil
+	}
+
+	_, err = findHPAForTarget(ctx, c, namespace, targetName, targetKind)
+	if err != nil && !errors.Is(err, errNotFound) {
+		return false, err
+	}
+	if err == nil {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// ResolveMinReplicas returns the effective minimum replica count for a workload.
+// Priority: KEDA ScaledObject minReplicaCount > HPA minReplicas > deployment.spec.replicas.
+// Returns an error on real API failures so the caller can retry rather than using a wrong value.
+func ResolveMinReplicas(ctx context.Context, c client.Client, namespace, targetName, targetKind string, deployReplicas int32) (int32, error) {
+	logger := log.FromContext(ctx)
+
+	// 1. Check KEDA ScaledObject
+	scaledObj, err := findScaledObjectForTarget(ctx, c, namespace, targetName, targetKind)
+	if err != nil && !errors.Is(err, errNotFound) {
+		return 0, err
+	}
+	if err == nil && scaledObj != nil {
+		if val, found, _ := unstructured.NestedInt64(scaledObj.Object, "spec", "minReplicaCount"); found && val > 0 {
+			logger.V(1).Info("Using KEDA ScaledObject minReplicaCount",
+				"target", targetName, "minReplicaCount", val)
+			return int32(val), nil
+		}
+	}
+
+	// 2. Check standalone HPA
+	hpa, err := findHPAForTarget(ctx, c, namespace, targetName, targetKind)
+	if err != nil && !errors.Is(err, errNotFound) {
+		return 0, err
+	}
+	if err == nil && hpa != nil && hpa.Spec.MinReplicas != nil {
+		logger.V(1).Info("Using HPA minReplicas",
+			"target", targetName, "hpa", hpa.Name, "minReplicas", *hpa.Spec.MinReplicas)
+		return *hpa.Spec.MinReplicas, nil
+	}
+
+	// 3. Fall back to deployment replicas
+	return deployReplicas, nil
+}

--- a/internal/controller/autoscaler_to_pdb_controller.go
+++ b/internal/controller/autoscaler_to_pdb_controller.go
@@ -1,0 +1,196 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	v1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// AutoscalerToPDBReconciler watches HPA and KEDA ScaledObject changes
+// and updates the PDB minAvailable to match their min replicas floor.
+// This ensures the PDB stays correct when an autoscaler's minReplicas/minReplicaCount
+// changes without a corresponding deployment spec change.
+type AutoscalerToPDBReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+	Filter filter
+}
+
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch
+
+// Reconcile is triggered when an HPA or ScaledObject changes. The request key is the
+// target deployment's namespace/name (mapped by the watch handlers).
+func (r *AutoscalerToPDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Gate: only act in namespaces where the eviction autoscaler is enabled.
+	// Without this, we'd update PDBs in namespaces the operator isn't managing.
+	isEnabled, err := r.Filter.Filter(ctx, r.Client, req.Namespace)
+	if err != nil {
+		logger.Error(err, "Failed to check if eviction autoscaler is enabled", "namespace", req.Namespace)
+		return reconcile.Result{}, err
+	}
+	if !isEnabled {
+		return reconcile.Result{}, nil
+	}
+
+	// Resolve the target deployment from the HPA/ScaledObject's scaleTargetRef.
+	// The watch mappers translate HPA/ScaledObject events into deployment namespace/name keys.
+	// If the deployment doesn't exist (e.g. HPA outlived it), there's nothing to do.
+	var deployment v1.Deployment
+	if err := r.Get(ctx, req.NamespacedName, &deployment); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Find the PDB that matches this deployment's pod selector labels.
+	// Only consider PDBs created by this controller (ownedBy annotation) — user-managed PDBs
+	// should not be modified. If no controller-owned PDB exists, there's nothing to update.
+	pdb, found, err := findPDBForDeployment(ctx, r.Client, &deployment, true)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if !found {
+		return reconcile.Result{}, nil
+	}
+
+	// Don't update PDB minAvailable during an active surge. The eviction controller
+	// temporarily raises replicas (and possibly HPA/KEDA minReplicas) above the floor
+	// to handle evictions. Updating the PDB now would lock in the surged value as the
+	// new floor. The surge revert path will restore original values, and the next
+	// reconcile after that will set minAvailable correctly.
+	if _, surgeActive := deployment.Annotations[EvictionSurgeReplicasAnnotationKey]; surgeActive {
+		logger.V(1).Info("Surge active on deployment, skipping PDB minAvailable update",
+			"deployment", deployment.Name)
+		return reconcile.Result{}, nil
+	}
+
+	// Resolve the autoscaler's minimum replica floor (KEDA minReplicaCount > HPA minReplicas).
+	// We pass 0 as the fallback so we can detect when no autoscaler was found — if
+	// ResolveMinReplicas returns 0, it means neither HPA nor KEDA targets this deployment
+	// anymore. In that case, the deployment controller owns PDB updates and we bail out.
+	minAvailable := ResolveMinReplicas(ctx, r.Client, req.Namespace, req.Name, ResourceTypeDeployment, 0)
+	if minAvailable == 0 {
+		logger.V(1).Info("No HPA/KEDA found for deployment, skipping PDB update",
+			"deployment", req.Name)
+		return reconcile.Result{}, nil
+	}
+
+	// Idempotency: skip the API write if the PDB already has the correct value.
+	// This avoids unnecessary updates and the resulting watch events.
+	if pdb.Spec.MinAvailable != nil && pdb.Spec.MinAvailable.IntVal == minAvailable {
+		return reconcile.Result{}, nil
+	}
+
+	pdb.Spec.MinAvailable = &intstr.IntOrString{IntVal: minAvailable}
+	if err := r.Update(ctx, pdb); err != nil {
+		logger.Error(err, "unable to update PDB minAvailable from autoscaler",
+			"pdb", pdb.Name, "minAvailable", minAvailable)
+		return reconcile.Result{}, err
+	}
+
+	logger.Info("Updated PDB minAvailable from autoscaler floor",
+		"pdb", pdb.Name, "minAvailable", minAvailable)
+	return reconcile.Result{}, nil
+}
+
+// requeueDeploymentFromHPA maps an HPA event to the target deployment's reconcile request.
+func requeueDeploymentFromHPA() handler.MapFunc {
+	return func(_ context.Context, obj client.Object) []reconcile.Request {
+		hpa, ok := obj.(*autoscalingv2.HorizontalPodAutoscaler)
+		if !ok {
+			return nil
+		}
+		// Skip KEDA-managed HPAs — the ScaledObject watch handles those
+		if isKEDAManagedHPA(hpa) {
+			return nil
+		}
+		if !strings.EqualFold(hpa.Spec.ScaleTargetRef.Kind, ResourceTypeDeployment) {
+			return nil
+		}
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{
+				Namespace: hpa.Namespace,
+				Name:      hpa.Spec.ScaleTargetRef.Name,
+			},
+		}}
+	}
+}
+
+// requeueDeploymentFromScaledObject maps a KEDA ScaledObject event to the target deployment.
+func requeueDeploymentFromScaledObject() handler.TypedMapFunc[*unstructured.Unstructured, reconcile.Request] {
+	return func(_ context.Context, obj *unstructured.Unstructured) []reconcile.Request {
+		scaleTargetRef, found, err := unstructured.NestedMap(obj.Object, "spec", "scaleTargetRef")
+		if err != nil || !found {
+			return nil
+		}
+		name, _ := scaleTargetRef["name"].(string)
+		kind, _ := scaleTargetRef["kind"].(string)
+		if kind == "" {
+			kind = "Deployment"
+		}
+		if !strings.EqualFold(kind, ResourceTypeDeployment) {
+			return nil
+		}
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{
+				Namespace: obj.GetNamespace(),
+				Name:      name,
+			},
+		}}
+	}
+}
+
+// SetupWithManager registers watches on HPA and KEDA ScaledObject resources.
+func (r *AutoscalerToPDBReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	builder := ctrl.NewControllerManagedBy(mgr).
+		// No primary "For" resource — this controller is driven entirely by watches.
+		// We use a dummy source to satisfy the builder and rely on Watches below.
+		Watches(&autoscalingv2.HorizontalPodAutoscaler{},
+			handler.EnqueueRequestsFromMapFunc(requeueDeploymentFromHPA()))
+
+	// Try to watch KEDA ScaledObjects (only if the CRD is installed)
+	scaledObjectGVK := schema.GroupVersionKind{
+		Group:   "keda.sh",
+		Version: "v1alpha1",
+		Kind:    "ScaledObject",
+	}
+	scaledObj := &unstructured.Unstructured{}
+	scaledObj.SetGroupVersionKind(scaledObjectGVK)
+
+	if err := r.discoverScaledObjectCRD(mgr); err == nil {
+		builder = builder.WatchesRawSource(
+			source.Kind(mgr.GetCache(), scaledObj,
+				handler.TypedEnqueueRequestsFromMapFunc(requeueDeploymentFromScaledObject())))
+	} else {
+		mgr.GetLogger().Info("KEDA ScaledObject CRD not found, skipping ScaledObject watch")
+	}
+
+	return builder.Complete(r)
+}
+
+// discoverScaledObjectCRD checks if the KEDA ScaledObject CRD is available.
+func (r *AutoscalerToPDBReconciler) discoverScaledObjectCRD(mgr ctrl.Manager) error {
+	_, err := mgr.GetRESTMapper().RESTMapping(
+		schema.GroupKind{Group: "keda.sh", Kind: "ScaledObject"},
+		"v1alpha1",
+	)
+	if err != nil {
+		return errors.New("ScaledObject CRD not available")
+	}
+	return nil
+}

--- a/internal/controller/autoscaler_to_pdb_controller.go
+++ b/internal/controller/autoscaler_to_pdb_controller.go
@@ -83,7 +83,10 @@ func (r *AutoscalerToPDBReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// We pass 0 as the fallback so we can detect when no autoscaler was found — if
 	// ResolveMinReplicas returns 0, it means neither HPA nor KEDA targets this deployment
 	// anymore. In that case, the deployment controller owns PDB updates and we bail out.
-	minAvailable := ResolveMinReplicas(ctx, r.Client, req.Namespace, req.Name, ResourceTypeDeployment, 0)
+	minAvailable, err := ResolveMinReplicas(ctx, r.Client, req.Namespace, req.Name, ResourceTypeDeployment, 0)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 	if minAvailable == 0 {
 		logger.V(1).Info("No HPA/KEDA found for deployment, skipping PDB update",
 			"deployment", req.Name)

--- a/internal/controller/deployment_to_pdb_controller.go
+++ b/internal/controller/deployment_to_pdb_controller.go
@@ -10,7 +10,6 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -141,12 +140,24 @@ func (r *DeploymentToPDBReconciler) updateMinAvailableAsNecessary(ctx context.Co
 		return nil
 	}
 
+	// When HPA/KEDA targets this deployment, a separate controller (AutoscalerToPDBReconciler)
+	// is responsible for tracking their minReplicas/minReplicaCount and updating PDB minAvailable.
+	// This controller should not interfere with autoscaler-driven replica changes.
+	_, kedaErr := findScaledObjectForTarget(ctx, r.Client, deployment.Namespace, deployment.Name, ResourceTypeDeployment)
+	_, hpaErr := findHPAForTarget(ctx, r.Client, deployment.Namespace, deployment.Name, ResourceTypeDeployment)
+	if kedaErr == nil || hpaErr == nil {
+		logger.V(1).Info("HPA/KEDA controls this deployment, skipping PDB minAvailable update",
+			"target", deployment.Name)
+		return nil
+	}
+
+	// No autoscaler — only proceed if the deployment generation actually changed
 	if EvictionAutoScaler.Status.TargetGeneration == deployment.GetGeneration() {
 		return nil
 	}
 
-	// Skip PDB updates if the replica change was caused by our own eviction surge.
-	// This applies regardless of whether HPA/KEDA is present.
+	// Track deployment.spec.replicas directly.
+	// But skip if the replica change was caused by our own eviction surge.
 	if surgeReplicas, exists := deployment.Annotations[EvictionSurgeReplicasAnnotationKey]; exists {
 		newReplicas, err := strconv.Atoi(surgeReplicas)
 		if err != nil {
@@ -158,39 +169,7 @@ func (r *DeploymentToPDBReconciler) updateMinAvailableAsNecessary(ctx context.Co
 			return nil
 		}
 	}
-
-	// Determine the correct minAvailable value.
-	// When HPA/KEDA targets this deployment, minAvailable tracks the autoscaler's
-	// min replicas (the floor). Otherwise, it tracks deployment.spec.replicas.
-	var minAvailable int32
-
-	hpa, hpaErr := findHPAForTarget(ctx, r.Client, deployment.Namespace, deployment.Name, ResourceTypeDeployment)
-	scaledObj, kedaErr := findScaledObjectForTarget(ctx, r.Client, deployment.Namespace, deployment.Name, ResourceTypeDeployment)
-
-	switch {
-	case kedaErr == nil && scaledObj != nil:
-		// KEDA controls this deployment — use ScaledObject minReplicaCount
-		if val, found, _ := unstructured.NestedInt64(scaledObj.Object, "spec", "minReplicaCount"); found && val > 0 {
-			minAvailable = int32(val)
-		} else {
-			minAvailable = 1 // KEDA default
-		}
-		logger.V(1).Info("Using KEDA ScaledObject minReplicaCount for PDB minAvailable",
-			"target", deployment.Name, "minAvailable", minAvailable)
-
-	case hpaErr == nil && hpa != nil:
-		// HPA controls this deployment — use HPA minReplicas
-		if hpa.Spec.MinReplicas != nil {
-			minAvailable = *hpa.Spec.MinReplicas
-		} else {
-			minAvailable = 1 // HPA default
-		}
-		logger.V(1).Info("Using HPA minReplicas for PDB minAvailable",
-			"target", deployment.Name, "hpa", hpa.Name, "minAvailable", minAvailable)
-
-	default:
-		minAvailable = *deployment.Spec.Replicas
-	}
+	minAvailable := *deployment.Spec.Replicas
 
 	if pdb.Spec.MinAvailable != nil && pdb.Spec.MinAvailable.IntVal == minAvailable {
 		return nil // already correct

--- a/internal/controller/deployment_to_pdb_controller.go
+++ b/internal/controller/deployment_to_pdb_controller.go
@@ -145,12 +145,23 @@ func (r *DeploymentToPDBReconciler) updateMinAvailableAsNecessary(ctx context.Co
 		return nil
 	}
 
+	// Skip PDB updates if the replica change was caused by our own eviction surge.
+	// This applies regardless of whether HPA/KEDA is present.
+	if surgeReplicas, exists := deployment.Annotations[EvictionSurgeReplicasAnnotationKey]; exists {
+		newReplicas, err := strconv.Atoi(surgeReplicas)
+		if err != nil {
+			logger.Error(err, "unable to parse surge replicas from annotation NOT updating",
+				"namespace", deployment.Namespace, "name", deployment.Name, "replicas", surgeReplicas)
+			return err
+		}
+		if int32(newReplicas) == *deployment.Spec.Replicas {
+			return nil
+		}
+	}
+
 	// Determine the correct minAvailable value.
-	// When HPA/KEDA targets this deployment, minAvailable should always track
-	// the autoscaler's min replicas (not the deployment's current count, which
-	// may be scaled up by the autoscaler).
-	// When no HPA/KEDA exists, minAvailable tracks deployment.spec.replicas,
-	// but we skip updates if the replica change was caused by our own surge.
+	// When HPA/KEDA targets this deployment, minAvailable tracks the autoscaler's
+	// min replicas (the floor). Otherwise, it tracks deployment.spec.replicas.
 	var minAvailable int32
 
 	hpa, hpaErr := findHPAForTarget(ctx, r.Client, deployment.Namespace, deployment.Name, ResourceTypeDeployment)
@@ -178,19 +189,6 @@ func (r *DeploymentToPDBReconciler) updateMinAvailableAsNecessary(ctx context.Co
 			"target", deployment.Name, "hpa", hpa.Name, "minAvailable", minAvailable)
 
 	default:
-		// No autoscaler — track deployment.spec.replicas directly.
-		// But skip if the replica change was caused by our own eviction surge.
-		if surgeReplicas, exists := deployment.Annotations[EvictionSurgeReplicasAnnotationKey]; exists {
-			newReplicas, err := strconv.Atoi(surgeReplicas)
-			if err != nil {
-				logger.Error(err, "unable to parse surge replicas from annotation NOT updating",
-					"namespace", deployment.Namespace, "name", deployment.Name, "replicas", surgeReplicas)
-				return err
-			}
-			if int32(newReplicas) == *deployment.Spec.Replicas {
-				return nil
-			}
-		}
 		minAvailable = *deployment.Spec.Replicas
 	}
 

--- a/internal/controller/deployment_to_pdb_controller.go
+++ b/internal/controller/deployment_to_pdb_controller.go
@@ -143,9 +143,11 @@ func (r *DeploymentToPDBReconciler) updateMinAvailableAsNecessary(ctx context.Co
 	// When HPA/KEDA targets this deployment, a separate controller (AutoscalerToPDBReconciler)
 	// is responsible for tracking their minReplicas/minReplicaCount and updating PDB minAvailable.
 	// This controller should not interfere with autoscaler-driven replica changes.
-	_, kedaErr := findScaledObjectForTarget(ctx, r.Client, deployment.Namespace, deployment.Name, ResourceTypeDeployment)
-	_, hpaErr := findHPAForTarget(ctx, r.Client, deployment.Namespace, deployment.Name, ResourceTypeDeployment)
-	if kedaErr == nil || hpaErr == nil {
+	hasAS, err := HasAutoscaler(ctx, r.Client, deployment.Namespace, deployment.Name, ResourceTypeDeployment)
+	if err != nil {
+		return err
+	}
+	if hasAS {
 		logger.V(1).Info("HPA/KEDA controls this deployment, skipping PDB minAvailable update",
 			"target", deployment.Name)
 		return nil
@@ -176,8 +178,7 @@ func (r *DeploymentToPDBReconciler) updateMinAvailableAsNecessary(ctx context.Co
 	}
 
 	pdb.Spec.MinAvailable = &intstr.IntOrString{IntVal: minAvailable}
-	err := r.Update(ctx, &pdb)
-	if err != nil {
+	if err = r.Update(ctx, &pdb); err != nil {
 		logger.Error(err, "unable to update pdb minAvailable",
 			"namespace", pdb.Namespace, "name", pdb.Name, "minAvailable", minAvailable)
 		return err

--- a/internal/controller/deployment_to_pdb_controller.go
+++ b/internal/controller/deployment_to_pdb_controller.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -140,33 +141,72 @@ func (r *DeploymentToPDBReconciler) updateMinAvailableAsNecessary(ctx context.Co
 		return nil
 	}
 
-	if EvictionAutoScaler.Status.TargetGeneration != deployment.GetGeneration() {
-		//EvictionAutoScaler can fail between updating deployment and EvictionAutoScaler targetGeneration;
-		//hence we need to rely on checking if annotation exists and compare with deployment.Spec.Replicas
-		// no surge happened but customer already increased deployment replicas, then annotation would not exist
-		if surgeReplicas, scaleUpAnnotationExists := deployment.Annotations[EvictionSurgeReplicasAnnotationKey]; scaleUpAnnotationExists {
+	if EvictionAutoScaler.Status.TargetGeneration == deployment.GetGeneration() {
+		return nil
+	}
+
+	// Determine the correct minAvailable value.
+	// When HPA/KEDA targets this deployment, minAvailable should always track
+	// the autoscaler's min replicas (not the deployment's current count, which
+	// may be scaled up by the autoscaler).
+	// When no HPA/KEDA exists, minAvailable tracks deployment.spec.replicas,
+	// but we skip updates if the replica change was caused by our own surge.
+	var minAvailable int32
+
+	hpa, hpaErr := findHPAForTarget(ctx, r.Client, deployment.Namespace, deployment.Name, ResourceTypeDeployment)
+	scaledObj, kedaErr := findScaledObjectForTarget(ctx, r.Client, deployment.Namespace, deployment.Name, ResourceTypeDeployment)
+
+	switch {
+	case kedaErr == nil && scaledObj != nil:
+		// KEDA controls this deployment — use ScaledObject minReplicaCount
+		if val, found, _ := unstructured.NestedInt64(scaledObj.Object, "spec", "minReplicaCount"); found && val > 0 {
+			minAvailable = int32(val)
+		} else {
+			minAvailable = 1 // KEDA default
+		}
+		logger.V(1).Info("Using KEDA ScaledObject minReplicaCount for PDB minAvailable",
+			"target", deployment.Name, "minAvailable", minAvailable)
+
+	case hpaErr == nil && hpa != nil:
+		// HPA controls this deployment — use HPA minReplicas
+		if hpa.Spec.MinReplicas != nil {
+			minAvailable = *hpa.Spec.MinReplicas
+		} else {
+			minAvailable = 1 // HPA default
+		}
+		logger.V(1).Info("Using HPA minReplicas for PDB minAvailable",
+			"target", deployment.Name, "hpa", hpa.Name, "minAvailable", minAvailable)
+
+	default:
+		// No autoscaler — track deployment.spec.replicas directly.
+		// But skip if the replica change was caused by our own eviction surge.
+		if surgeReplicas, exists := deployment.Annotations[EvictionSurgeReplicasAnnotationKey]; exists {
 			newReplicas, err := strconv.Atoi(surgeReplicas)
 			if err != nil {
 				logger.Error(err, "unable to parse surge replicas from annotation NOT updating",
 					"namespace", deployment.Namespace, "name", deployment.Name, "replicas", surgeReplicas)
 				return err
 			}
-
 			if int32(newReplicas) == *deployment.Spec.Replicas {
 				return nil
 			}
 		}
-		//someone else changed deployment num of replicas
-		pdb.Spec.MinAvailable = &intstr.IntOrString{IntVal: *deployment.Spec.Replicas}
-		err := r.Update(ctx, &pdb)
-		if err != nil {
-			logger.Error(err, "unable to update pdb minAvailable to deployment replicas ",
-				"namespace", pdb.Namespace, "name", pdb.Name, "replicas", *deployment.Spec.Replicas)
-			return err
-		}
-		logger.Info("Successfully updated pdb minAvailable to deployment replicas ",
-			"namespace", pdb.Namespace, "name", pdb.Name, "replicas", *deployment.Spec.Replicas)
+		minAvailable = *deployment.Spec.Replicas
 	}
+
+	if pdb.Spec.MinAvailable != nil && pdb.Spec.MinAvailable.IntVal == minAvailable {
+		return nil // already correct
+	}
+
+	pdb.Spec.MinAvailable = &intstr.IntOrString{IntVal: minAvailable}
+	err := r.Update(ctx, &pdb)
+	if err != nil {
+		logger.Error(err, "unable to update pdb minAvailable",
+			"namespace", pdb.Namespace, "name", pdb.Name, "minAvailable", minAvailable)
+		return err
+	}
+	logger.Info("Successfully updated pdb minAvailable",
+		"namespace", pdb.Namespace, "name", pdb.Name, "minAvailable", minAvailable)
 	return nil
 }
 

--- a/internal/controller/deployment_to_pdb_controller_test.go
+++ b/internal/controller/deployment_to_pdb_controller_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -417,5 +418,98 @@ var _ = Describe("DeploymentToPDBReconciler PDB creation control", func() {
 		err = k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: deploymentName}, pdb)
 		Expect(err).To(HaveOccurred())
 		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+})
+
+var _ = Describe("DeploymentToPDBReconciler with HPA", func() {
+	var (
+		namespace string
+		r         *DeploymentToPDBReconciler
+		ctx       context.Context
+	)
+
+	const deploymentName = "hpa-deployment"
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		namespaceObj := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-hpa-",
+				Annotations: map[string]string{
+					namespacefilter.EnableEvictionAutoscalerAnnotationKey: "true",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, namespaceObj)).To(Succeed())
+		namespace = namespaceObj.Name
+
+		s := scheme.Scheme
+		Expect(appsv1.AddToScheme(s)).To(Succeed())
+		Expect(policyv1.AddToScheme(s)).To(Succeed())
+		Expect(autoscalingv2.AddToScheme(s)).To(Succeed())
+
+		r = &DeploymentToPDBReconciler{
+			Client: k8sClient,
+			Scheme: s,
+			Filter: &deploymentTestFilter{},
+		}
+	})
+
+	It("should set PDB minAvailable from HPA minReplicas instead of deployment replicas", func() {
+		// Create a deployment with 5 replicas (simulating HPA has scaled it up)
+		maxUnavailable := intstr.FromInt(0)
+		deployment := createDeployment(deploymentName, namespace, "hpa-app", 5, &maxUnavailable)
+		Expect(k8sClient.Create(ctx, deployment)).To(Succeed())
+
+		// Create an HPA targeting this deployment with minReplicas=2
+		minReplicas := int32(2)
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentName,
+				Namespace: namespace,
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       deploymentName,
+				},
+				MinReplicas: &minReplicas,
+				MaxReplicas: 10,
+			},
+		}
+		Expect(k8sClient.Create(ctx, hpa)).To(Succeed())
+
+		// Reconcile — should create PDB with minAvailable=2 (HPA min), not 5 (deployment replicas)
+		req := reconcile.Request{
+			NamespacedName: client.ObjectKey{Namespace: namespace, Name: deploymentName},
+		}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		pdb := &policyv1.PodDisruptionBudget{}
+		err = k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: deploymentName}, pdb)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pdb.Spec.MinAvailable.IntVal).To(Equal(int32(2)))
+	})
+
+	It("should use deployment replicas for PDB minAvailable when no HPA exists", func() {
+		// Create a deployment with 3 replicas, no HPA
+		maxUnavailable := intstr.FromInt(0)
+		depName := "no-hpa-deployment"
+		deployment := createDeployment(depName, namespace, "no-hpa-app", 3, &maxUnavailable)
+		Expect(k8sClient.Create(ctx, deployment)).To(Succeed())
+
+		req := reconcile.Request{
+			NamespacedName: client.ObjectKey{Namespace: namespace, Name: depName},
+		}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+
+		pdb := &policyv1.PodDisruptionBudget{}
+		err = k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: depName}, pdb)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(pdb.Spec.MinAvailable.IntVal).To(Equal(int32(3)))
 	})
 })

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -125,11 +125,17 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Check if the resource version has changed or if it's empty (initial state)
 	if EvictionAutoScaler.Status.TargetGeneration == 0 || EvictionAutoScaler.Status.TargetGeneration != target.Obj().GetGeneration() {
-		logger.Info("Target resource version changed resetting min replicas", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "currentGeneration", target.Obj().GetGeneration(), "previousGeneration", EvictionAutoScaler.Status.TargetGeneration)
-		// The resource version has changed, which means someone else has modified the Target.
-		// To avoid conflicts, we update our status to reflect the new state and avoid making further changes.
 		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
-		EvictionAutoScaler.Status.MinReplicas = target.GetReplicas()
+		// Don't reset MinReplicas if a surge is in progress (e.g., HPA/KEDA-driven scaling
+		// changes the deployment generation as part of the surge, not a user change).
+		if hasTargetAnnotation(target) {
+			logger.Info("Target generation changed during active surge, preserving min replicas", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "currentGeneration", target.Obj().GetGeneration(), "previousGeneration", EvictionAutoScaler.Status.TargetGeneration, "minReplicas", EvictionAutoScaler.Status.MinReplicas)
+		} else {
+			logger.Info("Target resource version changed resetting min replicas", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "currentGeneration", target.Obj().GetGeneration(), "previousGeneration", EvictionAutoScaler.Status.TargetGeneration)
+			// The resource version has changed, which means someone else has modified the Target.
+			// To avoid conflicts, we update our status to reflect the new state and avoid making further changes.
+			EvictionAutoScaler.Status.MinReplicas = target.GetReplicas()
+		}
 		ready(&EvictionAutoScaler.Status.Conditions, "TargetSpecChange", fmt.Sprintf("resetting min replicas to %d", EvictionAutoScaler.Status.MinReplicas))
 		return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler) //should we go rety in case there is also an eviction or just wait till the next eviction
 	}

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -135,7 +135,11 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			// The resource version has changed, which means someone else has modified the Target.
 			// To avoid conflicts, we update our status to reflect the new state and avoid making further changes.
 			// Use ResolveMinReplicas to track the effective floor (HPA minReplicas, KEDA minReplicaCount, or deployment replicas).
-			EvictionAutoScaler.Status.MinReplicas = ResolveMinReplicas(ctx, r.Client, EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, EvictionAutoScaler.Spec.TargetKind, target.GetReplicas())
+			minReplicas, resolveErr := ResolveMinReplicas(ctx, r.Client, EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, EvictionAutoScaler.Spec.TargetKind, target.GetReplicas())
+			if resolveErr != nil {
+				return ctrl.Result{}, resolveErr
+			}
+			EvictionAutoScaler.Status.MinReplicas = minReplicas
 		}
 		ready(&EvictionAutoScaler.Status.Conditions, "TargetSpecChange", fmt.Sprintf("resetting min replicas to %d", EvictionAutoScaler.Status.MinReplicas))
 		return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler) //should we go rety in case there is also an eviction or just wait till the next eviction

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -126,15 +126,6 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Check if the resource version has changed or if it's empty (initial state)
 	if EvictionAutoScaler.Status.TargetGeneration == 0 || EvictionAutoScaler.Status.TargetGeneration != target.Obj().GetGeneration() {
 		logger.Info("Target resource version changed resetting min replicas", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "currentGeneration", target.Obj().GetGeneration(), "previousGeneration", EvictionAutoScaler.Status.TargetGeneration)
-		// If we were surged and the target changed externally
-		// Note: does not handle the case where an external scale happens while a surge is still active
-		// (e.g., user changes replicas mid-surge). We simply revert and reset to the new baseline.
-		if EvictionAutoScaler.Status.TargetGeneration != 0 && target.GetReplicas() > EvictionAutoScaler.Status.MinReplicas {
-			if revertErr := surgeApplier.RevertSurge(ctx, r.Client, target.GetReplicas()); revertErr != nil {
-				logger.Error(revertErr, "failed to revert surge on target generation change")
-				return ctrl.Result{}, revertErr
-			}
-		}
 		// The resource version has changed, which means someone else has modified the Target.
 		// To avoid conflicts, we update our status to reflect the new state and avoid making further changes.
 		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
@@ -145,6 +136,25 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Log current state before checks
 	logger.Info(fmt.Sprintf("Checking PDB for %s: DisruptionsAllowed=%d, MinReplicas=%d", pdb.Name, pdb.Status.DisruptionsAllowed, EvictionAutoScaler.Status.MinReplicas))
+
+	// Ensure any incomplete surge from a prior reconcile is completed.
+	// This handles the case where the controller crashed or the second write failed
+	// after annotating the target but before updating the HPA/ScaledObject.
+	if hasTargetAnnotation(target) && !surgeApplier.IsSurgeComplete() {
+		surgeVal := target.Obj().GetAnnotations()[EvictionSurgeReplicasAnnotationKey]
+		surgeReplicas, err := strconv.ParseInt(surgeVal, 10, 32)
+		if err != nil {
+			logger.Error(err, "invalid surge annotation value during re-drive", "value", surgeVal)
+		} else {
+			logger.Info("Detected incomplete surge, re-driving scaler update", "surgeReplicas", surgeReplicas, "strategy", surgeApplier.Name())
+			if err := surgeApplier.ApplySurge(ctx, r.Client, int32(surgeReplicas)); err != nil {
+				return ctrl.Result{}, err
+			}
+			EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
+			ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "completed incomplete surge re-drive")
+			return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
+		}
+	}
 
 	// Have we processed all evictions okay don't do anything else
 	if EvictionAutoScaler.Spec.LastEviction == EvictionAutoScaler.Status.LastEviction {
@@ -160,7 +170,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	metrics.EvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace).Inc()
 
 	//if we're not scaled up and theres new evictions we haven't processed
-	if pdb.Status.DisruptionsAllowed == 0 && target.GetReplicas() == EvictionAutoScaler.Status.MinReplicas {
+	if pdb.Status.DisruptionsAllowed == 0 && target.GetReplicas() == EvictionAutoScaler.Status.MinReplicas && !surgeApplier.IsSurgeComplete() {
 		// What if the evict went through because the pod being evicted wasn't ready anyways?
 		// TODO later. Surge more slowly based on number of evictions (need to move back to capturing them all)
 		logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name())

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -134,7 +134,8 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			logger.Info("Target resource version changed resetting min replicas", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "currentGeneration", target.Obj().GetGeneration(), "previousGeneration", EvictionAutoScaler.Status.TargetGeneration)
 			// The resource version has changed, which means someone else has modified the Target.
 			// To avoid conflicts, we update our status to reflect the new state and avoid making further changes.
-			EvictionAutoScaler.Status.MinReplicas = target.GetReplicas()
+			// Use ResolveMinReplicas to track the effective floor (HPA minReplicas, KEDA minReplicaCount, or deployment replicas).
+			EvictionAutoScaler.Status.MinReplicas = ResolveMinReplicas(ctx, r.Client, EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, EvictionAutoScaler.Spec.TargetKind, target.GetReplicas())
 		}
 		ready(&EvictionAutoScaler.Status.Conditions, "TargetSpecChange", fmt.Sprintf("resetting min replicas to %d", EvictionAutoScaler.Status.MinReplicas))
 		return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler) //should we go rety in case there is also an eviction or just wait till the next eviction

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -47,6 +47,8 @@ const cooldown = 1 * time.Minute
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=watch;get;list
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=update
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch;update
 
 func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -114,9 +116,25 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// TODO: Move PDB configuration tracking to PDB controller with aggregate labels
 	// Consider tracking: maxUnavailable==0 and minAvailable==replicas as PDBGauge labels
 
+	// Detect surge strategy based on KEDA, HPA, or plain deployment
+	surgeApplier, err := detectSurgeApplier(ctx, r.Client, EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, EvictionAutoScaler.Spec.TargetKind, target)
+	if err != nil {
+		logger.Error(err, "failed to detect surge strategy")
+		return ctrl.Result{}, err
+	}
+
 	// Check if the resource version has changed or if it's empty (initial state)
 	if EvictionAutoScaler.Status.TargetGeneration == 0 || EvictionAutoScaler.Status.TargetGeneration != target.Obj().GetGeneration() {
 		logger.Info("Target resource version changed resetting min replicas", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "currentGeneration", target.Obj().GetGeneration(), "previousGeneration", EvictionAutoScaler.Status.TargetGeneration)
+		// If we were surged and the target changed externally
+		// Note: does not handle the case where an external scale happens while a surge is still active
+		// (e.g., user changes replicas mid-surge). We simply revert and reset to the new baseline.
+		if EvictionAutoScaler.Status.TargetGeneration != 0 && surgeApplier.IsSurged() {
+			if revertErr := surgeApplier.RevertSurge(ctx, r.Client, target.GetReplicas()); revertErr != nil {
+				logger.Error(revertErr, "failed to revert surge on target generation change")
+				return ctrl.Result{}, revertErr
+			}
+		}
 		// The resource version has changed, which means someone else has modified the Target.
 		// To avoid conflicts, we update our status to reflect the new state and avoid making further changes.
 		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
@@ -142,10 +160,10 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	metrics.EvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace).Inc()
 
 	//if we're not scaled up and theres new evictions we haven't processed
-	if pdb.Status.DisruptionsAllowed == 0 && target.GetReplicas() == EvictionAutoScaler.Status.MinReplicas {
+	if pdb.Status.DisruptionsAllowed == 0 && !surgeApplier.IsSurged() {
 		// What if the evict went through because the pod being evicted wasn't ready anyways?
 		// TODO later. Surge more slowly based on number of evictions (need to move back to capturing them all)
-		logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction)
+		logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name())
 
 		// Track blocked eviction if the PDB is blocking the eviction
 		metrics.BlockedEvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name).Inc()
@@ -155,15 +173,9 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction, signalLabel).Inc()
 
 		newReplicas := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas)
-		target.SetReplicas(newReplicas)
-		//adding annotations here is an atomic operation;
-		//EvictionAutoScaler can fail between updating deployment and EvictionAutoScaler targetGeneration;
-		//hence we need to rely on checking if annotation exists and compare with deployment.Spec.Replicas
-		// this is to solve customer scaling up deployment manually so EvictionAutoScaler minAvailable needs to be updated
-		target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, strconv.FormatInt(int64(newReplicas), 10))
-		err = r.Update(ctx, target.Obj())
+		err = surgeApplier.ApplySurge(ctx, r.Client, newReplicas)
 		if err != nil {
-			logger.Error(err, "failed to update Target", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName)
+			logger.Error(err, "failed to apply surge", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "strategy", surgeApplier.Name())
 			return ctrl.Result{}, err
 		}
 
@@ -171,7 +183,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		metrics.ActualScalingCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction).Inc()
 
 		// Log the scaling action
-		logger.Info(fmt.Sprintf("Scaled up %s %s/%s to %d replicas", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), newReplicas))
+		logger.Info(fmt.Sprintf("Scaled up %s %s/%s to %d replicas (via %s)", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), newReplicas, surgeApplier.Name()))
 		logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
 		// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
 		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
@@ -192,15 +204,13 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	//still at a scaled out state check if we can scale back down
-	if target.GetReplicas() > EvictionAutoScaler.Status.MinReplicas { //would we ever be below min replicas
+	if surgeApplier.IsSurged() {
 
 		// Track scaling opportunity
 		metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleDownAction, metrics.CooldownElapsedSignal).Inc()
 
 		//okay we aren't at allowed disruptions Revert Target to the original state
-		target.SetReplicas(EvictionAutoScaler.Status.MinReplicas)
-		target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
-		err = r.Update(ctx, target.Obj())
+		err = surgeApplier.RevertSurge(ctx, r.Client, EvictionAutoScaler.Status.MinReplicas)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -209,7 +219,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		metrics.ActualScalingCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleDownAction).Inc()
 
 		// Log the scaling action
-		logger.Info(fmt.Sprintf("Scaled down %s %s/%s to %d replicas", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), target.GetReplicas()))
+		logger.Info(fmt.Sprintf("Reverted surge on %s %s/%s (via %s)", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), surgeApplier.Name()))
 		// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
 		logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
 		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -129,7 +129,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// If we were surged and the target changed externally
 		// Note: does not handle the case where an external scale happens while a surge is still active
 		// (e.g., user changes replicas mid-surge). We simply revert and reset to the new baseline.
-		if EvictionAutoScaler.Status.TargetGeneration != 0 && surgeApplier.IsSurged() {
+		if EvictionAutoScaler.Status.TargetGeneration != 0 && target.GetReplicas() > EvictionAutoScaler.Status.MinReplicas {
 			if revertErr := surgeApplier.RevertSurge(ctx, r.Client, target.GetReplicas()); revertErr != nil {
 				logger.Error(revertErr, "failed to revert surge on target generation change")
 				return ctrl.Result{}, revertErr
@@ -160,7 +160,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	metrics.EvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace).Inc()
 
 	//if we're not scaled up and theres new evictions we haven't processed
-	if pdb.Status.DisruptionsAllowed == 0 && !surgeApplier.IsSurged() {
+	if pdb.Status.DisruptionsAllowed == 0 && target.GetReplicas() == EvictionAutoScaler.Status.MinReplicas {
 		// What if the evict went through because the pod being evicted wasn't ready anyways?
 		// TODO later. Surge more slowly based on number of evictions (need to move back to capturing them all)
 		logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name())
@@ -204,7 +204,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	//still at a scaled out state check if we can scale back down
-	if surgeApplier.IsSurged() {
+	if target.GetReplicas() > EvictionAutoScaler.Status.MinReplicas {
 
 		// Track scaling opportunity
 		metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleDownAction, metrics.CooldownElapsedSignal).Inc()

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -144,25 +144,6 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Log current state before checks
 	logger.Info(fmt.Sprintf("Checking PDB for %s: DisruptionsAllowed=%d, MinReplicas=%d", pdb.Name, pdb.Status.DisruptionsAllowed, EvictionAutoScaler.Status.MinReplicas))
 
-	// Ensure any incomplete surge from a prior reconcile is completed.
-	// This handles the case where the controller crashed or the second write failed
-	// after annotating the target but before updating the HPA/ScaledObject.
-	if hasTargetAnnotation(target) && !surgeApplier.IsSurgeComplete() {
-		surgeVal := target.Obj().GetAnnotations()[EvictionSurgeReplicasAnnotationKey]
-		surgeReplicas, err := strconv.ParseInt(surgeVal, 10, 32)
-		if err != nil {
-			logger.Error(err, "invalid surge annotation value during re-drive", "value", surgeVal)
-		} else {
-			logger.Info("Detected incomplete surge, re-driving scaler update", "surgeReplicas", surgeReplicas, "strategy", surgeApplier.Name())
-			if err := surgeApplier.ApplySurge(ctx, r.Client, int32(surgeReplicas)); err != nil {
-				return ctrl.Result{}, err
-			}
-			EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
-			ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "completed incomplete surge re-drive")
-			return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
-		}
-	}
-
 	// Have we processed all evictions okay don't do anything else
 	if EvictionAutoScaler.Spec.LastEviction == EvictionAutoScaler.Status.LastEviction {
 		logger.Info("No unhandled eviction ", "pdbname", pdb.Name)
@@ -177,7 +158,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	metrics.EvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace).Inc()
 
 	//if we're not scaled up and theres new evictions we haven't processed
-	if pdb.Status.DisruptionsAllowed == 0 && target.GetReplicas() == EvictionAutoScaler.Status.MinReplicas && !surgeApplier.IsSurgeComplete() {
+	if pdb.Status.DisruptionsAllowed == 0 && target.GetReplicas() == EvictionAutoScaler.Status.MinReplicas {
 		// What if the evict went through because the pod being evicted wasn't ready anyways?
 		// TODO later. Surge more slowly based on number of evictions (need to move back to capturing them all)
 		logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name())

--- a/internal/controller/pdb_helpers.go
+++ b/internal/controller/pdb_helpers.go
@@ -91,7 +91,10 @@ func CreatePDBForDeployment(ctx context.Context, c client.Client, deployment *v1
 
 	// Use KEDA/HPA minReplicas when available instead of deployment.spec.replicas,
 	// since the autoscaler controls the actual replica count and may have scaled above its floor.
-	minAvailable := ResolveMinReplicas(ctx, c, deployment.Namespace, deployment.Name, ResourceTypeDeployment, *deployment.Spec.Replicas)
+	minAvailable, err := ResolveMinReplicas(ctx, c, deployment.Namespace, deployment.Name, ResourceTypeDeployment, *deployment.Spec.Replicas)
+	if err != nil {
+		return err
+	}
 
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/pdb_helpers.go
+++ b/internal/controller/pdb_helpers.go
@@ -89,6 +89,10 @@ func CreatePDBForDeployment(ctx context.Context, c client.Client, deployment *v1
 	controller := true
 	blockOwnerDeletion := true
 
+	// Use KEDA/HPA minReplicas when available instead of deployment.spec.replicas,
+	// since the autoscaler controls the actual replica count and may have scaled above its floor.
+	minAvailable := ResolveMinReplicas(ctx, c, deployment.Namespace, deployment.Name, ResourceTypeDeployment, *deployment.Spec.Replicas)
+
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deployment.Name,
@@ -109,7 +113,7 @@ func CreatePDBForDeployment(ctx context.Context, c client.Client, deployment *v1
 			},
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
-			MinAvailable: &intstr.IntOrString{IntVal: *deployment.Spec.Replicas},
+			MinAvailable: &intstr.IntOrString{IntVal: minAvailable},
 			Selector:     &metav1.LabelSelector{MatchLabels: deployment.Spec.Selector.MatchLabels},
 		},
 	}

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -8,35 +8,55 @@ import (
 	"strings"
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var errNotFound = errors.New("not found")
 
+const maxConflictRetries = 3
+
+// reGetAndUpdateTarget re-fetches the target to get the latest resourceVersion,
+// applies the given mutate function, and retries on conflict up to maxConflictRetries times.
+func reGetAndUpdateTarget(ctx context.Context, c client.Client, target Surger, mutate func()) error {
+	for i := 0; i < maxConflictRetries; i++ {
+		// Re-fetch to get fresh resourceVersion
+		obj := target.Obj()
+		if err := c.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
+			return fmt.Errorf("re-fetching target: %w", err)
+		}
+		mutate()
+		// Use target.Obj() after mutate because SetReplicas may replace the underlying
+		// object via DeepCopy, making the captured 'obj' pointer stale.
+		err := c.Update(ctx, target.Obj())
+		if err == nil {
+			return nil
+		}
+		if !kerrors.IsConflict(err) {
+			return err
+		}
+		log.FromContext(ctx).V(1).Info("Conflict updating target, retrying", "attempt", i+1)
+	}
+	return fmt.Errorf("failed to update target after %d conflict retries", maxConflictRetries)
+}
+
 // SurgeApplier abstracts the mechanism for temporarily increasing minimum replicas.
 // Depending on whether KEDA, HPA, or neither is present, a different implementation is used.
 //
-// For multi-resource strategies (HPA, KEDA): writes are ordered for safe partial-failure recovery.
-// ApplySurge: annotates the target first (intent marker), then updates the HPA/ScaledObject.
-// RevertSurge: reverts the HPA/ScaledObject first, then removes the target annotation.
-// This ensures that on retry after a crash between the two writes, the controller can detect
-// the incomplete state and re-drive the operation to completion.
+// For multi-resource strategies (HPA, KEDA): the HPA/KEDA floor is raised first, then
+// deployment replicas are set directly for immediate effect. On failure, the reconcile
+// loop retries ApplySurge idempotently until the deployment write succeeds.
 type SurgeApplier interface {
 	// ApplySurge sets the minimum replica count to surgeReplicas.
 	// Callers may invoke this multiple times; implementations must be idempotent.
 	ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error
 	// RevertSurge restores the original minimum replica count.
-	// For deployment strategy, originalMinReplicas is used; for HPA/KEDA, the stored annotation is used.
 	RevertSurge(ctx context.Context, c client.Client, originalMinReplicas int32) error
-	// IsSurgeComplete returns true only when the surge intent annotation exists on the
-	// target AND every external resource (HPA, ScaledObject) has been updated to match.
-	// A false return with a present intent annotation signals a partial write that must
-	// be re-driven.
-	IsSurgeComplete() bool
 	// Name returns a human-readable name for logging
 	Name() string
 }
@@ -241,12 +261,6 @@ func (d *DeploymentSurgeApplier) RevertSurge(ctx context.Context, c client.Clien
 	return c.Update(ctx, d.target.Obj())
 }
 
-func (d *DeploymentSurgeApplier) IsSurgeComplete() bool {
-	// For the deployment strategy, annotation and replicas are written in a single
-	// atomic update, so the presence of the annotation implies completeness.
-	return hasTargetAnnotation(d.target)
-}
-
 func (d *DeploymentSurgeApplier) Name() string {
 	return "deployment"
 }
@@ -264,25 +278,34 @@ var _ SurgeApplier = &HPASurgeApplier{}
 func (h *HPASurgeApplier) ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error {
 	logger := log.FromContext(ctx)
 
-	// Step 1: Annotate the target as intent marker.
-	// If we crash after this but before updating the HPA, the next reconcile
-	// will see the annotation and re-drive the HPA update.
+	// Step 1: Update HPA minReplicas first to raise the floor.
+	// This must happen before setting deployment replicas to prevent a race where
+	// the HPA sync loop scales the deployment back down between the two writes.
+	hpa := h.hpa.DeepCopy()
+	hpa.Spec.MinReplicas = &surgeReplicas
+	h.hpa = hpa
+	if err := c.Update(ctx, hpa); err != nil {
+		return fmt.Errorf("updating HPA minReplicas: %w", err)
+	}
+	logger.V(1).Info("Updated HPA minReplicas", "minReplicas", surgeReplicas)
+
+	// Step 2: Set deployment replicas directly for immediate scale-up and annotate
+	// with surge intent marker. This avoids waiting for the HPA sync loop (~15s)
+	// and handles the case where the HPA cannot compute metrics (e.g., no metrics-server).
 	// Skip if already annotated (e.g., by another applier in a composite).
 	surgeVal := strconv.FormatInt(int64(surgeReplicas), 10)
 	if !hasTargetAnnotationWithValue(h.target, surgeVal) {
-		h.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, surgeVal)
-		if err := c.Update(ctx, h.target.Obj()); err != nil {
-			return fmt.Errorf("annotating target with surge intent: %w", err)
+		if err := reGetAndUpdateTarget(ctx, c, h.target, func() {
+			if h.target.GetReplicas() != surgeReplicas {
+				h.target.SetReplicas(surgeReplicas)
+			}
+			h.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, surgeVal)
+		}); err != nil {
+			return fmt.Errorf("setting replicas and annotating target: %w", err)
 		}
-		logger.V(1).Info("Annotated target with surge intent", "replicas", surgeReplicas)
+		logger.V(1).Info("Set replicas and annotated target with surge intent", "replicas", surgeReplicas)
 	}
-
-	// Step 2: Update HPA minReplicas so the HPA doesn't scale back down below the surge
-	hpa := h.hpa.DeepCopy()
-	hpa.Spec.MinReplicas = &surgeReplicas
-
-	h.hpa = hpa
-	return c.Update(ctx, hpa)
+	return nil
 }
 
 func (h *HPASurgeApplier) RevertSurge(ctx context.Context, c client.Client, originalMinReplicas int32) error {
@@ -297,28 +320,19 @@ func (h *HPASurgeApplier) RevertSurge(ctx context.Context, c client.Client, orig
 	}
 	logger.V(1).Info("Reverted HPA minReplicas", "originalMin", originalMinReplicas)
 
-	// Step 2: Remove surge annotation from target (skip if already removed by another applier)
+	// Step 2: Remove surge annotation and set replicas directly for immediate scale-down.
+	// This avoids waiting for the HPA sync loop to enforce the reverted minReplicas.
 	if hasTargetAnnotation(h.target) {
-		h.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
-		if err := c.Update(ctx, h.target.Obj()); err != nil {
+		if err := reGetAndUpdateTarget(ctx, c, h.target, func() {
+			if h.target.GetReplicas() != originalMinReplicas {
+				h.target.SetReplicas(originalMinReplicas)
+			}
+			h.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
+		}); err != nil {
 			return fmt.Errorf("removing surge annotation from target: %w", err)
 		}
 	}
 	return nil
-}
-
-func (h *HPASurgeApplier) IsSurgeComplete() bool {
-	if !hasTargetAnnotation(h.target) {
-		return false
-	}
-	// Verify HPA minReplicas matches the surge value from the target annotation.
-	// If they don't match, the HPA was never updated (partial write).
-	surgeVal := h.target.Obj().GetAnnotations()[EvictionSurgeReplicasAnnotationKey]
-	surgeReplicas, err := strconv.ParseInt(surgeVal, 10, 32)
-	if err != nil {
-		return false
-	}
-	return h.hpa.Spec.MinReplicas != nil && *h.hpa.Spec.MinReplicas == int32(surgeReplicas)
 }
 
 func (h *HPASurgeApplier) Name() string {
@@ -338,25 +352,36 @@ var _ SurgeApplier = &KEDASurgeApplier{}
 func (k *KEDASurgeApplier) ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error {
 	logger := log.FromContext(ctx)
 
-	// Step 1: Annotate the target first as intent marker.
-	// Skip if already annotated (e.g., by another applier in a composite).
-	surgeVal := strconv.FormatInt(int64(surgeReplicas), 10)
-	if !hasTargetAnnotationWithValue(k.target, surgeVal) {
-		k.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, surgeVal)
-		if err := c.Update(ctx, k.target.Obj()); err != nil {
-			return fmt.Errorf("annotating target with surge intent: %w", err)
-		}
-		logger.V(1).Info("Annotated target with surge intent", "replicas", surgeReplicas)
-	}
-
-	// Step 2: Update ScaledObject minReplicaCount
+	// Step 1: Update ScaledObject minReplicaCount first to raise the floor.
+	// This must happen before setting deployment replicas to prevent a race where
+	// KEDA/HPA scales the deployment back down between the two writes.
 	obj := k.scaledObject.DeepCopy()
 	if err := unstructured.SetNestedField(obj.Object, int64(surgeReplicas), "spec", "minReplicaCount"); err != nil {
 		return fmt.Errorf("setting minReplicaCount: %w", err)
 	}
-
 	k.scaledObject = obj
-	return c.Update(ctx, obj)
+	if err := c.Update(ctx, obj); err != nil {
+		return fmt.Errorf("updating ScaledObject minReplicaCount: %w", err)
+	}
+	logger.V(1).Info("Updated ScaledObject minReplicaCount", "minReplicaCount", surgeReplicas)
+
+	// Step 2: Set deployment replicas directly for immediate scale-up and annotate
+	// with surge intent marker. This avoids waiting for the KEDA→HPA sync loop
+	// and handles the case where the HPA cannot compute metrics (e.g., no metrics-server).
+	// Skip if already annotated (e.g., by another applier in a composite).
+	surgeVal := strconv.FormatInt(int64(surgeReplicas), 10)
+	if !hasTargetAnnotationWithValue(k.target, surgeVal) {
+		if err := reGetAndUpdateTarget(ctx, c, k.target, func() {
+			if k.target.GetReplicas() != surgeReplicas {
+				k.target.SetReplicas(surgeReplicas)
+			}
+			k.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, surgeVal)
+		}); err != nil {
+			return fmt.Errorf("setting replicas and annotating target: %w", err)
+		}
+		logger.V(1).Info("Set replicas and annotated target with surge intent", "replicas", surgeReplicas)
+	}
+	return nil
 }
 
 func (k *KEDASurgeApplier) RevertSurge(ctx context.Context, c client.Client, originalMinReplicas int32) error {
@@ -374,29 +399,19 @@ func (k *KEDASurgeApplier) RevertSurge(ctx context.Context, c client.Client, ori
 	}
 	logger.V(1).Info("Reverted ScaledObject minReplicaCount", "originalMin", originalMinReplicas)
 
-	// Step 2: Remove surge annotation from target (skip if already removed by another applier)
+	// Step 2: Remove surge annotation and set replicas directly for immediate scale-down.
+	// This avoids waiting for the KEDA→HPA sync loop to enforce the reverted minReplicaCount.
 	if hasTargetAnnotation(k.target) {
-		k.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
-		if err := c.Update(ctx, k.target.Obj()); err != nil {
+		if err := reGetAndUpdateTarget(ctx, c, k.target, func() {
+			if k.target.GetReplicas() != originalMinReplicas {
+				k.target.SetReplicas(originalMinReplicas)
+			}
+			k.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
+		}); err != nil {
 			return fmt.Errorf("removing surge annotation from target: %w", err)
 		}
 	}
 	return nil
-}
-
-func (k *KEDASurgeApplier) IsSurgeComplete() bool {
-	if !hasTargetAnnotation(k.target) {
-		return false
-	}
-	// Verify ScaledObject minReplicaCount matches the surge value from the target annotation.
-	// If they don't match, the ScaledObject was never updated (partial write).
-	surgeVal := k.target.Obj().GetAnnotations()[EvictionSurgeReplicasAnnotationKey]
-	surgeReplicas, err := strconv.ParseInt(surgeVal, 10, 64)
-	if err != nil {
-		return false
-	}
-	val, found, _ := unstructured.NestedInt64(k.scaledObject.Object, "spec", "minReplicaCount")
-	return found && val == surgeReplicas
 }
 
 func (k *KEDASurgeApplier) Name() string {
@@ -433,15 +448,6 @@ func (comp *CompositeSurgeApplier) RevertSurge(ctx context.Context, c client.Cli
 		}
 	}
 	return nil
-}
-
-func (comp *CompositeSurgeApplier) IsSurgeComplete() bool {
-	for _, a := range comp.appliers {
-		if !a.IsSurgeComplete() {
-			return false
-		}
-	}
-	return true
 }
 
 func (comp *CompositeSurgeApplier) Name() string {

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -23,6 +23,14 @@ const maxConflictRetries = 3
 
 // reGetAndUpdateTarget re-fetches the target to get the latest resourceVersion,
 // applies the given mutate function, and retries on conflict up to maxConflictRetries times.
+//
+// This is needed because HPA/KEDA ApplySurge and RevertSurge are two-step operations:
+// step 1 updates the HPA/ScaledObject, step 2 updates the deployment. Between these steps,
+// the HPA controller may modify the deployment via the /scale subresource, changing its
+// resourceVersion. If we used the stale resourceVersion from the start of the reconcile,
+// the deployment update would fail with a 409 Conflict (optimistic concurrency).
+// Re-fetching gets the latest resourceVersion, and retrying handles the case where
+// the HPA races us again between the re-fetch and the update.
 func reGetAndUpdateTarget(ctx context.Context, c client.Client, target Surger, mutate func()) error {
 	for i := 0; i < maxConflictRetries; i++ {
 		// Re-fetch to get fresh resourceVersion

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -9,15 +9,11 @@ import (
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-var errNotFound = errors.New("not found")
 
 const maxConflictRetries = 3
 
@@ -69,133 +65,51 @@ type SurgeApplier interface {
 	Name() string
 }
 
-// detectSurgeApplier determines which surge strategy to use:
-// 1. If KEDA ScaledObject targets the workload → KEDASurgeApplier (modify minReplicaCount)
-// 2. If HPA targets the workload → HPASurgeApplier (modify minReplicas)
-// 3. Otherwise → DeploymentSurgeApplier (modify deployment.spec.replicas)
+// detectSurgeApplier determines which surge strategy to use by building a
+// composite of all applicable appliers. DeploymentSurgeApplier is always
+// included as the base (it sets deployment.spec.replicas directly). KEDA and
+// HPA appliers are added when their resources target this workload, ensuring
+// their floors are raised before the deployment scales.
 func detectSurgeApplier(ctx context.Context, c client.Client, namespace, targetName, targetKind string, target Surger) (SurgeApplier, error) {
 	logger := log.FromContext(ctx)
 
-	// 1. Check for KEDA ScaledObject targeting this workload
+	var appliers []SurgeApplier
+
+	// Check for KEDA ScaledObject targeting this workload
 	scaledObj, err := findScaledObjectForTarget(ctx, c, namespace, targetName, targetKind)
 	if err != nil && !errors.Is(err, errNotFound) {
 		return nil, fmt.Errorf("checking for KEDA ScaledObject: %w", err)
 	}
+	if scaledObj != nil {
+		logger.Info("Found KEDA ScaledObject for target, adding KEDA surge applier",
+			"scaledObject", scaledObj.GetName(), "target", targetName)
+		appliers = append(appliers, &KEDASurgeApplier{scaledObject: scaledObj, target: target})
+	}
 
-	// 2. Check for standalone HPA targeting this workload
+	// Check for standalone HPA targeting this workload
 	hpa, err := findHPAForTarget(ctx, c, namespace, targetName, targetKind)
 	if err != nil && !errors.Is(err, errNotFound) {
 		return nil, fmt.Errorf("checking for HPA: %w", err)
 	}
-
-	// 3. If both KEDA and standalone HPA exist, surge both to avoid the HPA blocking scale-up
-	if scaledObj != nil && hpa != nil {
-		logger.Info("Found both KEDA ScaledObject and standalone HPA for target, using composite surge strategy",
-			"scaledObject", scaledObj.GetName(), "hpa", hpa.Name, "target", targetName)
-		return &CompositeSurgeApplier{
-			appliers: []SurgeApplier{
-				&KEDASurgeApplier{scaledObject: scaledObj, target: target},
-				&HPASurgeApplier{hpa: hpa, target: target},
-			},
-			target: target,
-		}, nil
-	}
-
-	// 4. KEDA only
-	if scaledObj != nil {
-		logger.Info("Found KEDA ScaledObject for target, using KEDA surge strategy",
-			"scaledObject", scaledObj.GetName(), "target", targetName)
-		return &KEDASurgeApplier{scaledObject: scaledObj, target: target}, nil
-	}
-
-	// 5. HPA only
 	if hpa != nil {
-		logger.Info("Found HPA for target, using HPA surge strategy",
+		logger.Info("Found HPA for target, adding HPA surge applier",
 			"hpa", hpa.Name, "target", targetName)
-		return &HPASurgeApplier{hpa: hpa, target: target}, nil
+		appliers = append(appliers, &HPASurgeApplier{hpa: hpa, target: target})
 	}
 
-	// 6. Fall back to direct deployment/statefulset replica management
-	logger.V(1).Info("No KEDA or HPA found, using deployment surge strategy", "target", targetName)
-	return &DeploymentSurgeApplier{target: target}, nil
-}
-
-// findScaledObjectForTarget looks for a KEDA ScaledObject targeting the given workload.
-// Returns nil, errNotFound if KEDA is not installed or no matching ScaledObject is found.
-func findScaledObjectForTarget(ctx context.Context, c client.Client, namespace, targetName, targetKind string) (*unstructured.Unstructured, error) {
-	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "keda.sh",
-		Version: "v1alpha1",
-		Kind:    "ScaledObjectList",
-	})
-
-	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
-		if meta.IsNoMatchError(err) {
-			return nil, errNotFound
-		}
-		return nil, err
+	// DeploymentSurgeApplier is only needed when no autoscaler appliers were added.
+	// HPA/KEDA appliers already handle setting deployment replicas and the surge
+	// annotation internally (via reGetAndUpdateTarget), so adding DeploymentSurgeApplier
+	// alongside them would cause a stale-object conflict on the second Update.
+	if len(appliers) == 0 {
+		logger.V(1).Info("No KEDA or HPA found, using deployment surge strategy", "target", targetName)
+		appliers = append(appliers, &DeploymentSurgeApplier{target: target})
 	}
 
-	for i := range list.Items {
-		item := &list.Items[i]
-		scaleTargetRef, found, err := unstructured.NestedMap(item.Object, "spec", "scaleTargetRef")
-		if err != nil || !found {
-			continue
-		}
-		name, _ := scaleTargetRef["name"].(string)
-		kind, _ := scaleTargetRef["kind"].(string)
-		if kind == "" {
-			kind = "Deployment" // KEDA default
-		}
-		if name == targetName && strings.EqualFold(kind, targetKind) {
-			return item, nil
-		}
-	}
-
-	return nil, errNotFound
-}
-
-// findHPAForTarget looks for a standalone (non-KEDA-managed) HPA targeting the given workload.
-// KEDA-managed HPAs are filtered out because they are owned by the ScaledObject and should
-// be controlled via the KEDA strategy instead. This avoids accidentally modifying a KEDA-managed
-// HPA when the customer also has their own standalone HPA on a different deployment.
-// Returns nil, errNotFound if no matching standalone HPA is found.
-func findHPAForTarget(ctx context.Context, c client.Client, namespace, targetName, targetKind string) (*autoscalingv2.HorizontalPodAutoscaler, error) {
-	var hpaList autoscalingv2.HorizontalPodAutoscalerList
-	if err := c.List(ctx, &hpaList, client.InNamespace(namespace)); err != nil {
-		return nil, err
-	}
-
-	for i := range hpaList.Items {
-		hpa := &hpaList.Items[i]
-		if hpa.Spec.ScaleTargetRef.Name == targetName &&
-			strings.EqualFold(hpa.Spec.ScaleTargetRef.Kind, targetKind) {
-			if isKEDAManagedHPA(hpa) {
-				continue // skip KEDA-managed HPAs
-			}
-			return hpa, nil
-		}
-	}
-
-	return nil, errNotFound
-}
-
-// isKEDAManagedHPA returns true if the HPA is owned/managed by KEDA.
-// KEDA-managed HPAs have either an owner reference with kind "ScaledObject"
-// or the label "scaledobject.keda.sh/name".
-func isKEDAManagedHPA(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
-	// Check for KEDA label
-	if _, ok := hpa.Labels["scaledobject.keda.sh/name"]; ok {
-		return true
-	}
-	// Check for owner reference from a ScaledObject
-	for _, ref := range hpa.OwnerReferences {
-		if ref.Kind == "ScaledObject" {
-			return true
-		}
-	}
-	return false
+	return &CompositeSurgeApplier{
+		appliers: appliers,
+		target:   target,
+	}, nil
 }
 
 // hasTargetAnnotationWithValue checks if the target has the evictionSurgeReplicas annotation
@@ -217,34 +131,6 @@ func hasTargetAnnotation(target Surger) bool {
 	}
 	_, exists := annotations[EvictionSurgeReplicasAnnotationKey]
 	return exists
-}
-
-// ResolveMinReplicas returns the effective minimum replica count for a workload.
-// Priority: KEDA ScaledObject minReplicaCount > HPA minReplicas > deployment.spec.replicas.
-// This ensures PDB minAvailable reflects the true floor when an autoscaler controls replicas.
-func ResolveMinReplicas(ctx context.Context, c client.Client, namespace, targetName, targetKind string, deployReplicas int32) int32 {
-	logger := log.FromContext(ctx)
-
-	// 1. Check KEDA ScaledObject
-	scaledObj, err := findScaledObjectForTarget(ctx, c, namespace, targetName, targetKind)
-	if err == nil && scaledObj != nil {
-		if val, found, _ := unstructured.NestedInt64(scaledObj.Object, "spec", "minReplicaCount"); found && val > 0 {
-			logger.V(1).Info("Using KEDA ScaledObject minReplicaCount for PDB minAvailable",
-				"target", targetName, "minReplicaCount", val)
-			return int32(val)
-		}
-	}
-
-	// 2. Check standalone HPA
-	hpa, err := findHPAForTarget(ctx, c, namespace, targetName, targetKind)
-	if err == nil && hpa != nil && hpa.Spec.MinReplicas != nil {
-		logger.V(1).Info("Using HPA minReplicas for PDB minAvailable",
-			"target", targetName, "hpa", hpa.Name, "minReplicas", *hpa.Spec.MinReplicas)
-		return *hpa.Spec.MinReplicas
-	}
-
-	// 3. Fall back to deployment replicas
-	return deployReplicas
 }
 
 // --- DeploymentSurgeApplier ---

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -193,6 +193,34 @@ func hasTargetAnnotation(target Surger) bool {
 	return exists
 }
 
+// ResolveMinReplicas returns the effective minimum replica count for a workload.
+// Priority: KEDA ScaledObject minReplicaCount > HPA minReplicas > deployment.spec.replicas.
+// This ensures PDB minAvailable reflects the true floor when an autoscaler controls replicas.
+func ResolveMinReplicas(ctx context.Context, c client.Client, namespace, targetName, targetKind string, deployReplicas int32) int32 {
+	logger := log.FromContext(ctx)
+
+	// 1. Check KEDA ScaledObject
+	scaledObj, err := findScaledObjectForTarget(ctx, c, namespace, targetName, targetKind)
+	if err == nil && scaledObj != nil {
+		if val, found, _ := unstructured.NestedInt64(scaledObj.Object, "spec", "minReplicaCount"); found && val > 0 {
+			logger.V(1).Info("Using KEDA ScaledObject minReplicaCount for PDB minAvailable",
+				"target", targetName, "minReplicaCount", val)
+			return int32(val)
+		}
+	}
+
+	// 2. Check standalone HPA
+	hpa, err := findHPAForTarget(ctx, c, namespace, targetName, targetKind)
+	if err == nil && hpa != nil && hpa.Spec.MinReplicas != nil {
+		logger.V(1).Info("Using HPA minReplicas for PDB minAvailable",
+			"target", targetName, "hpa", hpa.Name, "minReplicas", *hpa.Spec.MinReplicas)
+		return *hpa.Spec.MinReplicas
+	}
+
+	// 3. Fall back to deployment replicas
+	return deployReplicas
+}
+
 // --- DeploymentSurgeApplier ---
 // Surges by modifying the deployment/statefulset spec.replicas directly.
 // This is the default strategy when no KEDA or HPA is present.

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -25,9 +25,6 @@ const OriginalMinReplicasAnnotationKey = "eviction-autoscaler.azure.com/original
 // This ensures that on retry after a crash between the two writes, the controller can detect
 // the incomplete state and re-drive the operation to completion.
 type SurgeApplier interface {
-	// IsSurged returns true if the controller has already applied a surge.
-	// Checks the evictionSurgeReplicas annotation on the target (deployment/statefulset).
-	IsSurged() bool
 	// ApplySurge sets the minimum replica count to surgeReplicas
 	ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error
 	// RevertSurge restores the original minimum replica count.
@@ -49,24 +46,41 @@ func detectSurgeApplier(ctx context.Context, c client.Client, namespace, targetN
 	if err != nil {
 		return nil, fmt.Errorf("checking for KEDA ScaledObject: %w", err)
 	}
+
+	// 2. Check for standalone HPA targeting this workload
+	hpa, err := findHPAForTarget(ctx, c, namespace, targetName, targetKind)
+	if err != nil {
+		return nil, fmt.Errorf("checking for HPA: %w", err)
+	}
+
+	// 3. If both KEDA and standalone HPA exist, surge both to avoid the HPA blocking scale-up
+	if scaledObj != nil && hpa != nil {
+		logger.Info("Found both KEDA ScaledObject and standalone HPA for target, using composite surge strategy",
+			"scaledObject", scaledObj.GetName(), "hpa", hpa.Name, "target", targetName)
+		return &CompositeSurgeApplier{
+			appliers: []SurgeApplier{
+				&KEDASurgeApplier{scaledObject: scaledObj, target: target},
+				&HPASurgeApplier{hpa: hpa, target: target},
+			},
+			target: target,
+		}, nil
+	}
+
+	// 4. KEDA only
 	if scaledObj != nil {
 		logger.Info("Found KEDA ScaledObject for target, using KEDA surge strategy",
 			"scaledObject", scaledObj.GetName(), "target", targetName)
 		return &KEDASurgeApplier{scaledObject: scaledObj, target: target}, nil
 	}
 
-	// 2. Check for HPA targeting this workload
-	hpa, err := findHPAForTarget(ctx, c, namespace, targetName, targetKind)
-	if err != nil {
-		return nil, fmt.Errorf("checking for HPA: %w", err)
-	}
+	// 5. HPA only
 	if hpa != nil {
 		logger.Info("Found HPA for target, using HPA surge strategy",
 			"hpa", hpa.Name, "target", targetName)
 		return &HPASurgeApplier{hpa: hpa, target: target}, nil
 	}
 
-	// 3. Fall back to direct deployment/statefulset replica management
+	// 6. Fall back to direct deployment/statefulset replica management
 	logger.V(1).Info("No KEDA or HPA found, using deployment surge strategy", "target", targetName)
 	return &DeploymentSurgeApplier{target: target}, nil
 }
@@ -149,6 +163,27 @@ func isKEDAManagedHPA(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
 	return false
 }
 
+// hasTargetAnnotationWithValue checks if the target has the evictionSurgeReplicas annotation
+// with the expected value. Used internally by appliers to avoid redundant writes in composite mode.
+func hasTargetAnnotationWithValue(target Surger, value string) bool {
+	annotations := target.Obj().GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	v, exists := annotations[EvictionSurgeReplicasAnnotationKey]
+	return exists && v == value
+}
+
+// hasTargetAnnotation checks if the target has the evictionSurgeReplicas annotation (any value).
+func hasTargetAnnotation(target Surger) bool {
+	annotations := target.Obj().GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, exists := annotations[EvictionSurgeReplicasAnnotationKey]
+	return exists
+}
+
 // --- DeploymentSurgeApplier ---
 // Surges by modifying the deployment/statefulset spec.replicas directly.
 // This is the default strategy when no KEDA or HPA is present.
@@ -158,15 +193,6 @@ type DeploymentSurgeApplier struct {
 }
 
 var _ SurgeApplier = &DeploymentSurgeApplier{}
-
-func (d *DeploymentSurgeApplier) IsSurged() bool {
-	annotations := d.target.Obj().GetAnnotations()
-	if annotations == nil {
-		return false
-	}
-	_, exists := annotations[EvictionSurgeReplicasAnnotationKey]
-	return exists
-}
 
 func (d *DeploymentSurgeApplier) ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error {
 	d.target.SetReplicas(surgeReplicas)
@@ -194,26 +220,21 @@ type HPASurgeApplier struct {
 
 var _ SurgeApplier = &HPASurgeApplier{}
 
-func (h *HPASurgeApplier) IsSurged() bool {
-	annotations := h.target.Obj().GetAnnotations()
-	if annotations == nil {
-		return false
-	}
-	_, exists := annotations[EvictionSurgeReplicasAnnotationKey]
-	return exists
-}
-
 func (h *HPASurgeApplier) ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error {
 	logger := log.FromContext(ctx)
 
 	// Step 1: Annotate the target first as intent marker.
 	// If we crash after this but before updating the HPA, the next reconcile
 	// will see the annotation and re-drive the HPA update.
-	h.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, strconv.FormatInt(int64(surgeReplicas), 10))
-	if err := c.Update(ctx, h.target.Obj()); err != nil {
-		return fmt.Errorf("annotating target with surge intent: %w", err)
+	// Skip if already annotated (e.g., by another applier in a composite).
+	surgeVal := strconv.FormatInt(int64(surgeReplicas), 10)
+	if !hasTargetAnnotationWithValue(h.target, surgeVal) {
+		h.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, surgeVal)
+		if err := c.Update(ctx, h.target.Obj()); err != nil {
+			return fmt.Errorf("annotating target with surge intent: %w", err)
+		}
+		logger.V(1).Info("Annotated target with surge intent", "replicas", surgeReplicas)
 	}
-	logger.V(1).Info("Annotated target with surge intent", "replicas", surgeReplicas)
 
 	// Step 2: Update HPA minReplicas
 	hpa := h.hpa.DeepCopy()
@@ -250,9 +271,14 @@ func (h *HPASurgeApplier) RevertSurge(ctx context.Context, c client.Client, _ in
 	}
 	logger.V(1).Info("Reverted HPA minReplicas")
 
-	// Step 2: Remove surge annotation from target
-	h.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
-	return c.Update(ctx, h.target.Obj())
+	// Step 2: Remove surge annotation from target (skip if already removed by another applier)
+	if hasTargetAnnotation(h.target) {
+		h.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
+		if err := c.Update(ctx, h.target.Obj()); err != nil {
+			return fmt.Errorf("removing surge annotation from target: %w", err)
+		}
+	}
+	return nil
 }
 
 func (h *HPASurgeApplier) Name() string {
@@ -269,24 +295,19 @@ type KEDASurgeApplier struct {
 
 var _ SurgeApplier = &KEDASurgeApplier{}
 
-func (k *KEDASurgeApplier) IsSurged() bool {
-	annotations := k.target.Obj().GetAnnotations()
-	if annotations == nil {
-		return false
-	}
-	_, exists := annotations[EvictionSurgeReplicasAnnotationKey]
-	return exists
-}
-
 func (k *KEDASurgeApplier) ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error {
 	logger := log.FromContext(ctx)
 
 	// Step 1: Annotate the target first as intent marker.
-	k.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, strconv.FormatInt(int64(surgeReplicas), 10))
-	if err := c.Update(ctx, k.target.Obj()); err != nil {
-		return fmt.Errorf("annotating target with surge intent: %w", err)
+	// Skip if already annotated (e.g., by another applier in a composite).
+	surgeVal := strconv.FormatInt(int64(surgeReplicas), 10)
+	if !hasTargetAnnotationWithValue(k.target, surgeVal) {
+		k.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, surgeVal)
+		if err := c.Update(ctx, k.target.Obj()); err != nil {
+			return fmt.Errorf("annotating target with surge intent: %w", err)
+		}
+		logger.V(1).Info("Annotated target with surge intent", "replicas", surgeReplicas)
 	}
-	logger.V(1).Info("Annotated target with surge intent", "replicas", surgeReplicas)
 
 	// Step 2: Update ScaledObject minReplicaCount
 	obj := k.scaledObject.DeepCopy()
@@ -336,11 +357,56 @@ func (k *KEDASurgeApplier) RevertSurge(ctx context.Context, c client.Client, _ i
 	}
 	logger.V(1).Info("Reverted ScaledObject minReplicaCount")
 
-	// Step 2: Remove surge annotation from target
-	k.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
-	return c.Update(ctx, k.target.Obj())
+	// Step 2: Remove surge annotation from target (skip if already removed by another applier)
+	if hasTargetAnnotation(k.target) {
+		k.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
+		if err := c.Update(ctx, k.target.Obj()); err != nil {
+			return fmt.Errorf("removing surge annotation from target: %w", err)
+		}
+	}
+	return nil
 }
 
 func (k *KEDASurgeApplier) Name() string {
 	return "keda"
+}
+
+// --- CompositeSurgeApplier ---
+// Surges multiple resources (e.g., both KEDA ScaledObject and standalone HPA) when both
+// target the same workload. This prevents the standalone HPA from blocking scale-up when
+// only the ScaledObject is surged, or vice versa.
+// The target annotation (evictionSurgeReplicas) is written once by the first applier;
+// subsequent appliers skip re-annotating the target to avoid duplicate writes.
+
+type CompositeSurgeApplier struct {
+	appliers []SurgeApplier
+	target   Surger
+}
+
+var _ SurgeApplier = &CompositeSurgeApplier{}
+
+func (comp *CompositeSurgeApplier) ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error {
+	for _, applier := range comp.appliers {
+		if err := applier.ApplySurge(ctx, c, surgeReplicas); err != nil {
+			return fmt.Errorf("composite surge (%s): %w", applier.Name(), err)
+		}
+	}
+	return nil
+}
+
+func (comp *CompositeSurgeApplier) RevertSurge(ctx context.Context, c client.Client, originalMinReplicas int32) error {
+	for _, applier := range comp.appliers {
+		if err := applier.RevertSurge(ctx, c, originalMinReplicas); err != nil {
+			return fmt.Errorf("composite revert (%s): %w", applier.Name(), err)
+		}
+	}
+	return nil
+}
+
+func (comp *CompositeSurgeApplier) Name() string {
+	names := make([]string, len(comp.appliers))
+	for i, a := range comp.appliers {
+		names[i] = a.Name()
+	}
+	return "composite(" + strings.Join(names, "+") + ")"
 }

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -17,8 +17,6 @@ import (
 
 var errNotFound = errors.New("not found")
 
-const OriginalMinReplicasAnnotationKey = "eviction-autoscaler.azure.com/original-min-replicas"
-
 // SurgeApplier abstracts the mechanism for temporarily increasing minimum replicas.
 // Depending on whether KEDA, HPA, or neither is present, a different implementation is used.
 //
@@ -266,7 +264,7 @@ var _ SurgeApplier = &HPASurgeApplier{}
 func (h *HPASurgeApplier) ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error {
 	logger := log.FromContext(ctx)
 
-	// Step 1: Annotate the target first as intent marker.
+	// Step 1: Annotate the target as intent marker.
 	// If we crash after this but before updating the HPA, the next reconcile
 	// will see the annotation and re-drive the HPA update.
 	// Skip if already annotated (e.g., by another applier in a composite).
@@ -279,43 +277,25 @@ func (h *HPASurgeApplier) ApplySurge(ctx context.Context, c client.Client, surge
 		logger.V(1).Info("Annotated target with surge intent", "replicas", surgeReplicas)
 	}
 
-	// Step 2: Update HPA minReplicas
+	// Step 2: Update HPA minReplicas so the HPA doesn't scale back down below the surge
 	hpa := h.hpa.DeepCopy()
-	originalMin := int32(1) // HPA default
-	if hpa.Spec.MinReplicas != nil {
-		originalMin = *hpa.Spec.MinReplicas
-	}
-	if hpa.Annotations == nil {
-		hpa.Annotations = make(map[string]string)
-	}
-	hpa.Annotations[OriginalMinReplicasAnnotationKey] = strconv.FormatInt(int64(originalMin), 10)
 	hpa.Spec.MinReplicas = &surgeReplicas
 
 	h.hpa = hpa
 	return c.Update(ctx, hpa)
 }
 
-func (h *HPASurgeApplier) RevertSurge(ctx context.Context, c client.Client, _ int32) error {
+func (h *HPASurgeApplier) RevertSurge(ctx context.Context, c client.Client, originalMinReplicas int32) error {
 	logger := log.FromContext(ctx)
 
-	// Step 1: Revert HPA minReplicas first
+	// Step 1: Revert HPA minReplicas using EA.Status.MinReplicas (the effective floor)
 	hpa := h.hpa.DeepCopy()
-	origStr, ok := hpa.Annotations[OriginalMinReplicasAnnotationKey]
-	if !ok {
-		return fmt.Errorf("cannot revert HPA %s/%s: missing %s annotation", hpa.Namespace, hpa.Name, OriginalMinReplicasAnnotationKey)
-	}
-	orig, err := strconv.ParseInt(origStr, 10, 32)
-	if err != nil {
-		return fmt.Errorf("cannot revert HPA %s/%s: invalid %s annotation value %q: %w", hpa.Namespace, hpa.Name, OriginalMinReplicasAnnotationKey, origStr, err)
-	}
-	origInt32 := int32(orig)
-	hpa.Spec.MinReplicas = &origInt32
-	delete(hpa.Annotations, OriginalMinReplicasAnnotationKey)
+	hpa.Spec.MinReplicas = &originalMinReplicas
 	h.hpa = hpa
 	if err := c.Update(ctx, hpa); err != nil {
 		return fmt.Errorf("reverting HPA minReplicas: %w", err)
 	}
-	logger.V(1).Info("Reverted HPA minReplicas", "originalMin", origInt32)
+	logger.V(1).Info("Reverted HPA minReplicas", "originalMin", originalMinReplicas)
 
 	// Step 2: Remove surge annotation from target (skip if already removed by another applier)
 	if hasTargetAnnotation(h.target) {
@@ -331,13 +311,14 @@ func (h *HPASurgeApplier) IsSurgeComplete() bool {
 	if !hasTargetAnnotation(h.target) {
 		return false
 	}
-	// The HPA must also carry the original-min-replicas annotation, which is written
-	// in step 2 of ApplySurge. If it is missing, the HPA was never updated.
-	if h.hpa.Annotations == nil {
+	// Verify HPA minReplicas matches the surge value from the target annotation.
+	// If they don't match, the HPA was never updated (partial write).
+	surgeVal := h.target.Obj().GetAnnotations()[EvictionSurgeReplicasAnnotationKey]
+	surgeReplicas, err := strconv.ParseInt(surgeVal, 10, 32)
+	if err != nil {
 		return false
 	}
-	_, ok := h.hpa.Annotations[OriginalMinReplicasAnnotationKey]
-	return ok
+	return h.hpa.Spec.MinReplicas != nil && *h.hpa.Spec.MinReplicas == int32(surgeReplicas)
 }
 
 func (h *HPASurgeApplier) Name() string {
@@ -370,17 +351,6 @@ func (k *KEDASurgeApplier) ApplySurge(ctx context.Context, c client.Client, surg
 
 	// Step 2: Update ScaledObject minReplicaCount
 	obj := k.scaledObject.DeepCopy()
-	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	if val, found, _ := unstructured.NestedInt64(obj.Object, "spec", "minReplicaCount"); found {
-		annotations[OriginalMinReplicasAnnotationKey] = strconv.FormatInt(val, 10)
-	} else {
-		annotations[OriginalMinReplicasAnnotationKey] = "" // was not set
-	}
-	obj.SetAnnotations(annotations)
-
 	if err := unstructured.SetNestedField(obj.Object, int64(surgeReplicas), "spec", "minReplicaCount"); err != nil {
 		return fmt.Errorf("setting minReplicaCount: %w", err)
 	}
@@ -389,35 +359,20 @@ func (k *KEDASurgeApplier) ApplySurge(ctx context.Context, c client.Client, surg
 	return c.Update(ctx, obj)
 }
 
-func (k *KEDASurgeApplier) RevertSurge(ctx context.Context, c client.Client, _ int32) error {
+func (k *KEDASurgeApplier) RevertSurge(ctx context.Context, c client.Client, originalMinReplicas int32) error {
 	logger := log.FromContext(ctx)
 
-	// Step 1: Revert ScaledObject minReplicaCount first
+	// Step 1: Revert ScaledObject minReplicaCount using EA.Status.MinReplicas (the effective floor)
 	obj := k.scaledObject.DeepCopy()
-	annotations := obj.GetAnnotations()
-	origStr, ok := annotations[OriginalMinReplicasAnnotationKey]
-	if !ok {
-		return fmt.Errorf("cannot revert ScaledObject %s/%s: missing %s annotation", obj.GetNamespace(), obj.GetName(), OriginalMinReplicasAnnotationKey)
+	if err := unstructured.SetNestedField(obj.Object, int64(originalMinReplicas), "spec", "minReplicaCount"); err != nil {
+		return fmt.Errorf("restoring minReplicaCount: %w", err)
 	}
-	if origStr == "" {
-		unstructured.RemoveNestedField(obj.Object, "spec", "minReplicaCount")
-	} else {
-		orig, err := strconv.ParseInt(origStr, 10, 64)
-		if err != nil {
-			return fmt.Errorf("cannot revert ScaledObject %s/%s: invalid %s annotation value %q: %w", obj.GetNamespace(), obj.GetName(), OriginalMinReplicasAnnotationKey, origStr, err)
-		}
-		if err := unstructured.SetNestedField(obj.Object, orig, "spec", "minReplicaCount"); err != nil {
-			return fmt.Errorf("restoring minReplicaCount: %w", err)
-		}
-	}
-	delete(annotations, OriginalMinReplicasAnnotationKey)
-	obj.SetAnnotations(annotations)
 
 	k.scaledObject = obj
 	if err := c.Update(ctx, obj); err != nil {
 		return fmt.Errorf("reverting ScaledObject minReplicaCount: %w", err)
 	}
-	logger.V(1).Info("Reverted ScaledObject minReplicaCount")
+	logger.V(1).Info("Reverted ScaledObject minReplicaCount", "originalMin", originalMinReplicas)
 
 	// Step 2: Remove surge annotation from target (skip if already removed by another applier)
 	if hasTargetAnnotation(k.target) {
@@ -433,14 +388,15 @@ func (k *KEDASurgeApplier) IsSurgeComplete() bool {
 	if !hasTargetAnnotation(k.target) {
 		return false
 	}
-	// The ScaledObject must also carry the original-min-replicas annotation, which is
-	// written in step 2 of ApplySurge. If it is missing, the ScaledObject was never updated.
-	annotations := k.scaledObject.GetAnnotations()
-	if annotations == nil {
+	// Verify ScaledObject minReplicaCount matches the surge value from the target annotation.
+	// If they don't match, the ScaledObject was never updated (partial write).
+	surgeVal := k.target.Obj().GetAnnotations()[EvictionSurgeReplicasAnnotationKey]
+	surgeReplicas, err := strconv.ParseInt(surgeVal, 10, 64)
+	if err != nil {
 		return false
 	}
-	_, ok := annotations[OriginalMinReplicasAnnotationKey]
-	return ok
+	val, found, _ := unstructured.NestedInt64(k.scaledObject.Object, "spec", "minReplicaCount")
+	return found && val == surgeReplicas
 }
 
 func (k *KEDASurgeApplier) Name() string {

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -25,11 +25,17 @@ const OriginalMinReplicasAnnotationKey = "eviction-autoscaler.azure.com/original
 // This ensures that on retry after a crash between the two writes, the controller can detect
 // the incomplete state and re-drive the operation to completion.
 type SurgeApplier interface {
-	// ApplySurge sets the minimum replica count to surgeReplicas
+	// ApplySurge sets the minimum replica count to surgeReplicas.
+	// Callers may invoke this multiple times; implementations must be idempotent.
 	ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error
 	// RevertSurge restores the original minimum replica count.
 	// For deployment strategy, originalMinReplicas is used; for HPA/KEDA, the stored annotation is used.
 	RevertSurge(ctx context.Context, c client.Client, originalMinReplicas int32) error
+	// IsSurgeComplete returns true only when the surge intent annotation exists on the
+	// target AND every external resource (HPA, ScaledObject) has been updated to match.
+	// A false return with a present intent annotation signals a partial write that must
+	// be re-driven.
+	IsSurgeComplete() bool
 	// Name returns a human-readable name for logging
 	Name() string
 }
@@ -206,6 +212,12 @@ func (d *DeploymentSurgeApplier) RevertSurge(ctx context.Context, c client.Clien
 	return c.Update(ctx, d.target.Obj())
 }
 
+func (d *DeploymentSurgeApplier) IsSurgeComplete() bool {
+	// For the deployment strategy, annotation and replicas are written in a single
+	// atomic update, so the presence of the annotation implies completeness.
+	return hasTargetAnnotation(d.target)
+}
+
 func (d *DeploymentSurgeApplier) Name() string {
 	return "deployment"
 }
@@ -257,19 +269,22 @@ func (h *HPASurgeApplier) RevertSurge(ctx context.Context, c client.Client, _ in
 
 	// Step 1: Revert HPA minReplicas first
 	hpa := h.hpa.DeepCopy()
-	if origStr, ok := hpa.Annotations[OriginalMinReplicasAnnotationKey]; ok {
-		orig, err := strconv.ParseInt(origStr, 10, 32)
-		if err == nil {
-			origInt32 := int32(orig)
-			hpa.Spec.MinReplicas = &origInt32
-		}
+	origStr, ok := hpa.Annotations[OriginalMinReplicasAnnotationKey]
+	if !ok {
+		return fmt.Errorf("cannot revert HPA %s/%s: missing %s annotation", hpa.Namespace, hpa.Name, OriginalMinReplicasAnnotationKey)
 	}
+	orig, err := strconv.ParseInt(origStr, 10, 32)
+	if err != nil {
+		return fmt.Errorf("cannot revert HPA %s/%s: invalid %s annotation value %q: %w", hpa.Namespace, hpa.Name, OriginalMinReplicasAnnotationKey, origStr, err)
+	}
+	origInt32 := int32(orig)
+	hpa.Spec.MinReplicas = &origInt32
 	delete(hpa.Annotations, OriginalMinReplicasAnnotationKey)
 	h.hpa = hpa
 	if err := c.Update(ctx, hpa); err != nil {
 		return fmt.Errorf("reverting HPA minReplicas: %w", err)
 	}
-	logger.V(1).Info("Reverted HPA minReplicas")
+	logger.V(1).Info("Reverted HPA minReplicas", "originalMin", origInt32)
 
 	// Step 2: Remove surge annotation from target (skip if already removed by another applier)
 	if hasTargetAnnotation(h.target) {
@@ -279,6 +294,19 @@ func (h *HPASurgeApplier) RevertSurge(ctx context.Context, c client.Client, _ in
 		}
 	}
 	return nil
+}
+
+func (h *HPASurgeApplier) IsSurgeComplete() bool {
+	if !hasTargetAnnotation(h.target) {
+		return false
+	}
+	// The HPA must also carry the original-min-replicas annotation, which is written
+	// in step 2 of ApplySurge. If it is missing, the HPA was never updated.
+	if h.hpa.Annotations == nil {
+		return false
+	}
+	_, ok := h.hpa.Annotations[OriginalMinReplicasAnnotationKey]
+	return ok
 }
 
 func (h *HPASurgeApplier) Name() string {
@@ -336,16 +364,19 @@ func (k *KEDASurgeApplier) RevertSurge(ctx context.Context, c client.Client, _ i
 	// Step 1: Revert ScaledObject minReplicaCount first
 	obj := k.scaledObject.DeepCopy()
 	annotations := obj.GetAnnotations()
-	if origStr, ok := annotations[OriginalMinReplicasAnnotationKey]; ok {
-		if origStr == "" {
-			unstructured.RemoveNestedField(obj.Object, "spec", "minReplicaCount")
-		} else {
-			orig, err := strconv.ParseInt(origStr, 10, 64)
-			if err == nil {
-				if err := unstructured.SetNestedField(obj.Object, orig, "spec", "minReplicaCount"); err != nil {
-					return fmt.Errorf("restoring minReplicaCount: %w", err)
-				}
-			}
+	origStr, ok := annotations[OriginalMinReplicasAnnotationKey]
+	if !ok {
+		return fmt.Errorf("cannot revert ScaledObject %s/%s: missing %s annotation", obj.GetNamespace(), obj.GetName(), OriginalMinReplicasAnnotationKey)
+	}
+	if origStr == "" {
+		unstructured.RemoveNestedField(obj.Object, "spec", "minReplicaCount")
+	} else {
+		orig, err := strconv.ParseInt(origStr, 10, 64)
+		if err != nil {
+			return fmt.Errorf("cannot revert ScaledObject %s/%s: invalid %s annotation value %q: %w", obj.GetNamespace(), obj.GetName(), OriginalMinReplicasAnnotationKey, origStr, err)
+		}
+		if err := unstructured.SetNestedField(obj.Object, orig, "spec", "minReplicaCount"); err != nil {
+			return fmt.Errorf("restoring minReplicaCount: %w", err)
 		}
 	}
 	delete(annotations, OriginalMinReplicasAnnotationKey)
@@ -365,6 +396,20 @@ func (k *KEDASurgeApplier) RevertSurge(ctx context.Context, c client.Client, _ i
 		}
 	}
 	return nil
+}
+
+func (k *KEDASurgeApplier) IsSurgeComplete() bool {
+	if !hasTargetAnnotation(k.target) {
+		return false
+	}
+	// The ScaledObject must also carry the original-min-replicas annotation, which is
+	// written in step 2 of ApplySurge. If it is missing, the ScaledObject was never updated.
+	annotations := k.scaledObject.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, ok := annotations[OriginalMinReplicasAnnotationKey]
+	return ok
 }
 
 func (k *KEDASurgeApplier) Name() string {
@@ -401,6 +446,15 @@ func (comp *CompositeSurgeApplier) RevertSurge(ctx context.Context, c client.Cli
 		}
 	}
 	return nil
+}
+
+func (comp *CompositeSurgeApplier) IsSurgeComplete() bool {
+	for _, a := range comp.appliers {
+		if !a.IsSurgeComplete() {
+			return false
+		}
+	}
+	return true
 }
 
 func (comp *CompositeSurgeApplier) Name() string {

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -1,0 +1,346 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const OriginalMinReplicasAnnotationKey = "eviction-autoscaler.azure.com/original-min-replicas"
+
+// SurgeApplier abstracts the mechanism for temporarily increasing minimum replicas.
+// Depending on whether KEDA, HPA, or neither is present, a different implementation is used.
+//
+// For multi-resource strategies (HPA, KEDA): writes are ordered for safe partial-failure recovery.
+// ApplySurge: annotates the target first (intent marker), then updates the HPA/ScaledObject.
+// RevertSurge: reverts the HPA/ScaledObject first, then removes the target annotation.
+// This ensures that on retry after a crash between the two writes, the controller can detect
+// the incomplete state and re-drive the operation to completion.
+type SurgeApplier interface {
+	// IsSurged returns true if the controller has already applied a surge.
+	// Checks the evictionSurgeReplicas annotation on the target (deployment/statefulset).
+	IsSurged() bool
+	// ApplySurge sets the minimum replica count to surgeReplicas
+	ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error
+	// RevertSurge restores the original minimum replica count.
+	// For deployment strategy, originalMinReplicas is used; for HPA/KEDA, the stored annotation is used.
+	RevertSurge(ctx context.Context, c client.Client, originalMinReplicas int32) error
+	// Name returns a human-readable name for logging
+	Name() string
+}
+
+// detectSurgeApplier determines which surge strategy to use:
+// 1. If KEDA ScaledObject targets the workload → KEDASurgeApplier (modify minReplicaCount)
+// 2. If HPA targets the workload → HPASurgeApplier (modify minReplicas)
+// 3. Otherwise → DeploymentSurgeApplier (modify deployment.spec.replicas)
+func detectSurgeApplier(ctx context.Context, c client.Client, namespace, targetName, targetKind string, target Surger) (SurgeApplier, error) {
+	logger := log.FromContext(ctx)
+
+	// 1. Check for KEDA ScaledObject targeting this workload
+	scaledObj, err := findScaledObjectForTarget(ctx, c, namespace, targetName, targetKind)
+	if err != nil {
+		return nil, fmt.Errorf("checking for KEDA ScaledObject: %w", err)
+	}
+	if scaledObj != nil {
+		logger.Info("Found KEDA ScaledObject for target, using KEDA surge strategy",
+			"scaledObject", scaledObj.GetName(), "target", targetName)
+		return &KEDASurgeApplier{scaledObject: scaledObj, target: target}, nil
+	}
+
+	// 2. Check for HPA targeting this workload
+	hpa, err := findHPAForTarget(ctx, c, namespace, targetName, targetKind)
+	if err != nil {
+		return nil, fmt.Errorf("checking for HPA: %w", err)
+	}
+	if hpa != nil {
+		logger.Info("Found HPA for target, using HPA surge strategy",
+			"hpa", hpa.Name, "target", targetName)
+		return &HPASurgeApplier{hpa: hpa, target: target}, nil
+	}
+
+	// 3. Fall back to direct deployment/statefulset replica management
+	logger.V(1).Info("No KEDA or HPA found, using deployment surge strategy", "target", targetName)
+	return &DeploymentSurgeApplier{target: target}, nil
+}
+
+// findScaledObjectForTarget looks for a KEDA ScaledObject targeting the given workload.
+// Returns nil, nil if KEDA is not installed or no matching ScaledObject is found.
+func findScaledObjectForTarget(ctx context.Context, c client.Client, namespace, targetName, targetKind string) (*unstructured.Unstructured, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "keda.sh",
+		Version: "v1alpha1",
+		Kind:    "ScaledObjectList",
+	})
+
+	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil // KEDA CRD not installed
+		}
+		return nil, err
+	}
+
+	for i := range list.Items {
+		item := &list.Items[i]
+		scaleTargetRef, found, err := unstructured.NestedMap(item.Object, "spec", "scaleTargetRef")
+		if err != nil || !found {
+			continue
+		}
+		name, _ := scaleTargetRef["name"].(string)
+		kind, _ := scaleTargetRef["kind"].(string)
+		if kind == "" {
+			kind = "Deployment" // KEDA default
+		}
+		if name == targetName && strings.EqualFold(kind, targetKind) {
+			return item, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// findHPAForTarget looks for a standalone (non-KEDA-managed) HPA targeting the given workload.
+// KEDA-managed HPAs are filtered out because they are owned by the ScaledObject and should
+// be controlled via the KEDA strategy instead. This avoids accidentally modifying a KEDA-managed
+// HPA when the customer also has their own standalone HPA on a different deployment.
+// Returns nil, nil if no matching standalone HPA is found.
+func findHPAForTarget(ctx context.Context, c client.Client, namespace, targetName, targetKind string) (*autoscalingv2.HorizontalPodAutoscaler, error) {
+	var hpaList autoscalingv2.HorizontalPodAutoscalerList
+	if err := c.List(ctx, &hpaList, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+
+	for i := range hpaList.Items {
+		hpa := &hpaList.Items[i]
+		if hpa.Spec.ScaleTargetRef.Name == targetName &&
+			strings.EqualFold(hpa.Spec.ScaleTargetRef.Kind, targetKind) {
+			if isKEDAManagedHPA(hpa) {
+				continue // skip KEDA-managed HPAs
+			}
+			return hpa, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// isKEDAManagedHPA returns true if the HPA is owned/managed by KEDA.
+// KEDA-managed HPAs have either an owner reference with kind "ScaledObject"
+// or the label "scaledobject.keda.sh/name".
+func isKEDAManagedHPA(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
+	// Check for KEDA label
+	if _, ok := hpa.Labels["scaledobject.keda.sh/name"]; ok {
+		return true
+	}
+	// Check for owner reference from a ScaledObject
+	for _, ref := range hpa.OwnerReferences {
+		if ref.Kind == "ScaledObject" {
+			return true
+		}
+	}
+	return false
+}
+
+// --- DeploymentSurgeApplier ---
+// Surges by modifying the deployment/statefulset spec.replicas directly.
+// This is the default strategy when no KEDA or HPA is present.
+
+type DeploymentSurgeApplier struct {
+	target Surger
+}
+
+var _ SurgeApplier = &DeploymentSurgeApplier{}
+
+func (d *DeploymentSurgeApplier) IsSurged() bool {
+	annotations := d.target.Obj().GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, exists := annotations[EvictionSurgeReplicasAnnotationKey]
+	return exists
+}
+
+func (d *DeploymentSurgeApplier) ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error {
+	d.target.SetReplicas(surgeReplicas)
+	d.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, strconv.FormatInt(int64(surgeReplicas), 10))
+	return c.Update(ctx, d.target.Obj())
+}
+
+func (d *DeploymentSurgeApplier) RevertSurge(ctx context.Context, c client.Client, originalMinReplicas int32) error {
+	d.target.SetReplicas(originalMinReplicas)
+	d.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
+	return c.Update(ctx, d.target.Obj())
+}
+
+func (d *DeploymentSurgeApplier) Name() string {
+	return "deployment"
+}
+
+// --- HPASurgeApplier ---
+// Surges by temporarily increasing HPA spec.minReplicas.
+
+type HPASurgeApplier struct {
+	hpa    *autoscalingv2.HorizontalPodAutoscaler
+	target Surger
+}
+
+var _ SurgeApplier = &HPASurgeApplier{}
+
+func (h *HPASurgeApplier) IsSurged() bool {
+	annotations := h.target.Obj().GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, exists := annotations[EvictionSurgeReplicasAnnotationKey]
+	return exists
+}
+
+func (h *HPASurgeApplier) ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error {
+	logger := log.FromContext(ctx)
+
+	// Step 1: Annotate the target first as intent marker.
+	// If we crash after this but before updating the HPA, the next reconcile
+	// will see the annotation and re-drive the HPA update.
+	h.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, strconv.FormatInt(int64(surgeReplicas), 10))
+	if err := c.Update(ctx, h.target.Obj()); err != nil {
+		return fmt.Errorf("annotating target with surge intent: %w", err)
+	}
+	logger.V(1).Info("Annotated target with surge intent", "replicas", surgeReplicas)
+
+	// Step 2: Update HPA minReplicas
+	hpa := h.hpa.DeepCopy()
+	originalMin := int32(1) // HPA default
+	if hpa.Spec.MinReplicas != nil {
+		originalMin = *hpa.Spec.MinReplicas
+	}
+	if hpa.Annotations == nil {
+		hpa.Annotations = make(map[string]string)
+	}
+	hpa.Annotations[OriginalMinReplicasAnnotationKey] = strconv.FormatInt(int64(originalMin), 10)
+	hpa.Spec.MinReplicas = &surgeReplicas
+
+	h.hpa = hpa
+	return c.Update(ctx, hpa)
+}
+
+func (h *HPASurgeApplier) RevertSurge(ctx context.Context, c client.Client, _ int32) error {
+	logger := log.FromContext(ctx)
+
+	// Step 1: Revert HPA minReplicas first
+	hpa := h.hpa.DeepCopy()
+	if origStr, ok := hpa.Annotations[OriginalMinReplicasAnnotationKey]; ok {
+		orig, err := strconv.ParseInt(origStr, 10, 32)
+		if err == nil {
+			origInt32 := int32(orig)
+			hpa.Spec.MinReplicas = &origInt32
+		}
+	}
+	delete(hpa.Annotations, OriginalMinReplicasAnnotationKey)
+	h.hpa = hpa
+	if err := c.Update(ctx, hpa); err != nil {
+		return fmt.Errorf("reverting HPA minReplicas: %w", err)
+	}
+	logger.V(1).Info("Reverted HPA minReplicas")
+
+	// Step 2: Remove surge annotation from target
+	h.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
+	return c.Update(ctx, h.target.Obj())
+}
+
+func (h *HPASurgeApplier) Name() string {
+	return "hpa"
+}
+
+// --- KEDASurgeApplier ---
+// Surges by temporarily increasing ScaledObject spec.minReplicaCount.
+
+type KEDASurgeApplier struct {
+	scaledObject *unstructured.Unstructured
+	target       Surger
+}
+
+var _ SurgeApplier = &KEDASurgeApplier{}
+
+func (k *KEDASurgeApplier) IsSurged() bool {
+	annotations := k.target.Obj().GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, exists := annotations[EvictionSurgeReplicasAnnotationKey]
+	return exists
+}
+
+func (k *KEDASurgeApplier) ApplySurge(ctx context.Context, c client.Client, surgeReplicas int32) error {
+	logger := log.FromContext(ctx)
+
+	// Step 1: Annotate the target first as intent marker.
+	k.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, strconv.FormatInt(int64(surgeReplicas), 10))
+	if err := c.Update(ctx, k.target.Obj()); err != nil {
+		return fmt.Errorf("annotating target with surge intent: %w", err)
+	}
+	logger.V(1).Info("Annotated target with surge intent", "replicas", surgeReplicas)
+
+	// Step 2: Update ScaledObject minReplicaCount
+	obj := k.scaledObject.DeepCopy()
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if val, found, _ := unstructured.NestedInt64(obj.Object, "spec", "minReplicaCount"); found {
+		annotations[OriginalMinReplicasAnnotationKey] = strconv.FormatInt(val, 10)
+	} else {
+		annotations[OriginalMinReplicasAnnotationKey] = "" // was not set
+	}
+	obj.SetAnnotations(annotations)
+
+	if err := unstructured.SetNestedField(obj.Object, int64(surgeReplicas), "spec", "minReplicaCount"); err != nil {
+		return fmt.Errorf("setting minReplicaCount: %w", err)
+	}
+
+	k.scaledObject = obj
+	return c.Update(ctx, obj)
+}
+
+func (k *KEDASurgeApplier) RevertSurge(ctx context.Context, c client.Client, _ int32) error {
+	logger := log.FromContext(ctx)
+
+	// Step 1: Revert ScaledObject minReplicaCount first
+	obj := k.scaledObject.DeepCopy()
+	annotations := obj.GetAnnotations()
+	if origStr, ok := annotations[OriginalMinReplicasAnnotationKey]; ok {
+		if origStr == "" {
+			unstructured.RemoveNestedField(obj.Object, "spec", "minReplicaCount")
+		} else {
+			orig, err := strconv.ParseInt(origStr, 10, 64)
+			if err == nil {
+				if err := unstructured.SetNestedField(obj.Object, orig, "spec", "minReplicaCount"); err != nil {
+					return fmt.Errorf("restoring minReplicaCount: %w", err)
+				}
+			}
+		}
+	}
+	delete(annotations, OriginalMinReplicasAnnotationKey)
+	obj.SetAnnotations(annotations)
+
+	k.scaledObject = obj
+	if err := c.Update(ctx, obj); err != nil {
+		return fmt.Errorf("reverting ScaledObject minReplicaCount: %w", err)
+	}
+	logger.V(1).Info("Reverted ScaledObject minReplicaCount")
+
+	// Step 2: Remove surge annotation from target
+	k.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
+	return c.Update(ctx, k.target.Obj())
+}
+
+func (k *KEDASurgeApplier) Name() string {
+	return "keda"
+}

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -13,6 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+var errNotFound = errors.New("not found")
 
 const OriginalMinReplicasAnnotationKey = "eviction-autoscaler.azure.com/original-min-replicas"
 
@@ -49,13 +52,13 @@ func detectSurgeApplier(ctx context.Context, c client.Client, namespace, targetN
 
 	// 1. Check for KEDA ScaledObject targeting this workload
 	scaledObj, err := findScaledObjectForTarget(ctx, c, namespace, targetName, targetKind)
-	if err != nil {
+	if err != nil && !errors.Is(err, errNotFound) {
 		return nil, fmt.Errorf("checking for KEDA ScaledObject: %w", err)
 	}
 
 	// 2. Check for standalone HPA targeting this workload
 	hpa, err := findHPAForTarget(ctx, c, namespace, targetName, targetKind)
-	if err != nil {
+	if err != nil && !errors.Is(err, errNotFound) {
 		return nil, fmt.Errorf("checking for HPA: %w", err)
 	}
 
@@ -92,7 +95,7 @@ func detectSurgeApplier(ctx context.Context, c client.Client, namespace, targetN
 }
 
 // findScaledObjectForTarget looks for a KEDA ScaledObject targeting the given workload.
-// Returns nil, nil if KEDA is not installed or no matching ScaledObject is found.
+// Returns nil, errNotFound if KEDA is not installed or no matching ScaledObject is found.
 func findScaledObjectForTarget(ctx context.Context, c client.Client, namespace, targetName, targetKind string) (*unstructured.Unstructured, error) {
 	list := &unstructured.UnstructuredList{}
 	list.SetGroupVersionKind(schema.GroupVersionKind{
@@ -103,7 +106,7 @@ func findScaledObjectForTarget(ctx context.Context, c client.Client, namespace, 
 
 	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
 		if meta.IsNoMatchError(err) {
-			return nil, nil // KEDA CRD not installed
+			return nil, errNotFound
 		}
 		return nil, err
 	}
@@ -124,14 +127,14 @@ func findScaledObjectForTarget(ctx context.Context, c client.Client, namespace, 
 		}
 	}
 
-	return nil, nil
+	return nil, errNotFound
 }
 
 // findHPAForTarget looks for a standalone (non-KEDA-managed) HPA targeting the given workload.
 // KEDA-managed HPAs are filtered out because they are owned by the ScaledObject and should
 // be controlled via the KEDA strategy instead. This avoids accidentally modifying a KEDA-managed
 // HPA when the customer also has their own standalone HPA on a different deployment.
-// Returns nil, nil if no matching standalone HPA is found.
+// Returns nil, errNotFound if no matching standalone HPA is found.
 func findHPAForTarget(ctx context.Context, c client.Client, namespace, targetName, targetKind string) (*autoscalingv2.HorizontalPodAutoscaler, error) {
 	var hpaList autoscalingv2.HorizontalPodAutoscalerList
 	if err := c.List(ctx, &hpaList, client.InNamespace(namespace)); err != nil {
@@ -149,7 +152,7 @@ func findHPAForTarget(ctx context.Context, c client.Client, namespace, targetNam
 		}
 	}
 
-	return nil, nil
+	return nil, errNotFound
 }
 
 // isKEDAManagedHPA returns true if the HPA is owned/managed by KEDA.

--- a/test/e2e/e2e_helpers.go
+++ b/test/e2e/e2e_helpers.go
@@ -40,6 +40,7 @@ type deploymentConfig struct {
 	Replicas       int32
 	MaxUnavailable int
 	Annotations    map[string]string
+	CPURequest     string // optional, e.g. "10m"
 }
 
 // createDeployment creates a deployment with the given configuration
@@ -79,6 +80,11 @@ spec:
       containers:
         - name: nginx
           image: nginx:latest
+{{- if .CPURequest}}
+          resources:
+            requests:
+              cpu: "{{.CPURequest}}"
+{{- end}}
 `
 	t, err := template.New("deployment").Parse(tmpl)
 	if err != nil {
@@ -92,12 +98,14 @@ spec:
 		Replicas       int32
 		MaxUnavailable string
 		Annotations    map[string]string
+		CPURequest     string
 	}{
 		Name:           cfg.Name,
 		Namespace:      cfg.Namespace,
 		Replicas:       cfg.Replicas,
 		MaxUnavailable: maxUnavailable,
 		Annotations:    cfg.Annotations,
+		CPURequest:     cfg.CPURequest,
 	}
 
 	if err := t.Execute(&buf, data); err != nil {

--- a/test/e2e/e2e_helpers.go
+++ b/test/e2e/e2e_helpers.go
@@ -301,7 +301,9 @@ func verifyHPAMinReplicas(ctx context.Context, clientset client.Client, ns, name
 }
 
 // verifyDeploymentAnnotation checks if a deployment has the expected annotation value
-func verifyDeploymentAnnotation(ctx context.Context, clientset client.Client, ns, name, annotationKey, expectedValue string) error {
+func verifyDeploymentAnnotation(
+	ctx context.Context, clientset client.Client, ns, name, annotationKey, expectedValue string,
+) error {
 	var dep appsv1.Deployment
 	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &dep)
 	if err != nil {
@@ -326,22 +328,6 @@ func verifyDeploymentNoAnnotation(ctx context.Context, clientset client.Client, 
 	}
 	if _, ok := dep.Annotations[annotationKey]; ok {
 		return fmt.Errorf("annotation %q should not be present on deployment %s", annotationKey, name)
-	}
-	return nil
-}
-
-// verifyDeploymentReplicas checks that a deployment has the expected number of replicas
-func verifyDeploymentReplicaCount(ctx context.Context, clientset client.Client, ns, name string, expected int32) error {
-	var dep appsv1.Deployment
-	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &dep)
-	if err != nil {
-		return err
-	}
-	if dep.Spec.Replicas == nil {
-		return fmt.Errorf("deployment replicas is nil")
-	}
-	if *dep.Spec.Replicas != expected {
-		return fmt.Errorf("expected %d replicas, got %d", expected, *dep.Spec.Replicas)
 	}
 	return nil
 }

--- a/test/e2e/e2e_helpers.go
+++ b/test/e2e/e2e_helpers.go
@@ -27,6 +27,8 @@ import (
 	types "github.com/azure/eviction-autoscaler/api/v1"
 	"github.com/azure/eviction-autoscaler/test/utils"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	policy "k8s.io/api/policy/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -245,4 +247,173 @@ func verifyHasOwnerReference(ctx context.Context, clientset client.Client, ns, n
 		return fmt.Errorf("PDB has no owner references")
 	}
 	return nil
+}
+
+// createHPA creates an HPA targeting a deployment
+func createHPA(name, namespace, targetDeployment string, minReplicas, maxReplicas int32) error {
+	hpaYaml := fmt.Sprintf(`apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: %s
+  minReplicas: %d
+  maxReplicas: %d
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
+`, name, namespace, targetDeployment, minReplicas, maxReplicas)
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(hpaYaml)
+	_, err := utils.Run(cmd)
+	return err
+}
+
+// deleteHPA deletes a HorizontalPodAutoscaler
+func deleteHPA(name, namespace string) {
+	cmd := exec.Command("kubectl", "delete", "hpa", name, "--namespace", namespace)
+	_, _ = utils.Run(cmd)
+}
+
+// verifyHPAMinReplicas checks if an HPA has the expected minReplicas value
+func verifyHPAMinReplicas(ctx context.Context, clientset client.Client, ns, name string, expectedMin int32) error {
+	var hpa autoscalingv2.HorizontalPodAutoscaler
+	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &hpa)
+	if err != nil {
+		return err
+	}
+	if hpa.Spec.MinReplicas == nil {
+		return fmt.Errorf("HPA minReplicas is nil")
+	}
+	if *hpa.Spec.MinReplicas != expectedMin {
+		return fmt.Errorf("expected HPA minReplicas to be %d, got %d", expectedMin, *hpa.Spec.MinReplicas)
+	}
+	return nil
+}
+
+// verifyDeploymentAnnotation checks if a deployment has the expected annotation value
+func verifyDeploymentAnnotation(ctx context.Context, clientset client.Client, ns, name, annotationKey, expectedValue string) error {
+	var dep appsv1.Deployment
+	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &dep)
+	if err != nil {
+		return err
+	}
+	val, ok := dep.Annotations[annotationKey]
+	if !ok {
+		return fmt.Errorf("annotation %q not found on deployment %s", annotationKey, name)
+	}
+	if val != expectedValue {
+		return fmt.Errorf("expected annotation %q=%q, got %q", annotationKey, expectedValue, val)
+	}
+	return nil
+}
+
+// verifyDeploymentNoAnnotation checks that a deployment does NOT have a specific annotation
+func verifyDeploymentNoAnnotation(ctx context.Context, clientset client.Client, ns, name, annotationKey string) error {
+	var dep appsv1.Deployment
+	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &dep)
+	if err != nil {
+		return err
+	}
+	if _, ok := dep.Annotations[annotationKey]; ok {
+		return fmt.Errorf("annotation %q should not be present on deployment %s", annotationKey, name)
+	}
+	return nil
+}
+
+// verifyDeploymentReplicas checks that a deployment has the expected number of replicas
+func verifyDeploymentReplicaCount(ctx context.Context, clientset client.Client, ns, name string, expected int32) error {
+	var dep appsv1.Deployment
+	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &dep)
+	if err != nil {
+		return err
+	}
+	if dep.Spec.Replicas == nil {
+		return fmt.Errorf("deployment replicas is nil")
+	}
+	if *dep.Spec.Replicas != expected {
+		return fmt.Errorf("expected %d replicas, got %d", expected, *dep.Spec.Replicas)
+	}
+	return nil
+}
+
+// createKEDAScaledObject creates a KEDA ScaledObject targeting a deployment
+func createKEDAScaledObject(name, namespace, targetDeployment string, minReplicaCount, maxReplicaCount int32) error {
+	scaledObjectYaml := fmt.Sprintf(`apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  scaleTargetRef:
+    name: %s
+    kind: Deployment
+  minReplicaCount: %d
+  maxReplicaCount: %d
+  triggers:
+  - type: cpu
+    metadata:
+      type: Utilization
+      value: "80"
+`, name, namespace, targetDeployment, minReplicaCount, maxReplicaCount)
+
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(scaledObjectYaml)
+	_, err := utils.Run(cmd)
+	return err
+}
+
+// deleteKEDAScaledObject deletes a KEDA ScaledObject
+func deleteKEDAScaledObject(name, namespace string) {
+	cmd := exec.Command("kubectl", "delete", "scaledobject", name, "--namespace", namespace)
+	_, _ = utils.Run(cmd)
+}
+
+// verifyKEDAScaledObjectMinReplicas checks the minReplicaCount on a ScaledObject using kubectl
+func verifyKEDAScaledObjectMinReplicas(name, namespace string, expectedMin int32) error {
+	cmd := exec.Command("kubectl", "get", "scaledobject", name,
+		"--namespace", namespace,
+		"-o", "jsonpath={.spec.minReplicaCount}")
+	output, err := utils.Run(cmd)
+	if err != nil {
+		return err
+	}
+	actual := strings.TrimSpace(string(output))
+	expected := fmt.Sprintf("%d", expectedMin)
+	if actual != expected {
+		return fmt.Errorf("expected ScaledObject minReplicaCount=%s, got %s", expected, actual)
+	}
+	return nil
+}
+
+// installKEDA installs KEDA using Helm
+func installKEDA() error {
+	cmd := exec.Command("helm", "repo", "add", "kedacore", "https://kedacore.github.io/charts")
+	_, _ = utils.Run(cmd) // ignore error if repo already exists
+	cmd = exec.Command("helm", "repo", "update")
+	_, err := utils.Run(cmd)
+	if err != nil {
+		return err
+	}
+	cmd = exec.Command("helm", "upgrade", "--install", "keda", "kedacore/keda",
+		"--namespace", "keda", "--create-namespace", "--wait", "--timeout", "300s")
+	_, err = utils.Run(cmd)
+	return err
+}
+
+// uninstallKEDA removes KEDA
+func uninstallKEDA() {
+	cmd := exec.Command("helm", "uninstall", "keda", "--namespace", "keda")
+	_, _ = utils.Run(cmd)
+	cmd = exec.Command("kubectl", "delete", "namespace", "keda")
+	_, _ = utils.Run(cmd)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1108,6 +1108,18 @@ var _ = Describe("controller", Ordered, func() {
 				return nil
 			}, 30*time.Second, time.Second).Should(Succeed())
 
+			By("waiting for deployment to scale to 2 available replicas")
+			EventuallyWithOffset(1, func() error {
+				var dep appsv1.Deployment
+				if err := clientset.Get(ctx, client.ObjectKey{Namespace: testNs, Name: "nginx-hpa"}, &dep); err != nil {
+					return err
+				}
+				if dep.Status.AvailableReplicas < 2 {
+					return fmt.Errorf("expected 2 available replicas, got %d", dep.Status.AvailableReplicas)
+				}
+				return nil
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
 			By("draining the node to trigger evictions")
 			drain := func() error {
 				var podList corev1.PodList

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1089,11 +1089,6 @@ var _ = Describe("controller", Ordered, func() {
 				return verifyHPAMinReplicas(ctx, clientset, testNs, "nginx-hpa", 2)
 			}, time.Minute, time.Second).Should(Succeed())
 
-			By("verifying deployment.spec.replicas is NOT changed (HPA manages it)")
-			EventuallyWithOffset(1, func() error {
-				return verifyDeploymentReplicaCount(ctx, clientset, testNs, "nginx-hpa", 1)
-			}, 10*time.Second, time.Second).Should(Succeed())
-
 			By("verifying HPA has the original-min-replicas annotation")
 			EventuallyWithOffset(1, func() error {
 				var hpa autoscalingv2.HorizontalPodAutoscaler
@@ -1123,8 +1118,8 @@ var _ = Describe("controller", Ordered, func() {
 					err = evictionClient.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policy.Eviction{
 						ObjectMeta: p.ObjectMeta,
 					})
-					if errors.IsTooManyRequests(err) {
-						return fmt.Errorf("failed to evict %s: %v", p.Name, err)
+					if err != nil {
+						return fmt.Errorf("failed to evict %s: %w", p.Name, err)
 					}
 				}
 				return nil
@@ -1247,11 +1242,6 @@ var _ = Describe("controller", Ordered, func() {
 				return verifyKEDAScaledObjectMinReplicas("nginx-keda", testNs, 2)
 			}, time.Minute, time.Second).Should(Succeed())
 
-			By("verifying deployment.spec.replicas is NOT changed (KEDA manages it)")
-			EventuallyWithOffset(1, func() error {
-				return verifyDeploymentReplicaCount(ctx, clientset, testNs, "nginx-keda", 1)
-			}, 10*time.Second, time.Second).Should(Succeed())
-
 			By("draining the node to trigger evictions")
 			drain := func() error {
 				var podList corev1.PodList
@@ -1264,8 +1254,8 @@ var _ = Describe("controller", Ordered, func() {
 					err = evictionClient.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policy.Eviction{
 						ObjectMeta: p.ObjectMeta,
 					})
-					if errors.IsTooManyRequests(err) {
-						return fmt.Errorf("failed to evict %s: %v", p.Name, err)
+					if err != nil {
+						return fmt.Errorf("failed to evict %s: %w", p.Name, err)
 					}
 				}
 				return nil

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -36,6 +36,7 @@ import (
 	types "github.com/azure/eviction-autoscaler/api/v1"
 	"github.com/azure/eviction-autoscaler/test/utils"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -52,6 +53,7 @@ var scheme = runtime.NewScheme()
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
+	utilruntime.Must(autoscalingv2.AddToScheme(scheme))
 	utilruntime.Must(policy.AddToScheme(scheme))
 	utilruntime.Must(types.AddToScheme(scheme))
 }
@@ -1011,6 +1013,289 @@ var _ = Describe("controller", Ordered, func() {
 			}
 
 			Expect(scrapeMetrics()).To(Succeed())
+		})
+
+		// Test 3: HPA surge strategy - when an HPA exists, surge by updating HPA minReplicas instead of deployment replicas
+		It("should surge via HPA minReplicas when an HPA targets the deployment", func() {
+			ctx := context.Background()
+			testNs := "test-hpa-surge"
+
+			By("creating test namespace with enable annotation")
+			cmd := exec.Command("kubectl", "create", "namespace", testNs)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("kubectl", "annotate", "namespace", testNs,
+				"eviction-autoscaler.azure.com/enable=true")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating a deployment with 1 replica and maxUnavailable=0")
+			err = createDeployment(deploymentConfig{
+				Name:           "nginx-hpa",
+				Namespace:      testNs,
+				Replicas:       1,
+				MaxUnavailable: 0,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for deployment to be ready")
+			err = waitForDeployment("nginx-hpa", testNs)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating an HPA targeting the deployment")
+			err = createHPA("nginx-hpa", testNs, "nginx-hpa", 1, 5)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying PDB and EvictionAutoScaler are created")
+			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+			Expect(err).NotTo(HaveOccurred())
+			clientset, err := client.New(config, client.Options{Scheme: scheme})
+			Expect(err).NotTo(HaveOccurred())
+			evictionClient, err := kubernetes.NewForConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			EventuallyWithOffset(1, func() error {
+				return verifyPdbCreated(ctx, clientset, testNs, "nginx-hpa")
+			}, time.Minute, time.Second).Should(Succeed())
+			EventuallyWithOffset(1, func() error {
+				return verifyEvictionAutoScalerCreated(ctx, clientset, testNs, "nginx-hpa")
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("finding the node the pod runs on")
+			var pods corev1.PodList
+			err = clientset.List(ctx, &pods, client.InNamespace(testNs))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pods.Items).NotTo(BeEmpty())
+			nodeName := pods.Items[0].Spec.NodeName
+			fmt.Printf("nginx-hpa pod running on node %s\n", nodeName)
+
+			By("cordoning the node to trigger eviction surge")
+			var node corev1.Node
+			err = clientset.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+			Expect(err).NotTo(HaveOccurred())
+			node.Spec.Unschedulable = true
+			err = clientset.Update(ctx, &node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the deployment gets the evictionSurgeReplicas annotation (intent marker)")
+			EventuallyWithOffset(1, func() error {
+				return verifyDeploymentAnnotation(ctx, clientset, testNs, "nginx-hpa",
+					"evictionSurgeReplicas", "2")
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("verifying the HPA minReplicas is surged to 2 (not the deployment replicas)")
+			EventuallyWithOffset(1, func() error {
+				return verifyHPAMinReplicas(ctx, clientset, testNs, "nginx-hpa", 2)
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("verifying deployment.spec.replicas is NOT changed (HPA manages it)")
+			EventuallyWithOffset(1, func() error {
+				return verifyDeploymentReplicaCount(ctx, clientset, testNs, "nginx-hpa", 1)
+			}, 10*time.Second, time.Second).Should(Succeed())
+
+			By("verifying HPA has the original-min-replicas annotation")
+			EventuallyWithOffset(1, func() error {
+				var hpa autoscalingv2.HorizontalPodAutoscaler
+				err := clientset.Get(ctx, client.ObjectKey{Namespace: testNs, Name: "nginx-hpa"}, &hpa)
+				if err != nil {
+					return err
+				}
+				val, ok := hpa.Annotations["eviction-autoscaler.azure.com/original-min-replicas"]
+				if !ok {
+					return fmt.Errorf("original-min-replicas annotation not found on HPA")
+				}
+				if val != "1" {
+					return fmt.Errorf("expected original-min-replicas=1, got %s", val)
+				}
+				return nil
+			}, 30*time.Second, time.Second).Should(Succeed())
+
+			By("draining the node to trigger evictions")
+			drain := func() error {
+				var podList corev1.PodList
+				err := clientset.List(ctx, &podList, client.InNamespace(testNs),
+					client.MatchingFields{"spec.nodeName": nodeName})
+				if err != nil {
+					return err
+				}
+				for _, p := range podList.Items {
+					err = evictionClient.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policy.Eviction{
+						ObjectMeta: p.ObjectMeta,
+					})
+					if errors.IsTooManyRequests(err) {
+						return fmt.Errorf("failed to evict %s: %v", p.Name, err)
+					}
+				}
+				return nil
+			}
+			EventuallyWithOffset(1, drain, time.Minute, time.Second).Should(Succeed())
+
+			By("verifying HPA minReplicas reverts to 1 after cooldown")
+			EventuallyWithOffset(1, func() error {
+				return verifyHPAMinReplicas(ctx, clientset, testNs, "nginx-hpa", 1)
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			By("verifying the evictionSurgeReplicas annotation is removed from deployment")
+			EventuallyWithOffset(1, func() error {
+				return verifyDeploymentNoAnnotation(ctx, clientset, testNs, "nginx-hpa",
+					"evictionSurgeReplicas")
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			By("verifying original-min-replicas annotation is removed from HPA")
+			EventuallyWithOffset(1, func() error {
+				var hpa autoscalingv2.HorizontalPodAutoscaler
+				err := clientset.Get(ctx, client.ObjectKey{Namespace: testNs, Name: "nginx-hpa"}, &hpa)
+				if err != nil {
+					return err
+				}
+				if _, ok := hpa.Annotations["eviction-autoscaler.azure.com/original-min-replicas"]; ok {
+					return fmt.Errorf("original-min-replicas annotation should be removed from HPA")
+				}
+				return nil
+			}, 30*time.Second, time.Second).Should(Succeed())
+
+			By("uncordoning the node")
+			err = clientset.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+			Expect(err).NotTo(HaveOccurred())
+			node.Spec.Unschedulable = false
+			err = clientset.Update(ctx, &node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("cleaning up HPA test resources")
+			deleteHPA("nginx-hpa", testNs)
+			deleteDeployment("nginx-hpa", testNs)
+			cmd = exec.Command("kubectl", "delete", "namespace", testNs)
+			_, _ = utils.Run(cmd)
+		})
+
+		// Test 4: KEDA surge strategy - when a ScaledObject exists, surge by updating minReplicaCount
+		It("should surge via KEDA ScaledObject minReplicaCount when a ScaledObject targets the deployment", func() {
+			ctx := context.Background()
+			testNs := "test-keda-surge"
+
+			By("installing KEDA on the cluster")
+			err := installKEDA()
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating test namespace with enable annotation")
+			cmd := exec.Command("kubectl", "create", "namespace", testNs)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("kubectl", "annotate", "namespace", testNs,
+				"eviction-autoscaler.azure.com/enable=true")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating a deployment with 1 replica and maxUnavailable=0")
+			err = createDeployment(deploymentConfig{
+				Name:           "nginx-keda",
+				Namespace:      testNs,
+				Replicas:       1,
+				MaxUnavailable: 0,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for deployment to be ready")
+			err = waitForDeployment("nginx-keda", testNs)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating a KEDA ScaledObject targeting the deployment")
+			err = createKEDAScaledObject("nginx-keda", testNs, "nginx-keda", 1, 5)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying PDB and EvictionAutoScaler are created")
+			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+			Expect(err).NotTo(HaveOccurred())
+			clientset, err := client.New(config, client.Options{Scheme: scheme})
+			Expect(err).NotTo(HaveOccurred())
+			evictionClient, err := kubernetes.NewForConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			EventuallyWithOffset(1, func() error {
+				return verifyPdbCreated(ctx, clientset, testNs, "nginx-keda")
+			}, time.Minute, time.Second).Should(Succeed())
+			EventuallyWithOffset(1, func() error {
+				return verifyEvictionAutoScalerCreated(ctx, clientset, testNs, "nginx-keda")
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("finding the node the pod runs on")
+			var pods corev1.PodList
+			err = clientset.List(ctx, &pods, client.InNamespace(testNs))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pods.Items).NotTo(BeEmpty())
+			nodeName := pods.Items[0].Spec.NodeName
+			fmt.Printf("nginx-keda pod running on node %s\n", nodeName)
+
+			By("cordoning the node to trigger eviction surge")
+			var node corev1.Node
+			err = clientset.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+			Expect(err).NotTo(HaveOccurred())
+			node.Spec.Unschedulable = true
+			err = clientset.Update(ctx, &node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the deployment gets the evictionSurgeReplicas annotation (intent marker)")
+			EventuallyWithOffset(1, func() error {
+				return verifyDeploymentAnnotation(ctx, clientset, testNs, "nginx-keda",
+					"evictionSurgeReplicas", "2")
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("verifying the ScaledObject minReplicaCount is surged to 2")
+			EventuallyWithOffset(1, func() error {
+				return verifyKEDAScaledObjectMinReplicas("nginx-keda", testNs, 2)
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("verifying deployment.spec.replicas is NOT changed (KEDA manages it)")
+			EventuallyWithOffset(1, func() error {
+				return verifyDeploymentReplicaCount(ctx, clientset, testNs, "nginx-keda", 1)
+			}, 10*time.Second, time.Second).Should(Succeed())
+
+			By("draining the node to trigger evictions")
+			drain := func() error {
+				var podList corev1.PodList
+				err := clientset.List(ctx, &podList, client.InNamespace(testNs),
+					client.MatchingFields{"spec.nodeName": nodeName})
+				if err != nil {
+					return err
+				}
+				for _, p := range podList.Items {
+					err = evictionClient.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policy.Eviction{
+						ObjectMeta: p.ObjectMeta,
+					})
+					if errors.IsTooManyRequests(err) {
+						return fmt.Errorf("failed to evict %s: %v", p.Name, err)
+					}
+				}
+				return nil
+			}
+			EventuallyWithOffset(1, drain, time.Minute, time.Second).Should(Succeed())
+
+			By("verifying ScaledObject minReplicaCount reverts to 1 after cooldown")
+			EventuallyWithOffset(1, func() error {
+				return verifyKEDAScaledObjectMinReplicas("nginx-keda", testNs, 1)
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			By("verifying the evictionSurgeReplicas annotation is removed from deployment")
+			EventuallyWithOffset(1, func() error {
+				return verifyDeploymentNoAnnotation(ctx, clientset, testNs, "nginx-keda",
+					"evictionSurgeReplicas")
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			By("uncordoning the node")
+			err = clientset.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+			Expect(err).NotTo(HaveOccurred())
+			node.Spec.Unschedulable = false
+			err = clientset.Update(ctx, &node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("cleaning up KEDA test resources")
+			deleteKEDAScaledObject("nginx-keda", testNs)
+			deleteDeployment("nginx-keda", testNs)
+			cmd = exec.Command("kubectl", "delete", "namespace", testNs)
+			_, _ = utils.Run(cmd)
+			uninstallKEDA()
 		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -100,8 +100,8 @@ var _ = Describe("controller", Ordered, func() {
 		if cleanEnv {
 
 			By("removing kind cluster")
-			cmd := exec.Command("kind", "delete", "cluster", "-n", kindClusterName)
-			_, _ = utils.Run(cmd)
+			//cmd := exec.Command("kind", "delete", "cluster", "-n", kindClusterName)
+			//_, _ = utils.Run(cmd)
 		}
 	})
 
@@ -1022,9 +1022,18 @@ var _ = Describe("controller", Ordered, func() {
 			ctx := context.Background()
 			testNs := "test-hpa-surge"
 
+			By("uncordoning all nodes to ensure clean state from prior tests")
+			cmd := exec.Command("kubectl", "get", "nodes", "-o", "jsonpath={.items[*].metadata.name}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			for _, nodeName := range strings.Fields(string(output)) {
+				cmd = exec.Command("kubectl", "uncordon", nodeName)
+				_, _ = utils.Run(cmd) // ignore error if already uncordoned
+			}
+
 			By("creating test namespace with enable annotation")
-			cmd := exec.Command("kubectl", "create", "namespace", testNs)
-			_, err := utils.Run(cmd)
+			cmd = exec.Command("kubectl", "create", "namespace", testNs)
+			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
 			cmd = exec.Command("kubectl", "annotate", "namespace", testNs,
@@ -1231,12 +1240,21 @@ var _ = Describe("controller", Ordered, func() {
 			ctx := context.Background()
 			testNs := "test-keda-surge"
 
+			By("uncordoning all nodes to ensure clean state from prior tests")
+			cmd := exec.Command("kubectl", "get", "nodes", "-o", "jsonpath={.items[*].metadata.name}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			for _, nodeName := range strings.Fields(string(output)) {
+				cmd = exec.Command("kubectl", "uncordon", nodeName)
+				_, _ = utils.Run(cmd)
+			}
+
 			By("installing KEDA on the cluster")
-			err := installKEDA()
+			err = installKEDA()
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating test namespace with enable annotation")
-			cmd := exec.Command("kubectl", "create", "namespace", testNs)
+			cmd = exec.Command("kubectl", "create", "namespace", testNs)
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1251,6 +1269,7 @@ var _ = Describe("controller", Ordered, func() {
 				Namespace:      testNs,
 				Replicas:       1,
 				MaxUnavailable: 0,
+				CPURequest:     "10m", // KEDA's admission webhook requires CPU requests for cpu trigger
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1278,11 +1297,21 @@ var _ = Describe("controller", Ordered, func() {
 			}, time.Minute, time.Second).Should(Succeed())
 
 			By("finding the node the pod runs on")
-			var pods corev1.PodList
-			err = clientset.List(ctx, &pods, client.InNamespace(testNs))
-			Expect(err).NotTo(HaveOccurred())
-			Expect(pods.Items).NotTo(BeEmpty())
-			nodeName := pods.Items[0].Spec.NodeName
+			var nodeName string
+			EventuallyWithOffset(1, func() error {
+				var pods corev1.PodList
+				err = clientset.List(ctx, &pods, client.InNamespace(testNs))
+				if err != nil {
+					return err
+				}
+				for _, p := range pods.Items {
+					if p.Status.Phase == corev1.PodRunning && p.Spec.NodeName != "" {
+						nodeName = p.Spec.NodeName
+						return nil
+					}
+				}
+				return fmt.Errorf("no running pod found in namespace %s", testNs)
+			}, time.Minute, time.Second).Should(Succeed())
 			fmt.Printf("nginx-keda pod running on node %s\n", nodeName)
 
 			By("cordoning the node to trigger eviction surge")
@@ -1297,12 +1326,12 @@ var _ = Describe("controller", Ordered, func() {
 			EventuallyWithOffset(1, func() error {
 				return verifyDeploymentAnnotation(ctx, clientset, testNs, "nginx-keda",
 					"evictionSurgeReplicas", "2")
-			}, time.Minute, time.Second).Should(Succeed())
+			}, 3*time.Minute, time.Second).Should(Succeed())
 
 			By("verifying the ScaledObject minReplicaCount is surged to 2")
 			EventuallyWithOffset(1, func() error {
 				return verifyKEDAScaledObjectMinReplicas("nginx-keda", testNs, 2)
-			}, time.Minute, time.Second).Should(Succeed())
+			}, 3*time.Minute, time.Second).Should(Succeed())
 
 			By("draining the node to trigger evictions")
 			drain := func() error {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -320,10 +320,12 @@ var _ = Describe("controller", Ordered, func() {
 					err = evictionClient.PolicyV1().Evictions(meta.Namespace).Evict(ctx, &policy.Eviction{
 						ObjectMeta: meta,
 					})
-					if errors.IsTooManyRequests(err) {
-						return fmt.Errorf("failed to evict %s/%s: %v", meta.Namespace, meta.Name, err)
+					if err != nil {
+						if errors.IsTooManyRequests(err) {
+							return fmt.Errorf("failed to evict %s/%s: %v", meta.Namespace, meta.Name, err)
+						}
+						return fmt.Errorf("failed to evict %s/%s: %w", meta.Namespace, meta.Name, err)
 					}
-					ExpectWithOffset(1, err).NotTo(HaveOccurred())
 					fmt.Printf("evicted %s/%s\n", meta.Namespace, meta.Name)
 				}
 				return nil

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1091,23 +1091,6 @@ var _ = Describe("controller", Ordered, func() {
 				return verifyHPAMinReplicas(ctx, clientset, testNs, "nginx-hpa", 2)
 			}, time.Minute, time.Second).Should(Succeed())
 
-			By("verifying HPA has the original-min-replicas annotation")
-			EventuallyWithOffset(1, func() error {
-				var hpa autoscalingv2.HorizontalPodAutoscaler
-				err := clientset.Get(ctx, client.ObjectKey{Namespace: testNs, Name: "nginx-hpa"}, &hpa)
-				if err != nil {
-					return err
-				}
-				val, ok := hpa.Annotations["eviction-autoscaler.azure.com/original-min-replicas"]
-				if !ok {
-					return fmt.Errorf("original-min-replicas annotation not found on HPA")
-				}
-				if val != "1" {
-					return fmt.Errorf("expected original-min-replicas=1, got %s", val)
-				}
-				return nil
-			}, 30*time.Second, time.Second).Should(Succeed())
-
 			By("waiting for deployment to scale to 2 available replicas")
 			EventuallyWithOffset(1, func() error {
 				var dep appsv1.Deployment
@@ -1151,19 +1134,6 @@ var _ = Describe("controller", Ordered, func() {
 					"evictionSurgeReplicas")
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
-			By("verifying original-min-replicas annotation is removed from HPA")
-			EventuallyWithOffset(1, func() error {
-				var hpa autoscalingv2.HorizontalPodAutoscaler
-				err := clientset.Get(ctx, client.ObjectKey{Namespace: testNs, Name: "nginx-hpa"}, &hpa)
-				if err != nil {
-					return err
-				}
-				if _, ok := hpa.Annotations["eviction-autoscaler.azure.com/original-min-replicas"]; ok {
-					return fmt.Errorf("original-min-replicas annotation should be removed from HPA")
-				}
-				return nil
-			}, 30*time.Second, time.Second).Should(Succeed())
-
 			By("uncordoning the node")
 			err = clientset.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
 			Expect(err).NotTo(HaveOccurred())
@@ -1174,6 +1144,84 @@ var _ = Describe("controller", Ordered, func() {
 			By("cleaning up HPA test resources")
 			deleteHPA("nginx-hpa", testNs)
 			deleteDeployment("nginx-hpa", testNs)
+			cmd = exec.Command("kubectl", "delete", "namespace", testNs)
+			_, _ = utils.Run(cmd)
+		})
+
+		// Test 3b: PDB minAvailable should use HPA minReplicas, not deployment replicas
+		It("should create PDB with minAvailable from HPA minReplicas when HPA targets the deployment", func() {
+			ctx := context.Background()
+			testNs := "test-hpa-pdb-min"
+
+			By("creating test namespace with enable annotation")
+			cmd := exec.Command("kubectl", "create", "namespace", testNs)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("kubectl", "annotate", "namespace", testNs,
+				"eviction-autoscaler.azure.com/enable=true")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating a deployment with 1 replica and maxUnavailable=0")
+			err = createDeployment(deploymentConfig{
+				Name:           "nginx-hpa-pdb",
+				Namespace:      testNs,
+				Replicas:       1,
+				MaxUnavailable: 0,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for deployment to be ready")
+			err = waitForDeployment("nginx-hpa-pdb", testNs)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating an HPA targeting the deployment with minReplicas=1")
+			err = createHPA("nginx-hpa-pdb", testNs, "nginx-hpa-pdb", 1, 5)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying PDB is created with minAvailable=1 (from HPA minReplicas)")
+			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+			Expect(err).NotTo(HaveOccurred())
+			clientset, err := client.New(config, client.Options{Scheme: scheme})
+			Expect(err).NotTo(HaveOccurred())
+
+			EventuallyWithOffset(1, func() error {
+				return verifyPdbCreated(ctx, clientset, testNs, "nginx-hpa-pdb")
+			}, time.Minute, time.Second).Should(Succeed())
+
+			EventuallyWithOffset(1, func() error {
+				return verifyPdbMinAvailable(ctx, clientset, testNs, "nginx-hpa-pdb", 1)
+			}, 30*time.Second, time.Second).Should(Succeed())
+
+			By("scaling deployment replicas to 3 manually (simulating HPA scale-up)")
+			cmd = exec.Command("kubectl", "scale", "deployment", "nginx-hpa-pdb",
+				"--replicas=3", "--namespace", testNs)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for deployment to have 3 replicas ready")
+			EventuallyWithOffset(1, func() error {
+				var dep appsv1.Deployment
+				if err := clientset.Get(ctx, client.ObjectKey{Namespace: testNs, Name: "nginx-hpa-pdb"}, &dep); err != nil {
+					return err
+				}
+				if dep.Status.AvailableReplicas < 3 {
+					return fmt.Errorf("expected 3 available replicas, got %d", dep.Status.AvailableReplicas)
+				}
+				return nil
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("verifying PDB minAvailable stays at 1 (HPA min), not 3 (deployment replicas)")
+			// Give the controller time to reconcile the deployment change
+			time.Sleep(5 * time.Second)
+			EventuallyWithOffset(1, func() error {
+				return verifyPdbMinAvailable(ctx, clientset, testNs, "nginx-hpa-pdb", 1)
+			}, 30*time.Second, time.Second).Should(Succeed())
+
+			By("cleaning up HPA PDB test resources")
+			deleteHPA("nginx-hpa-pdb", testNs)
+			deleteDeployment("nginx-hpa-pdb", testNs)
 			cmd = exec.Command("kubectl", "delete", "namespace", testNs)
 			_, _ = utils.Run(cmd)
 		})


### PR DESCRIPTION
- Updated RBAC roles to include permissions for horizontalpodautoscalers and scaledobjects.
- Refactored evictionautoscaler_controller to support surge strategies based on HPA and KEDA.
- Introduced SurgeApplier interface and implementations for Deployment, HPA, and KEDA surge strategies.
- Added e2e tests for HPA and KEDA surge scenarios, verifying correct behavior during node evictions and cooldown periods.
- Enhanced helper functions for creating and verifying HPA and KEDA resources in tests.