### PR TITLE
Hpa surge strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Your app might also experience issues for unrelated reasons, and a maintenance e
 
 - **Node Controller**: Signals eviction-autoscaler for all pods on cordoned nodes selected by corresponding pdb whose name/namespace it shares.
 - **Eviction-autoscaler Controller**: Watches eviction-autoscale resources. If there a recent eviction singals and the PDB's AllowedDisruotions is zero, it triggers a surge in the corresponding deployment. Once evitions have stopped for some cooldown period and allowed diruptions has rised above zero it scales down.
-- **PDB Controller** (Optional): Automatically creates eviction-autoscalers Custom Resources for existing PDBs.
-- **Deployment Controller** (Optional): Creates PDBs for deployments that don't already have them and keeps min available matching the deployments replicas (not counting any surged in by eviction autoscaler)
+- **HPA-aware surge**: When an HPA targets the deployment, the controller surges by temporarily raising the HPA's `minReplicas` instead of mutating deployment replicas directly. This prevents the HPA from immediately scaling the deployment back down during a surge. On revert, the original `minReplicas` floor is restored.
+- **PDB Controller** (Optional): Automatically creates eviction-autoscalers Custom Resources for existing PDBs. When an HPA or KEDA ScaledObject targets the deployment, PDB `minAvailable` is set from the autoscaler's min replicas floor rather than `deployment.spec.replicas`.
+- **Autoscaler-to-PDB Controller** (Optional): Watches HPA and KEDA ScaledObject changes and updates PDB `minAvailable` to track the autoscaler's min replicas floor, even when deployment replicas don't change.
+- **Deployment Controller** (Optional): Creates PDBs for deployments that don't already have them and keeps min available matching the deployments replicas (not counting any surged in by eviction autoscaler). Defers to the Autoscaler-to-PDB controller when an HPA or KEDA ScaledObject is present.
 
 ```mermaid
 graph TD;
@@ -37,16 +39,22 @@ graph TD;
     CRD[Eviction Autoscaler Custom Resource]
     Controller[Eviction-Autoscaler Controller]
     Deployment[Deployment or StatefulSet]
+    HPA[HPA / KEDA ScaledObject]
     PDB[Pod Disruption Budget]
     PDBController[Optional PDB creator]
+    AutoscalerToPDB[Autoscaler-to-PDB Controller]
 
 
     Cordon -->|Triggers| NodeController
     NodeController -->|writes spec| CRD
     CRD -->|spec watched by| Controller
-    Controller -->|surges and shrinks| Deployment
+    Controller -->|surges via| HPA
+    Controller -->|surges directly if no HPA| Deployment
     Controller -->|Writes status| CRD
     Controller -->|reads allowed disruptions | PDB
+    HPA -->|controls| Deployment
+    AutoscalerToPDB -->|watches| HPA
+    AutoscalerToPDB -->|updates minAvailable| PDB
     PDBController -->|watches | Deployment
     PDBController -->|creates if not exist| PDB
 ```

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,6 +38,7 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - eviction-autoscaler.azure.com

--- a/helm/eviction-autoscaler/templates/clusterrole.yaml
+++ b/helm/eviction-autoscaler/templates/clusterrole.yaml
@@ -95,6 +95,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - keda.sh
   resources:

--- a/internal/controller/autoscaler_to_pdb_controller.go
+++ b/internal/controller/autoscaler_to_pdb_controller.go
@@ -71,6 +71,19 @@ func (r *AutoscalerToPDBReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
+	// Don't update PDB minAvailable during an active surge. The eviction controller
+	// temporarily raises replicas (and possibly HPA/KEDA minReplicas) above the floor
+	// to handle evictions. Updating the PDB now would lock in the surged value as the
+	// new floor. The surge revert path will restore original values, and the next
+	// reconcile after that will set minAvailable correctly.
+	// Check the HPA/KEDA object for the surge annotation (not the deployment),
+	// since the surge annotation is placed on the autoscaler object.
+	if r.isSurgeActiveOnAutoscaler(ctx, req) {
+		logger.V(1).Info("Surge active on autoscaler, skipping PDB minAvailable update",
+			"deployment", deployment.Name)
+		return reconcile.Result{}, nil
+	}
+
 	// Find the PDB that matches this deployment's pod selector labels.
 	// Only consider PDBs created by this controller (ownedBy annotation) — user-managed PDBs
 	// should not be modified. If no controller-owned PDB exists, there's nothing to update.
@@ -84,17 +97,6 @@ func (r *AutoscalerToPDBReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return reconcile.Result{}, err
 	}
 	if !found {
-		return reconcile.Result{}, nil
-	}
-
-	// Don't update PDB minAvailable during an active surge. The eviction controller
-	// temporarily raises replicas (and possibly HPA/KEDA minReplicas) above the floor
-	// to handle evictions. Updating the PDB now would lock in the surged value as the
-	// new floor. The surge revert path will restore original values, and the next
-	// reconcile after that will set minAvailable correctly.
-	if _, surgeActive := deployment.Annotations[EvictionSurgeReplicasAnnotationKey]; surgeActive {
-		logger.V(1).Info("Surge active on deployment, skipping PDB minAvailable update",
-			"deployment", deployment.Name)
 		return reconcile.Result{}, nil
 	}
 
@@ -172,6 +174,32 @@ func (r *AutoscalerToPDBReconciler) resolveDeploymentName(ctx context.Context, r
 	}
 
 	return "", nil
+}
+
+// isSurgeActiveOnAutoscaler checks whether the HPA or ScaledObject identified by req
+// has the evictionSurgeReplicas annotation, indicating an active surge.
+func (r *AutoscalerToPDBReconciler) isSurgeActiveOnAutoscaler(ctx context.Context, req ctrl.Request) bool {
+	// Check HPA
+	var hpa autoscalingv2.HorizontalPodAutoscaler
+	if err := r.Get(ctx, req.NamespacedName, &hpa); err == nil {
+		if _, exists := hpa.Annotations[EvictionSurgeReplicasAnnotationKey]; exists {
+			return true
+		}
+	}
+
+	// Check ScaledObject
+	scaledObj := &unstructured.Unstructured{}
+	scaledObj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: "keda.sh", Version: "v1alpha1", Kind: "ScaledObject",
+	})
+	if err := r.Get(ctx, req.NamespacedName, scaledObj); err == nil {
+		annotations := scaledObj.GetAnnotations()
+		if _, exists := annotations[EvictionSurgeReplicasAnnotationKey]; exists {
+			return true
+		}
+	}
+
+	return false
 }
 
 // SetupWithManager registers watches on HPA and KEDA ScaledObject resources.

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -47,6 +47,7 @@ const cooldown = 1 * time.Minute
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=watch;get;list
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=update
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;update
 
 func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -29,6 +29,7 @@ import (
 )
 
 const EvictionSurgeReplicasAnnotationKey = "evictionSurgeReplicas"
