### PR TITLE
Add HPA surge annotations and improve surge handling logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,6 +621,28 @@ kubectl annotate pdb my-app -n default ownedBy=EvictionAutoScaler
 
 ## Usage
 
+### HPA Surge Annotations
+
+When an HPA targets a deployment, the eviction autoscaler places annotations on the **HPA object** (not the deployment) during a surge:
+
+| Annotation | Placed On | Value | Purpose |
+|---|---|---|---|
+| `evictionSurgeReplicas` | HPA | Surged replica count (e.g., `"3"`) | Marks that a surge is active |
+| `eviction-autoscaler.azure.com/original-min-replicas` | HPA | Pre-surge minReplicas (e.g., `"1"`) | Stores the original value for revert |
+| `evictionSurgeReplicas` | Deployment | Surged replica count | Only used when **no** HPA/KEDA is present |
+
+These annotations are managed automatically by the controller. They are set atomically with the HPA `minReplicas` change during surge and removed during revert. You should not modify them manually.
+
+**Inspecting surge state:**
+
+```bash
+# Check if a surge is active on an HPA
+kubectl get hpa <name> -n <namespace> -o jsonpath='{.metadata.annotations}'
+
+# Check the original minReplicas that will be restored on revert
+kubectl get hpa <name> -n <namespace> -o jsonpath='{.metadata.annotations.eviction-autoscaler\.azure\.com/original-min-replicas}'
+```
+
 ### Build and Push Multi-Arch Image
 
 Use `docker buildx` through the Make target to build and push a manifest image for multiple architectures.

--- a/internal/controller/autoscaler_to_pdb_controller.go
+++ b/internal/controller/autoscaler_to_pdb_controller.go
@@ -179,10 +179,13 @@ func (r *AutoscalerToPDBReconciler) resolveDeploymentName(ctx context.Context, r
 // isSurgeActiveOnAutoscaler checks whether the HPA or ScaledObject identified by req
 // has the evictionSurgeReplicas annotation, indicating an active surge.
 func (r *AutoscalerToPDBReconciler) isSurgeActiveOnAutoscaler(ctx context.Context, req ctrl.Request) bool {
+	logger := log.FromContext(ctx)
+
 	// Check HPA
 	var hpa autoscalingv2.HorizontalPodAutoscaler
 	if err := r.Get(ctx, req.NamespacedName, &hpa); err == nil {
 		if _, exists := hpa.Annotations[EvictionSurgeReplicasAnnotationKey]; exists {
+			logger.V(1).Info("Surge active on HPA", "hpa", hpa.Name, "namespace", hpa.Namespace)
 			return true
 		}
 	}
@@ -195,6 +198,7 @@ func (r *AutoscalerToPDBReconciler) isSurgeActiveOnAutoscaler(ctx context.Contex
 	if err := r.Get(ctx, req.NamespacedName, scaledObj); err == nil {
 		annotations := scaledObj.GetAnnotations()
 		if _, exists := annotations[EvictionSurgeReplicasAnnotationKey]; exists {
+			logger.V(1).Info("Surge active on ScaledObject", "scaledObject", scaledObj.GetName(), "namespace", scaledObj.GetNamespace())
 			return true
 		}
 	}

--- a/internal/controller/calculate_surge_test.go
+++ b/internal/controller/calculate_surge_test.go
@@ -1,0 +1,130 @@
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ = Describe("calculateSurge", func() {
+	ctx := context.Background()
+
+	It("should add integer maxSurge to minReplicas", func() {
+		surge := intstr.FromInt(1)
+		maxUnavailable := intstr.FromInt(0)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxSurge:       &surge,
+						MaxUnavailable: &maxUnavailable,
+					},
+				},
+			},
+		}
+		target := &DeploymentWrapper{obj: dep}
+		result, err := calculateSurge(ctx, target, 2)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(int32(3))) // 2 + 1
+	})
+
+	It("should add percentage maxSurge with ceiling", func() {
+		surge := intstr.FromString("25%")
+		maxUnavailable := intstr.FromInt(0)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxSurge:       &surge,
+						MaxUnavailable: &maxUnavailable,
+					},
+				},
+			},
+		}
+		target := &DeploymentWrapper{obj: dep}
+		result, err := calculateSurge(ctx, target, 3)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(int32(4))) // 3 + ceil(3*0.25) = 3 + 1
+	})
+
+	It("should round up percentage surge", func() {
+		surge := intstr.FromString("50%")
+		maxUnavailable := intstr.FromInt(0)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxSurge:       &surge,
+						MaxUnavailable: &maxUnavailable,
+					},
+				},
+			},
+		}
+		target := &DeploymentWrapper{obj: dep}
+		result, err := calculateSurge(ctx, target, 1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(int32(2))) // 1 + ceil(1*0.5) = 1 + 1
+	})
+
+	It("should return error for invalid percentage string", func() {
+		surge := intstr.FromString("abc%")
+		maxUnavailable := intstr.FromInt(0)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxSurge:       &surge,
+						MaxUnavailable: &maxUnavailable,
+					},
+				},
+			},
+		}
+		target := &DeploymentWrapper{obj: dep}
+		_, err := calculateSurge(ctx, target, 2)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid surge percentage"))
+	})
+
+	It("should return 0 surge when maxSurge is 0", func() {
+		surge := intstr.FromInt(0)
+		maxUnavailable := intstr.FromInt(0)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxSurge:       &surge,
+						MaxUnavailable: &maxUnavailable,
+					},
+				},
+			},
+		}
+		target := &DeploymentWrapper{obj: dep}
+		result, err := calculateSurge(ctx, target, 2)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(int32(2))) // 2 + 0
+	})
+
+	It("should return minReplicas when strategy is Recreate (no maxSurge)", func() {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					Type: appsv1.RecreateDeploymentStrategyType,
+				},
+			},
+		}
+		target := &DeploymentWrapper{obj: dep}
+		result, err := calculateSurge(ctx, target, 2)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(int32(2))) // No surge, maxSurge defaults to 0
+	})
+})