+const OriginalMinReplicasAnnotationKey = "eviction-autoscaler.azure.com/original-min-replicas"
 
 // EvictionAutoScalerReconciler reconciles a EvictionAutoScaler object
 type EvictionAutoScalerReconciler struct {

--- a/internal/controller/hpa_surge_applier.go
+++ b/internal/controller/hpa_surge_applier.go
@@ -1,0 +1,143 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// --- HPASurgeApplier ---
+//
+// Surges by temporarily increasing HPA spec.minReplicas and setting deployment
+// replicas directly for immediate effect.
+//
+// Why we update deployment replicas in addition to HPA minReplicas:
+//
+// The HPA controller only enforces minReplicas after it successfully computes a
+// desired replica count from metrics. If metric computation fails (e.g., no
+// metrics-server, metrics API unavailable, new deployment with no historical data),
+// the HPA preserves the current replica count and does NOT scale up to minReplicas.
+// This means raising HPA minReplicas alone is not enough to guarantee the surge
+// takes effect — the deployment could stay at 1 replica indefinitely.
+//
+// Setting deployment.spec.replicas directly triggers the deployment controller to
+// create new pods immediately, regardless of HPA metrics availability. The HPA's
+// raised minReplicas prevents it from scaling back down below the surge value on
+// its next successful metrics evaluation.
+//
+// Note: the HPA controller uses the /scale subresource to set deployment replicas,
+// which is equivalent to updating deployment.spec.replicas directly. Both result in
+// the same field being set; the /scale subresource is just a convenience API that
+// avoids sending the full deployment object. However, /scale does NOT bump
+// deployment metadata.generation, while a full Update does (if spec changes).
+
+type HPASurgeApplier struct {
+	client client.Client
+	hpa    *autoscalingv2.HorizontalPodAutoscaler
+	target Surger
+}
+
+var _ SurgeApplier = &HPASurgeApplier{}
+
+func (h *HPASurgeApplier) ApplySurge(ctx context.Context, surgeReplicas int32) error {
+	logger := log.FromContext(ctx)
+	surgeVal := strconv.FormatInt(int64(surgeReplicas), 10)
+
+	// Step 1: Update HPA minReplicas and annotate the HPA with both:
+	//   - evictionSurgeReplicas: the surged value (surge marker)
+	//   - original-min-replicas: the pre-surge value (for revert)
+	// Skip if HPA is already surged to the target value (idempotent on retry).
+	// Annotations are on the HPA (not the deployment) so we don't modify the
+	// deployment's metadata, avoiding unnecessary generation tracking complexity.
+	if h.hpa.Annotations == nil || h.hpa.Annotations[EvictionSurgeReplicasAnnotationKey] != surgeVal {
+		hpa := h.hpa.DeepCopy()
+		originalMin := int32(1) // default
+		if hpa.Spec.MinReplicas != nil {
+			originalMin = *hpa.Spec.MinReplicas
+		}
+		hpa.Spec.MinReplicas = &surgeReplicas
+		if hpa.Annotations == nil {
+			hpa.Annotations = make(map[string]string)
+		}
+		hpa.Annotations[EvictionSurgeReplicasAnnotationKey] = surgeVal
+		hpa.Annotations[OriginalMinReplicasAnnotationKey] = strconv.FormatInt(int64(originalMin), 10)
+		h.hpa = hpa
+		if err := h.client.Update(ctx, hpa); err != nil {
+			return fmt.Errorf("updating HPA minReplicas and annotations: %w", err)
+		}
+		logger.V(1).Info("Updated HPA minReplicas and annotated with surge intent",
+			"minReplicas", surgeReplicas, "originalMin", originalMin)
+	}
+
+	// Step 2: Set deployment replicas directly for immediate scale-up.
+	// See type-level comment for why this is needed alongside the HPA update.
+	// On 409 Conflict (stale resourceVersion), the error propagates to the
+	// reconcile loop which requeues. On retry, step 1 is skipped (idempotent)
+	// and step 2 retries with a fresh object from the informer cache.
+	if h.target.GetReplicas() != surgeReplicas {
+		h.target.SetReplicas(surgeReplicas)
+		if err := h.client.Update(ctx, h.target.Obj()); err != nil {
+			return fmt.Errorf("setting deployment replicas: %w", err)
+		}
+		logger.V(1).Info("Set deployment replicas for immediate surge", "replicas", surgeReplicas)
+	}
+
+	return nil
+}
+
+func (h *HPASurgeApplier) RevertSurge(ctx context.Context, originalMinReplicas int32) error {
+	logger := log.FromContext(ctx)
+
+	// Read the original minReplicas from the HPA annotation if available.
+	// This is the pre-surge value stored during ApplySurge, making the HPA
+	// self-describing for revert without depending on EA.Status.MinReplicas.
+	revertTo := originalMinReplicas
+	if h.hpa.Annotations != nil {
+		if val, exists := h.hpa.Annotations[OriginalMinReplicasAnnotationKey]; exists {
+			if parsed, err := strconv.ParseInt(val, 10, 32); err == nil {
+				revertTo = int32(parsed)
+			}
+		}
+	}
+
+	// Revert HPA minReplicas and remove both surge annotations in a single write.
+	hpa := h.hpa.DeepCopy()
+	hpa.Spec.MinReplicas = &revertTo
+	delete(hpa.Annotations, EvictionSurgeReplicasAnnotationKey)
+	delete(hpa.Annotations, OriginalMinReplicasAnnotationKey)
+	h.hpa = hpa
+	if err := h.client.Update(ctx, hpa); err != nil {
+		return fmt.Errorf("reverting HPA minReplicas and removing annotations: %w", err)
+	}
+	logger.V(1).Info("Reverted HPA minReplicas and removed surge annotations", "revertTo", revertTo)
+
+	// Don't set deployment replicas directly — let HPA handle the scale-down
+	// on its next sync (~15s). The eviction has already completed so there is
+	// no urgency. If the HPA cannot compute metrics, the deployment will stay
+	// at the surged replica count, which is safe (just over-provisioned).
+	if h.target.GetReplicas() > revertTo {
+		logger.Info("Deployment replicas still above baseline after HPA revert, "+
+			"waiting for HPA to scale down on next sync",
+			"currentReplicas", h.target.GetReplicas(),
+			"originalMinReplicas", revertTo,
+			"hpa", h.hpa.Name)
+	}
+	return nil
+}
+
+func (h *HPASurgeApplier) Name() string {
+	return "hpa"
+}
+
+func (h *HPASurgeApplier) IsSurgeActive() bool {
+	if h.hpa.Annotations != nil {
+		if _, exists := h.hpa.Annotations[EvictionSurgeReplicasAnnotationKey]; exists {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -7,9 +7,46 @@ import (
 	"strconv"
 	"strings"
 
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+const maxConflictRetries = 3
+
+// reGetAndUpdateTarget re-fetches the target to get the latest resourceVersion,
+// applies the given mutate function, and retries on conflict up to maxConflictRetries times.
+//
+// This is needed because HPA/KEDA ApplySurge and RevertSurge are two-step operations:
+// step 1 updates the HPA/ScaledObject, step 2 updates the deployment. Between these steps,
+// the HPA controller may modify the deployment via the /scale subresource, changing its
+// resourceVersion. If we used the stale resourceVersion from the start of the reconcile,
+// the deployment update would fail with a 409 Conflict (optimistic concurrency).
+// Re-fetching gets the latest resourceVersion, and retrying handles the case where
+// the HPA races us again between the re-fetch and the update.
+func reGetAndUpdateTarget(ctx context.Context, c client.Client, target Surger, mutate func()) error {
+	for i := 0; i < maxConflictRetries; i++ {
+		// Re-fetch to get fresh resourceVersion
+		obj := target.Obj()
+		if err := c.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
+			return fmt.Errorf("re-fetching target: %w", err)
+		}
+		mutate()
+		// Use target.Obj() after mutate because SetReplicas may replace the underlying
+		// object via DeepCopy, making the captured 'obj' pointer stale.
+		err := c.Update(ctx, target.Obj())
+		if err == nil {
+			return nil
+		}
+		if !kerrors.IsConflict(err) {
+			return err
+		}
+		log.FromContext(ctx).V(1).Info("Conflict updating target, retrying", "attempt", i+1)
+	}
+	return fmt.Errorf("failed to update target after %d conflict retries", maxConflictRetries)
+}
 
 // SurgeApplier abstracts the mechanism for temporarily increasing minimum replicas.
 // Depending on whether KEDA, HPA, or neither is present, a different implementation is used.
@@ -61,17 +98,18 @@ func detectSurgeApplier(ctx context.Context, c client.Client, namespace, targetN
 			return nil, fmt.Errorf("checking for HPA: %w", err)
 		}
 		if hpa != nil {
-			// HPA surge strategy not yet implemented — skip surging entirely so we
-			// don't bypass HPA by mutating deployment replicas directly.
-			logger.Info("Found HPA for target, skipping surge (HPA strategy not yet implemented)",
+			logger.Info("Found HPA for target, adding HPA surge applier",
 				"hpa", hpa.Name, "target", targetName)
-			return &NoOpSurgeApplier{}, nil
+			appliers = append(appliers, &HPASurgeApplier{client: c, hpa: hpa, target: target})
 		}
 	}
 
-	// DeploymentSurgeApplier is the default strategy when no autoscaler appliers are added.
+	// DeploymentSurgeApplier is only needed when no autoscaler appliers were added.
+	// HPA/KEDA appliers already handle setting deployment replicas and the surge
+	// annotation internally (via reGetAndUpdateTarget), so adding DeploymentSurgeApplier
+	// alongside them would cause a stale-object conflict on the second Update.
 	if len(appliers) == 0 {
-		logger.V(1).Info("Using deployment surge strategy", "target", targetName)
+		logger.V(1).Info("No KEDA or HPA found, using deployment surge strategy", "target", targetName)
 		appliers = append(appliers, &DeploymentSurgeApplier{client: c, target: target})
 	}
 
@@ -113,8 +151,8 @@ var _ SurgeApplier = &NoOpSurgeApplier{}
 
 func (n *NoOpSurgeApplier) ApplySurge(_ context.Context, _ int32) error  { return nil }
 func (n *NoOpSurgeApplier) RevertSurge(_ context.Context, _ int32) error { return nil }
-func (n *NoOpSurgeApplier) IsSurgeActive() bool                          { return false }
-func (n *NoOpSurgeApplier) Name() string                                 { return "noop" }
+func (n *NoOpSurgeApplier) IsSurgeActive() bool                         { return false }
+func (n *NoOpSurgeApplier) Name() string                                { return "noop" }
 
 // --- DeploymentSurgeApplier ---
 // Surges by modifying the deployment/statefulset spec.replicas directly.
@@ -147,21 +185,89 @@ func (d *DeploymentSurgeApplier) IsSurgeActive() bool {
 	return hasTargetAnnotation(d.target)
 }
 
+// --- HPASurgeApplier ---
+// Surges by temporarily increasing HPA spec.minReplicas.
+
+type HPASurgeApplier struct {
+	client client.Client
+	hpa    *autoscalingv2.HorizontalPodAutoscaler
+	target Surger
+}
+
+var _ SurgeApplier = &HPASurgeApplier{}
+
+func (h *HPASurgeApplier) ApplySurge(ctx context.Context, surgeReplicas int32) error {
+	logger := log.FromContext(ctx)
+
+	// Step 1: Update HPA minReplicas first to raise the floor.
+	// This must happen before setting deployment replicas to prevent a race where
+	// the HPA sync loop scales the deployment back down between the two writes.
+	hpa := h.hpa.DeepCopy()
+	hpa.Spec.MinReplicas = &surgeReplicas
+	h.hpa = hpa
+	if err := h.client.Update(ctx, hpa); err != nil {
+		return fmt.Errorf("updating HPA minReplicas: %w", err)
+	}
+	logger.V(1).Info("Updated HPA minReplicas", "minReplicas", surgeReplicas)
+
+	// Step 2: Set deployment replicas directly for immediate scale-up and annotate
+	// with surge intent marker. This avoids waiting for the HPA sync loop (~15s)
+	// and handles the case where the HPA cannot compute metrics (e.g., no metrics-server).
+	// Skip if already annotated (e.g., by another applier in a composite).
+	surgeVal := strconv.FormatInt(int64(surgeReplicas), 10)
+	if !hasTargetAnnotationWithValue(h.target, surgeVal) {
+		if err := reGetAndUpdateTarget(ctx, h.client, h.target, func() {
+			if h.target.GetReplicas() != surgeReplicas {
+				h.target.SetReplicas(surgeReplicas)
+			}
+			h.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, surgeVal)
+		}); err != nil {
+			return fmt.Errorf("setting replicas and annotating target: %w", err)
+		}
+		logger.V(1).Info("Set replicas and annotated target with surge intent", "replicas", surgeReplicas)
+	}
+	return nil
+}
+
+func (h *HPASurgeApplier) RevertSurge(ctx context.Context, originalMinReplicas int32) error {
+	logger := log.FromContext(ctx)
+
+	// Step 1: Revert HPA minReplicas using EA.Status.MinReplicas (the effective floor)
+	hpa := h.hpa.DeepCopy()
+	hpa.Spec.MinReplicas = &originalMinReplicas
+	h.hpa = hpa
+	if err := h.client.Update(ctx, hpa); err != nil {
+		return fmt.Errorf("reverting HPA minReplicas: %w", err)
+	}
+	logger.V(1).Info("Reverted HPA minReplicas", "originalMin", originalMinReplicas)
+
+	// Step 2: Remove surge annotation and set replicas directly for immediate scale-down.
+	// This avoids waiting for the HPA sync loop to enforce the reverted minReplicas.
+	if hasTargetAnnotation(h.target) {
+		if err := reGetAndUpdateTarget(ctx, h.client, h.target, func() {
+			if h.target.GetReplicas() != originalMinReplicas {
+				h.target.SetReplicas(originalMinReplicas)
+			}
+			h.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
+		}); err != nil {
+			return fmt.Errorf("removing surge annotation from target: %w", err)
+		}
+	}
+	return nil
+}
+
+func (h *HPASurgeApplier) Name() string {
+	return "hpa"
+}
+
+func (h *HPASurgeApplier) IsSurgeActive() bool {
+	return hasTargetAnnotation(h.target)
+}
+
 // --- CompositeSurgeApplier ---
 // Surges multiple resources (e.g., both KEDA ScaledObject and standalone HPA) when both
 // target the same workload. This prevents the standalone HPA from blocking scale-up when
 // only the ScaledObject is surged, or vice versa.
-//
-// Ordering: appliers are always invoked in KEDA → HPA → Deployment order.
-// The autoscaler floor (KEDA minReplicaCount or HPA minReplicas) must be raised
-// *before* setting deployment replicas, otherwise the autoscaler's sync loop can
-// scale the deployment back down between the two writes.
-//
-// Reverts follow the same order (not reversed) because the autoscaler floor must
-// be lowered first — if we reverted the deployment replicas before lowering the
-// HPA/KEDA floor, the autoscaler would immediately scale the deployment back up
-// to the still-surged floor value.
-//
 // The target annotation (evictionSurgeReplicas) is written once by the first applier;
 // subsequent appliers skip re-annotating the target to avoid duplicate writes.
 

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -7,46 +7,9 @@ import (
 	"strconv"
 	"strings"
 
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-const maxConflictRetries = 3
-
-// reGetAndUpdateTarget re-fetches the target to get the latest resourceVersion,
-// applies the given mutate function, and retries on conflict up to maxConflictRetries times.
-//
-// This is needed because HPA/KEDA ApplySurge and RevertSurge are two-step operations:
-// step 1 updates the HPA/ScaledObject, step 2 updates the deployment. Between these steps,
-// the HPA controller may modify the deployment via the /scale subresource, changing its
-// resourceVersion. If we used the stale resourceVersion from the start of the reconcile,
-// the deployment update would fail with a 409 Conflict (optimistic concurrency).
-// Re-fetching gets the latest resourceVersion, and retrying handles the case where
-// the HPA races us again between the re-fetch and the update.
-func reGetAndUpdateTarget(ctx context.Context, c client.Client, target Surger, mutate func()) error {
-	for i := 0; i < maxConflictRetries; i++ {
-		// Re-fetch to get fresh resourceVersion
-		obj := target.Obj()
-		if err := c.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
-			return fmt.Errorf("re-fetching target: %w", err)
-		}
-		mutate()
-		// Use target.Obj() after mutate because SetReplicas may replace the underlying
-		// object via DeepCopy, making the captured 'obj' pointer stale.
-		err := c.Update(ctx, target.Obj())
-		if err == nil {
-			return nil
-		}
-		if !kerrors.IsConflict(err) {
-			return err
-		}
-		log.FromContext(ctx).V(1).Info("Conflict updating target, retrying", "attempt", i+1)
-	}
-	return fmt.Errorf("failed to update target after %d conflict retries", maxConflictRetries)
-}
 
 // SurgeApplier abstracts the mechanism for temporarily increasing minimum replicas.
 // Depending on whether KEDA, HPA, or neither is present, a different implementation is used.
@@ -151,8 +114,8 @@ var _ SurgeApplier = &NoOpSurgeApplier{}
 
 func (n *NoOpSurgeApplier) ApplySurge(_ context.Context, _ int32) error  { return nil }
 func (n *NoOpSurgeApplier) RevertSurge(_ context.Context, _ int32) error { return nil }
-func (n *NoOpSurgeApplier) IsSurgeActive() bool                         { return false }
-func (n *NoOpSurgeApplier) Name() string                                { return "noop" }
+func (n *NoOpSurgeApplier) IsSurgeActive() bool                          { return false }
+func (n *NoOpSurgeApplier) Name() string                                 { return "noop" }
 
 // --- DeploymentSurgeApplier ---
 // Surges by modifying the deployment/statefulset spec.replicas directly.
@@ -183,85 +146,6 @@ func (d *DeploymentSurgeApplier) Name() string {
 
 func (d *DeploymentSurgeApplier) IsSurgeActive() bool {
 	return hasTargetAnnotation(d.target)
-}
-
-// --- HPASurgeApplier ---
-// Surges by temporarily increasing HPA spec.minReplicas.
-
-type HPASurgeApplier struct {
-	client client.Client
-	hpa    *autoscalingv2.HorizontalPodAutoscaler
-	target Surger
-}
-
-var _ SurgeApplier = &HPASurgeApplier{}
-
-func (h *HPASurgeApplier) ApplySurge(ctx context.Context, surgeReplicas int32) error {
-	logger := log.FromContext(ctx)
-
-	// Step 1: Update HPA minReplicas first to raise the floor.
-	// This must happen before setting deployment replicas to prevent a race where
-	// the HPA sync loop scales the deployment back down between the two writes.
-	hpa := h.hpa.DeepCopy()
-	hpa.Spec.MinReplicas = &surgeReplicas
-	h.hpa = hpa
-	if err := h.client.Update(ctx, hpa); err != nil {
-		return fmt.Errorf("updating HPA minReplicas: %w", err)
-	}
-	logger.V(1).Info("Updated HPA minReplicas", "minReplicas", surgeReplicas)
-
-	// Step 2: Set deployment replicas directly for immediate scale-up and annotate
-	// with surge intent marker. This avoids waiting for the HPA sync loop (~15s)
-	// and handles the case where the HPA cannot compute metrics (e.g., no metrics-server).
-	// Skip if already annotated (e.g., by another applier in a composite).
-	surgeVal := strconv.FormatInt(int64(surgeReplicas), 10)
-	if !hasTargetAnnotationWithValue(h.target, surgeVal) {
-		if err := reGetAndUpdateTarget(ctx, h.client, h.target, func() {
-			if h.target.GetReplicas() != surgeReplicas {
-				h.target.SetReplicas(surgeReplicas)
-			}
-			h.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, surgeVal)
-		}); err != nil {
-			return fmt.Errorf("setting replicas and annotating target: %w", err)
-		}
-		logger.V(1).Info("Set replicas and annotated target with surge intent", "replicas", surgeReplicas)
-	}
-	return nil
-}
-
-func (h *HPASurgeApplier) RevertSurge(ctx context.Context, originalMinReplicas int32) error {
-	logger := log.FromContext(ctx)
-
-	// Step 1: Revert HPA minReplicas using EA.Status.MinReplicas (the effective floor)
-	hpa := h.hpa.DeepCopy()
-	hpa.Spec.MinReplicas = &originalMinReplicas
-	h.hpa = hpa
-	if err := h.client.Update(ctx, hpa); err != nil {
-		return fmt.Errorf("reverting HPA minReplicas: %w", err)
-	}
-	logger.V(1).Info("Reverted HPA minReplicas", "originalMin", originalMinReplicas)
-
-	// Step 2: Remove surge annotation and set replicas directly for immediate scale-down.
-	// This avoids waiting for the HPA sync loop to enforce the reverted minReplicas.
-	if hasTargetAnnotation(h.target) {
-		if err := reGetAndUpdateTarget(ctx, h.client, h.target, func() {
-			if h.target.GetReplicas() != originalMinReplicas {
-				h.target.SetReplicas(originalMinReplicas)
-			}
-			h.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
-		}); err != nil {
-			return fmt.Errorf("removing surge annotation from target: %w", err)
-		}
-	}
-	return nil
-}
-
-func (h *HPASurgeApplier) Name() string {
-	return "hpa"
-}
-
-func (h *HPASurgeApplier) IsSurgeActive() bool {
-	return hasTargetAnnotation(h.target)
 }
 
 // --- CompositeSurgeApplier ---

--- a/test/e2e/e2e_helpers.go
+++ b/test/e2e/e2e_helpers.go
@@ -339,3 +339,33 @@ func verifyDeploymentNoAnnotation(ctx context.Context, clientset client.Client, 
 	}
 	return nil
 }
+
+// verifyHPAAnnotation checks if an HPA has the expected annotation value
+func verifyHPAAnnotation(ctx context.Context, clientset client.Client, ns, name, annotationKey, expectedValue string) error {
+	var hpa autoscalingv2.HorizontalPodAutoscaler
+	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &hpa)
+	if err != nil {
+		return err
+	}
+	val, ok := hpa.Annotations[annotationKey]
+	if !ok {
+		return fmt.Errorf("annotation %q not found on HPA %s", annotationKey, name)
+	}
+	if val != expectedValue {
+		return fmt.Errorf("expected HPA annotation %q=%q, got %q", annotationKey, expectedValue, val)
+	}
+	return nil
+}
+
+// verifyHPANoAnnotation checks that an HPA does NOT have a specific annotation
+func verifyHPANoAnnotation(ctx context.Context, clientset client.Client, ns, name, annotationKey string) error {
+	var hpa autoscalingv2.HorizontalPodAutoscaler
+	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &hpa)
+	if err != nil {
+		return err
+	}
+	if _, ok := hpa.Annotations[annotationKey]; ok {
+		return fmt.Errorf("annotation %q should not be present on HPA %s", annotationKey, name)
+	}
+	return nil
+}

--- a/test/e2e/e2e_helpers.go
+++ b/test/e2e/e2e_helpers.go
@@ -27,6 +27,8 @@ import (
 	types "github.com/azure/eviction-autoscaler/api/v1"
 	"github.com/azure/eviction-autoscaler/test/utils"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	policy "k8s.io/api/policy/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -38,6 +40,7 @@ type deploymentConfig struct {
 	Replicas       int32
 	MaxUnavailable int
 	Annotations    map[string]string
+	CPURequest     string // optional, e.g. "10m"
 }
 
 // createDeployment creates a deployment with the given configuration
@@ -77,6 +80,11 @@ spec:
       containers:
         - name: nginx
           image: nginx:latest
+          {{- if .CPURequest}}
+          resources:
+            requests:
+              cpu: "{{.CPURequest}}"
+          {{- end}}
 `
 	t, err := template.New("deployment").Parse(tmpl)
 	if err != nil {
@@ -90,12 +98,14 @@ spec:
 		Replicas       int32
 		MaxUnavailable string
 		Annotations    map[string]string
+		CPURequest     string
 	}{
 		Name:           cfg.Name,
 		Namespace:      cfg.Namespace,
 		Replicas:       cfg.Replicas,
 		MaxUnavailable: maxUnavailable,
 		Annotations:    cfg.Annotations,
+		CPURequest:     cfg.CPURequest,
 	}
 
 	if err := t.Execute(&buf, data); err != nil {
@@ -280,4 +290,52 @@ spec:
 func deleteHPA(name, namespace string) {
 	cmd := exec.Command("kubectl", "delete", "hpa", name, "--namespace", namespace)
 	_, _ = utils.Run(cmd)
+}
+
+// verifyHPAMinReplicas checks if an HPA has the expected minReplicas value
+func verifyHPAMinReplicas(ctx context.Context, clientset client.Client, ns, name string, expectedMin int32) error {
+	var hpa autoscalingv2.HorizontalPodAutoscaler
+	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &hpa)
+	if err != nil {
+		return err
+	}
+	if hpa.Spec.MinReplicas == nil {
+		return fmt.Errorf("HPA minReplicas is nil")
+	}
+	if *hpa.Spec.MinReplicas != expectedMin {
+		return fmt.Errorf("expected HPA minReplicas to be %d, got %d", expectedMin, *hpa.Spec.MinReplicas)
+	}
+	return nil
+}
+
+// verifyDeploymentAnnotation checks if a deployment has the expected annotation value
+func verifyDeploymentAnnotation(
+	ctx context.Context, clientset client.Client, ns, name, annotationKey, expectedValue string,
+) error {
+	var dep appsv1.Deployment
+	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &dep)
+	if err != nil {
+		return err
+	}
+	val, ok := dep.Annotations[annotationKey]
+	if !ok {
+		return fmt.Errorf("annotation %q not found on deployment %s", annotationKey, name)
+	}
+	if val != expectedValue {
+		return fmt.Errorf("expected annotation %q=%q, got %q", annotationKey, expectedValue, val)
+	}
+	return nil
+}
+
+// verifyDeploymentNoAnnotation checks that a deployment does NOT have a specific annotation
+func verifyDeploymentNoAnnotation(ctx context.Context, clientset client.Client, ns, name, annotationKey string) error {
+	var dep appsv1.Deployment
+	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &dep)
+	if err != nil {
+		return err
+	}
+	if _, ok := dep.Annotations[annotationKey]; ok {
+		return fmt.Errorf("annotation %q should not be present on deployment %s", annotationKey, name)
+	}
+	return nil
 }

--- a/test/e2e/e2e_helpers.go
+++ b/test/e2e/e2e_helpers.go
@@ -27,7 +27,6 @@ import (
 	types "github.com/azure/eviction-autoscaler/api/v1"
 	"github.com/azure/eviction-autoscaler/test/utils"
 	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	policy "k8s.io/api/policy/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -308,40 +307,10 @@ func verifyHPAMinReplicas(ctx context.Context, clientset client.Client, ns, name
 	return nil
 }
 
-// verifyDeploymentAnnotation checks if a deployment has the expected annotation value
-func verifyDeploymentAnnotation(
+// verifyHPAAnnotation checks if an HPA has the expected annotation value
+func verifyHPAAnnotation(
 	ctx context.Context, clientset client.Client, ns, name, annotationKey, expectedValue string,
 ) error {
-	var dep appsv1.Deployment
-	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &dep)
-	if err != nil {
-		return err
-	}
-	val, ok := dep.Annotations[annotationKey]
-	if !ok {
-		return fmt.Errorf("annotation %q not found on deployment %s", annotationKey, name)
-	}
-	if val != expectedValue {
-		return fmt.Errorf("expected annotation %q=%q, got %q", annotationKey, expectedValue, val)
-	}
-	return nil
-}
-
-// verifyDeploymentNoAnnotation checks that a deployment does NOT have a specific annotation
-func verifyDeploymentNoAnnotation(ctx context.Context, clientset client.Client, ns, name, annotationKey string) error {
-	var dep appsv1.Deployment
-	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &dep)
-	if err != nil {
-		return err
-	}
-	if _, ok := dep.Annotations[annotationKey]; ok {
-		return fmt.Errorf("annotation %q should not be present on deployment %s", annotationKey, name)
-	}
-	return nil
-}
-
-// verifyHPAAnnotation checks if an HPA has the expected annotation value
-func verifyHPAAnnotation(ctx context.Context, clientset client.Client, ns, name, annotationKey, expectedValue string) error {
 	var hpa autoscalingv2.HorizontalPodAutoscaler
 	err := clientset.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, &hpa)
 	if err != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -36,6 +36,7 @@ import (
 	types "github.com/azure/eviction-autoscaler/api/v1"
 	"github.com/azure/eviction-autoscaler/test/utils"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -52,6 +53,7 @@ var scheme = runtime.NewScheme()
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(appsv1.AddToScheme(scheme))
+	utilruntime.Must(autoscalingv2.AddToScheme(scheme))
 	utilruntime.Must(policy.AddToScheme(scheme))
 	utilruntime.Must(types.AddToScheme(scheme))
 }
@@ -1013,7 +1015,147 @@ var _ = Describe("controller", Ordered, func() {
 			Expect(scrapeMetrics()).To(Succeed())
 		})
 
-		// Test 3: PDB minAvailable should use HPA minReplicas, not deployment replicas
+		// Test 3: HPA surge strategy - when an HPA exists, surge by updating HPA minReplicas instead of deployment replicas
+		It("should surge via HPA minReplicas when an HPA targets the deployment", func() {
+			ctx := context.Background()
+			testNs := "test-hpa-surge"
+
+			By("uncordoning all nodes to ensure clean state from prior tests")
+			cmd := exec.Command("kubectl", "get", "nodes", "-o", "jsonpath={.items[*].metadata.name}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			for _, nodeName := range strings.Fields(string(output)) {
+				cmd = exec.Command("kubectl", "uncordon", nodeName)
+				_, _ = utils.Run(cmd) // ignore error if already uncordoned
+			}
+
+			By("creating test namespace with enable annotation")
+			cmd = exec.Command("kubectl", "create", "namespace", testNs)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("kubectl", "annotate", "namespace", testNs,
+				"eviction-autoscaler.azure.com/enable=true")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating a deployment with 1 replica and maxUnavailable=0")
+			err = createDeployment(deploymentConfig{
+				Name:           "nginx-hpa",
+				Namespace:      testNs,
+				Replicas:       1,
+				MaxUnavailable: 0,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for deployment to be ready")
+			err = waitForDeployment("nginx-hpa", testNs)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating an HPA targeting the deployment")
+			err = createHPA("nginx-hpa", testNs, "nginx-hpa", 1, 5)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying PDB and EvictionAutoScaler are created")
+			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+			Expect(err).NotTo(HaveOccurred())
+			clientset, err := client.New(config, client.Options{Scheme: scheme})
+			Expect(err).NotTo(HaveOccurred())
+			evictionClient, err := kubernetes.NewForConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			EventuallyWithOffset(1, func() error {
+				return verifyPdbCreated(ctx, clientset, testNs, "nginx-hpa")
+			}, time.Minute, time.Second).Should(Succeed())
+			EventuallyWithOffset(1, func() error {
+				return verifyEvictionAutoScalerCreated(ctx, clientset, testNs, "nginx-hpa")
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("finding the node the pod runs on")
+			var pods corev1.PodList
+			err = clientset.List(ctx, &pods, client.InNamespace(testNs))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pods.Items).NotTo(BeEmpty())
+			nodeName := pods.Items[0].Spec.NodeName
+			fmt.Printf("nginx-hpa pod running on node %s\n", nodeName)
+
+			By("cordoning the node to trigger eviction surge")
+			var node corev1.Node
+			err = clientset.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+			Expect(err).NotTo(HaveOccurred())
+			node.Spec.Unschedulable = true
+			err = clientset.Update(ctx, &node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the deployment gets the evictionSurgeReplicas annotation (intent marker)")
+			EventuallyWithOffset(1, func() error {
+				return verifyDeploymentAnnotation(ctx, clientset, testNs, "nginx-hpa",
+					"evictionSurgeReplicas", "2")
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("verifying the HPA minReplicas is surged to 2 (not the deployment replicas)")
+			EventuallyWithOffset(1, func() error {
+				return verifyHPAMinReplicas(ctx, clientset, testNs, "nginx-hpa", 2)
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("waiting for deployment to scale to 2 available replicas")
+			EventuallyWithOffset(1, func() error {
+				var dep appsv1.Deployment
+				if err := clientset.Get(ctx, client.ObjectKey{Namespace: testNs, Name: "nginx-hpa"}, &dep); err != nil {
+					return err
+				}
+				if dep.Status.AvailableReplicas < 2 {
+					return fmt.Errorf("expected 2 available replicas, got %d", dep.Status.AvailableReplicas)
+				}
+				return nil
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			By("draining the node to trigger evictions")
+			drain := func() error {
+				var podList corev1.PodList
+				err := clientset.List(ctx, &podList, client.InNamespace(testNs),
+					client.MatchingFields{"spec.nodeName": nodeName})
+				if err != nil {
+					return err
+				}
+				for _, p := range podList.Items {
+					err = evictionClient.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policy.Eviction{
+						ObjectMeta: p.ObjectMeta,
+					})
+					if err != nil {
+						return fmt.Errorf("failed to evict %s: %w", p.Name, err)
+					}
+				}
+				return nil
+			}
+			EventuallyWithOffset(1, drain, time.Minute, time.Second).Should(Succeed())
+
+			By("verifying HPA minReplicas reverts to 1 after cooldown")
+			EventuallyWithOffset(1, func() error {
+				return verifyHPAMinReplicas(ctx, clientset, testNs, "nginx-hpa", 1)
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			By("verifying the evictionSurgeReplicas annotation is removed from deployment")
+			EventuallyWithOffset(1, func() error {
+				return verifyDeploymentNoAnnotation(ctx, clientset, testNs, "nginx-hpa",
+					"evictionSurgeReplicas")
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			By("uncordoning the node")
+			err = clientset.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+			Expect(err).NotTo(HaveOccurred())
+			node.Spec.Unschedulable = false
+			err = clientset.Update(ctx, &node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("cleaning up HPA test resources")
+			deleteHPA("nginx-hpa", testNs)
+			deleteDeployment("nginx-hpa", testNs)
+			cmd = exec.Command("kubectl", "delete", "namespace", testNs)
+			_, _ = utils.Run(cmd)
+		})
+
+		// Test 3b: PDB minAvailable should use HPA minReplicas, not deployment replicas
 		It("should create PDB with minAvailable from HPA minReplicas when HPA targets the deployment", func() {
 			ctx := context.Background()
 			testNs := "test-hpa-pdb-min"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1087,9 +1087,9 @@ var _ = Describe("controller", Ordered, func() {
 			err = clientset.Update(ctx, &node)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("verifying the deployment gets the evictionSurgeReplicas annotation (intent marker)")
+			By("verifying the HPA gets the evictionSurgeReplicas annotation (surge marker)")
 			EventuallyWithOffset(1, func() error {
-				return verifyDeploymentAnnotation(ctx, clientset, testNs, "nginx-hpa",
+				return verifyHPAAnnotation(ctx, clientset, testNs, "nginx-hpa",
 					"evictionSurgeReplicas", "2")
 			}, time.Minute, time.Second).Should(Succeed())
 
@@ -1135,9 +1135,9 @@ var _ = Describe("controller", Ordered, func() {
 				return verifyHPAMinReplicas(ctx, clientset, testNs, "nginx-hpa", 1)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
-			By("verifying the evictionSurgeReplicas annotation is removed from deployment")
+			By("verifying the evictionSurgeReplicas annotation is removed from HPA")
 			EventuallyWithOffset(1, func() error {
-				return verifyDeploymentNoAnnotation(ctx, clientset, testNs, "nginx-hpa",
+				return verifyHPANoAnnotation(ctx, clientset, testNs, "nginx-hpa",
 					"evictionSurgeReplicas")
 			}, 2*time.Minute, time.Second).Should(Succeed())
 


### PR DESCRIPTION
This pull request introduces support for HPA-aware surge scaling in the eviction autoscaler, ensuring that when a Horizontal Pod Autoscaler (HPA) or KEDA ScaledObject targets a deployment, surge operations are performed by adjusting the autoscaler's `minReplicas` instead of directly modifying deployment replicas. This prevents the HPA from immediately scaling the deployment back down during a surge and maintains compatibility with autoscaler-driven workloads. The PR also updates documentation, RBAC permissions, and adds comprehensive end-to-end tests for the new behavior.

**HPA/KEDA Surge Integration:**

- Implemented an `HPASurgeApplier` that surges by temporarily increasing the HPA's `minReplicas` and reverts it after cooldown, ensuring surge actions are compatible with autoscaler-managed deployments. Also added a retry mechanism (`reGetAndUpdateTarget`) to handle update conflicts due to concurrent HPA/Deployment changes. [[1]](diffhunk://#diff-6fa5cb4c4321208255ba794a9987280a6288b467a4a75fe930bfe55de3de7781R10-R50) [[2]](diffhunk://#diff-6fa5cb4c4321208255ba794a9987280a6288b467a4a75fe930bfe55de3de7781L64-R112) [[3]](diffhunk://#diff-6fa5cb4c4321208255ba794a9987280a6288b467a4a75fe930bfe55de3de7781R188-L164)
- Modified the controller logic to detect when an HPA or KEDA ScaledObject is present and use the appropriate surge strategy, falling back to direct deployment scaling only if no autoscaler is found.

**Documentation Updates:**

- Updated `README.md` to describe the new HPA-aware surge behavior, the roles of the new controllers, and the overall architecture. Added explanations and diagrams for how surges interact with HPAs and KEDA. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42-R57)

**RBAC and Permissions:**

- Expanded RBAC permissions in `role.yaml` and `clusterrole.yaml` to allow `update` operations on HPAs and KEDA ScaledObjects, which is necessary for the controller to adjust `minReplicas`. [[1]](diffhunk://#diff-6d4c4e29ec096149781536bb9118fde8242c1901df764e3eda3019ac8503d6c7R41) [[2]](diffhunk://#diff-698aab4cef18204d0f22b56bcbc3bb0d67a950859fb20bb57b8408ce3f1a3701R98)
- Added a kubebuilder RBAC directive to allow the controller to update HPAs.

**End-to-End Testing Enhancements:**

- Added new E2E tests to verify HPA surge logic, including checks for correct updates to HPA `minReplicas`, deployment annotations, and proper cleanup after surge reversion. Introduced helper functions for these checks and updated deployment creation logic to support CPU requests for metric-based scaling. [[1]](diffhunk://#diff-d5d12b6ea07b0a78c9ad1987e1486c565ecf16839f77a93e91b09475cf6c0e99L1016-R1158) [[2]](diffhunk://#diff-11b53a7a4c93acf196e8a4a06af0efbce21ea669cdabff13362ed63c98198345R30-R31) [[3]](diffhunk://#diff-11b53a7a4c93acf196e8a4a06af0efbce21ea669cdabff13362ed63c98198345R43) [[4]](diffhunk://#diff-11b53a7a4c93acf196e8a4a06af0efbce21ea669cdabff13362ed63c98198345R83-R87) [[5]](diffhunk://#diff-11b53a7a4c93acf196e8a4a06af0efbce21ea669cdabff13362ed63c98198345R101-R108) [[6]](diffhunk://#diff-11b53a7a4c93acf196e8a4a06af0efbce21ea669cdabff13362ed63c98198345R294-R341) [[7]](diffhunk://#diff-d5d12b6ea07b0a78c9ad1987e1486c565ecf16839f77a93e91b09475cf6c0e99R39) [[8]](diffhunk://#diff-d5d12b6ea07b0a78c9ad1987e1486c565ecf16839f77a93e91b09475cf6c0e99R56)

These changes collectively ensure that surge scaling works seamlessly with autoscaler-managed workloads, improving reliability and correctness in production environments.