--- a/internal/controller/hpa_surge_applier.go
+++ b/internal/controller/hpa_surge_applier.go
@@ -55,7 +55,15 @@ func (h *HPASurgeApplier) ApplySurge(ctx context.Context, surgeReplicas int32) e
 	// deployment's metadata, avoiding unnecessary generation tracking complexity.
 	if h.hpa.Annotations == nil || h.hpa.Annotations[EvictionSurgeReplicasAnnotationKey] != surgeVal {
 		hpa := h.hpa.DeepCopy()
-		originalMin := int32(1) // default
+		// When minReplicas is nil, Kubernetes defaults it to 1 for standard HPAs.
+		// With KEDA, nil minReplicas can mean scale-to-zero is enabled, indicating
+		// the user doesn't require minimum availability. In that case, creating a
+		// PDB/EvictionAutoScaler may not be appropriate — but that decision belongs
+		// in the PDB creation logic, not here. If we get here, we have an EA and
+		// should surge.
+		// TODO: Consider skipping PDB/EA creation for HPAs with nil minReplicas
+		// (scale-to-zero workloads) in the deployment-to-pdb controller.
+		originalMin := int32(1) // Kubernetes default when minReplicas is nil
 		if hpa.Spec.MinReplicas != nil {
 			originalMin = *hpa.Spec.MinReplicas
 		}
@@ -74,7 +82,11 @@ func (h *HPASurgeApplier) ApplySurge(ctx context.Context, surgeReplicas int32) e
 	}
 
 	// Step 2: Set deployment replicas directly for immediate scale-up.
-	// See type-level comment for why this is needed alongside the HPA update.
+	// This is a time-saving optimization — the HPA would eventually enforce
+	// minReplicas on its next sync (~15s), but setting replicas directly
+	// triggers pod creation immediately. This also handles the edge case
+	// where the HPA cannot compute metrics (e.g., no metrics-server).
+	// See type-level comment for full rationale.
 	// On 409 Conflict (stale resourceVersion), the error propagates to the
 	// reconcile loop which requeues. On retry, step 1 is skipped (idempotent)
 	// and step 2 retries with a fresh object from the informer cache.
@@ -93,8 +105,12 @@ func (h *HPASurgeApplier) RevertSurge(ctx context.Context, originalMinReplicas i
 	logger := log.FromContext(ctx)
 
 	// Read the original minReplicas from the HPA annotation if available.
-	// This is the pre-surge value stored during ApplySurge, making the HPA
-	// self-describing for revert without depending on EA.Status.MinReplicas.
+	// The annotation takes priority over EA.Status.MinReplicas because:
+	//   1. It's self-describing — the HPA carries its own revert value
+	//   2. It was set atomically with the surge in ApplySurge
+	//   3. EA.Status.MinReplicas could be stale if the controller restarted
+	// Falls back to the passed-in originalMinReplicas (from EA.Status) if
+	// the annotation is missing (e.g., manual annotation removal).
 	revertTo := originalMinReplicas
 	if h.hpa.Annotations != nil {
 		if val, exists := h.hpa.Annotations[OriginalMinReplicasAnnotationKey]; exists {

--- a/internal/controller/hpa_surge_applier_test.go
+++ b/internal/controller/hpa_surge_applier_test.go
@@ -1,0 +1,236 @@
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func createHPA(name, namespace, targetDeployment string, minReplicas int32) *autoscalingv2.HorizontalPodAutoscaler {
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       targetDeployment,
+			},
+			MinReplicas: &minReplicas,
+			MaxReplicas: 10,
+		},
+	}
+}
+
+var _ = Describe("HPASurgeApplier", func() {
+	var (
+		namespace string
+		ctx       context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespaceObj := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-hpa-surge-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, namespaceObj)).To(Succeed())
+		namespace = namespaceObj.Name
+	})
+
+	It("should update HPA minReplicas and annotate HPA on ApplySurge", func() {
+		// Create deployment and HPA
+		maxUnavailable := intstr.FromInt(0)
+		dep := createDeployment("hpa-apply", namespace, "hpa-apply", 1, &maxUnavailable)
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		hpa := createHPA("hpa-apply", namespace, "hpa-apply", 1)
+		Expect(k8sClient.Create(ctx, hpa)).To(Succeed())
+
+		target := &DeploymentWrapper{obj: dep}
+		applier := &HPASurgeApplier{client: k8sClient, hpa: hpa, target: target}
+
+		err := applier.ApplySurge(ctx, 3)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify HPA was updated
+		var updatedHPA autoscalingv2.HorizontalPodAutoscaler
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(hpa), &updatedHPA)).To(Succeed())
+		Expect(*updatedHPA.Spec.MinReplicas).To(Equal(int32(3)))
+		Expect(updatedHPA.Annotations).To(HaveKeyWithValue(EvictionSurgeReplicasAnnotationKey, "3"))
+		Expect(updatedHPA.Annotations).To(HaveKeyWithValue(OriginalMinReplicasAnnotationKey, "1"))
+
+		// Verify deployment replicas were set directly
+		var updatedDep appsv1.Deployment
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dep), &updatedDep)).To(Succeed())
+		Expect(*updatedDep.Spec.Replicas).To(Equal(int32(3)))
+	})
+
+	It("should be idempotent on retry (skip HPA update if already surged)", func() {
+		maxUnavailable := intstr.FromInt(0)
+		dep := createDeployment("hpa-idempotent", namespace, "hpa-idempotent", 1, &maxUnavailable)
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		hpa := createHPA("hpa-idempotent", namespace, "hpa-idempotent", 1)
+		Expect(k8sClient.Create(ctx, hpa)).To(Succeed())
+
+		target := &DeploymentWrapper{obj: dep}
+		applier := &HPASurgeApplier{client: k8sClient, hpa: hpa, target: target}
+
+		// First call
+		Expect(applier.ApplySurge(ctx, 3)).To(Succeed())
+
+		// Re-fetch to get fresh objects (simulating a retry reconcile)
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(hpa), hpa)).To(Succeed())
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dep), dep)).To(Succeed())
+		applier = &HPASurgeApplier{client: k8sClient, hpa: hpa, target: &DeploymentWrapper{obj: dep}}
+
+		// Second call should succeed without conflict
+		Expect(applier.ApplySurge(ctx, 3)).To(Succeed())
+
+		// Values should still be correct
+		var updatedHPA autoscalingv2.HorizontalPodAutoscaler
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(hpa), &updatedHPA)).To(Succeed())
+		Expect(*updatedHPA.Spec.MinReplicas).To(Equal(int32(3)))
+		Expect(updatedHPA.Annotations).To(HaveKeyWithValue(EvictionSurgeReplicasAnnotationKey, "3"))
+	})
+
+	It("should store original minReplicas in annotation", func() {
+		maxUnavailable := intstr.FromInt(0)
+		dep := createDeployment("hpa-original", namespace, "hpa-original", 1, &maxUnavailable)
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		// HPA starts with minReplicas=2
+		hpa := createHPA("hpa-original", namespace, "hpa-original", 2)
+		Expect(k8sClient.Create(ctx, hpa)).To(Succeed())
+
+		target := &DeploymentWrapper{obj: dep}
+		applier := &HPASurgeApplier{client: k8sClient, hpa: hpa, target: target}
+
+		Expect(applier.ApplySurge(ctx, 4)).To(Succeed())
+
+		var updatedHPA autoscalingv2.HorizontalPodAutoscaler
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(hpa), &updatedHPA)).To(Succeed())
+		// Original was 2, surged to 4
+		Expect(updatedHPA.Annotations).To(HaveKeyWithValue(OriginalMinReplicasAnnotationKey, "2"))
+		Expect(*updatedHPA.Spec.MinReplicas).To(Equal(int32(4)))
+	})
+
+	It("should revert HPA minReplicas using original annotation on RevertSurge", func() {
+		maxUnavailable := intstr.FromInt(0)
+		dep := createDeployment("hpa-revert", namespace, "hpa-revert", 3, &maxUnavailable)
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		// HPA is in surged state: minReplicas=3, annotations set
+		hpa := createHPA("hpa-revert", namespace, "hpa-revert", 3)
+		hpa.Annotations = map[string]string{
+			EvictionSurgeReplicasAnnotationKey: "3",
+			OriginalMinReplicasAnnotationKey:   "1",
+		}
+		Expect(k8sClient.Create(ctx, hpa)).To(Succeed())
+
+		target := &DeploymentWrapper{obj: dep}
+		applier := &HPASurgeApplier{client: k8sClient, hpa: hpa, target: target}
+
+		// RevertSurge passes EA.Status.MinReplicas but HPASurgeApplier reads from annotation
+		Expect(applier.RevertSurge(ctx, 999)).To(Succeed()) // 999 should be ignored
+
+		var updatedHPA autoscalingv2.HorizontalPodAutoscaler
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(hpa), &updatedHPA)).To(Succeed())
+		// Should revert to 1 (from annotation), not 999
+		Expect(*updatedHPA.Spec.MinReplicas).To(Equal(int32(1)))
+		Expect(updatedHPA.Annotations).ToNot(HaveKey(EvictionSurgeReplicasAnnotationKey))
+		Expect(updatedHPA.Annotations).ToNot(HaveKey(OriginalMinReplicasAnnotationKey))
+	})
+
+	It("should fall back to passed originalMinReplicas when annotation is missing", func() {
+		maxUnavailable := intstr.FromInt(0)
+		dep := createDeployment("hpa-fallback", namespace, "hpa-fallback", 3, &maxUnavailable)
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		// HPA in surged state but missing the original annotation
+		hpa := createHPA("hpa-fallback", namespace, "hpa-fallback", 3)
+		hpa.Annotations = map[string]string{
+			EvictionSurgeReplicasAnnotationKey: "3",
+		}
+		Expect(k8sClient.Create(ctx, hpa)).To(Succeed())
+
+		target := &DeploymentWrapper{obj: dep}
+		applier := &HPASurgeApplier{client: k8sClient, hpa: hpa, target: target}
+
+		Expect(applier.RevertSurge(ctx, 2)).To(Succeed())
+
+		var updatedHPA autoscalingv2.HorizontalPodAutoscaler
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(hpa), &updatedHPA)).To(Succeed())
+		// Falls back to passed value since annotation is missing
+		Expect(*updatedHPA.Spec.MinReplicas).To(Equal(int32(2)))
+	})
+
+	It("should not set deployment replicas on RevertSurge (let HPA handle scale-down)", func() {
+		maxUnavailable := intstr.FromInt(0)
+		dep := createDeployment("hpa-no-scaledown", namespace, "hpa-no-scaledown", 3, &maxUnavailable)
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		hpa := createHPA("hpa-no-scaledown", namespace, "hpa-no-scaledown", 3)
+		hpa.Annotations = map[string]string{
+			EvictionSurgeReplicasAnnotationKey: "3",
+			OriginalMinReplicasAnnotationKey:   "1",
+		}
+		Expect(k8sClient.Create(ctx, hpa)).To(Succeed())
+
+		target := &DeploymentWrapper{obj: dep}
+		applier := &HPASurgeApplier{client: k8sClient, hpa: hpa, target: target}
+
+		Expect(applier.RevertSurge(ctx, 1)).To(Succeed())
+
+		// Deployment replicas should NOT have changed (still 3)
+		var updatedDep appsv1.Deployment
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dep), &updatedDep)).To(Succeed())
+		Expect(*updatedDep.Spec.Replicas).To(Equal(int32(3)))
+	})
+
+	Context("IsSurgeActive", func() {
+		It("should return true when HPA has surge annotation", func() {
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						EvictionSurgeReplicasAnnotationKey: "3",
+					},
+				},
+			}
+			applier := &HPASurgeApplier{hpa: hpa}
+			Expect(applier.IsSurgeActive()).To(BeTrue())
+		})
+
+		It("should return false when HPA has no surge annotation", func() {
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"other": "value"},
+				},
+			}
+			applier := &HPASurgeApplier{hpa: hpa}
+			Expect(applier.IsSurgeActive()).To(BeFalse())
+		})
+
+		It("should return false when HPA has nil annotations", func() {
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+			applier := &HPASurgeApplier{hpa: hpa}
+			Expect(applier.IsSurgeActive()).To(BeFalse())
+		})
+	})
+
+	It("should return 'hpa' as Name", func() {
+		applier := &HPASurgeApplier{}
+		Expect(applier.Name()).To(Equal("hpa"))
+	})
+})

--- a/internal/controller/node_reconciler.go
+++ b/internal/controller/node_reconciler.go
@@ -162,11 +162,12 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Node{}).
 		WithEventFilter(predicate.Funcs{
-			// ignore status updates as we only care about cordon.
+			// Only reconcile when Unschedulable changes (cordon/uncordon), not on
+			// status-only updates like node heartbeats or condition changes.
 			UpdateFunc: func(ue event.UpdateEvent) bool {
 				oldNode := ue.ObjectOld.(*corev1.Node)
 				newNode := ue.ObjectNew.(*corev1.Node)
-				return oldNode.Spec.Unschedulable == newNode.Spec.Unschedulable
+				return oldNode.Spec.Unschedulable != newNode.Spec.Unschedulable
 			},
 		}).
 		Complete(r)


### PR DESCRIPTION
- Document HPA surge annotations in README
- Implement logging for surge activity in AutoscalerToPDBReconciler
- Enhance HPASurgeApplier to handle minReplicas and surge annotations
- Add tests for surge calculation and HPASurgeApplier functionality