### PR TITLE
skip statefulsets

### DIFF
--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -95,7 +95,15 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler)
 	}
 
-	// Fetch the Deployment or Statefulset
+	// StatefulSets are intentionally skipped — their ordered pod management
+	// semantics conflict with the eviction surge strategy.
+	if strings.EqualFold(EvictionAutoScaler.Spec.TargetKind, statefulSetKind) {
+		logger.V(1).Info("skipping StatefulSet target, not supported for eviction surge",
+			"targetname", EvictionAutoScaler.Spec.TargetName)
+		return ctrl.Result{}, nil
+	}
+
+	// Fetch the Deployment target
 	// TODO enum validation https://book.kubebuilder.io/reference/generating-crd#validation
 	target, err := GetSurger(EvictionAutoScaler.Spec.TargetKind)
 	if err != nil {

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -232,9 +232,9 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			Expect(*deployment.Spec.Replicas).To(Equal(int32(2))) // Change as needed to verify scaling
 		})
 
-		It("should deal with an eviction when allowedDisruptions == 0 for statefulset!", func() {
+		It("should skip StatefulSet targets without surging", func() {
 
-			By("creating a Deployment resource")
+			By("creating a StatefulSet resource")
 			statefulSet := &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      statefulSetName,
@@ -247,19 +247,14 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 							"app": "example",
 						},
 					},
-					/*Strategy: appsv1.StatefulSetStrategy{
-						RollingUpdate: &appsv1.RollingUpdateDeployment{
-							MaxSurge: &surge,
-						},
-					},*/
-					Template: corev1.PodTemplateSpec{ // Use corev1.PodTemplateSpec
+					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
 								"app": "example",
 							},
 						},
-						Spec: corev1.PodSpec{ // Use corev1.PodSpec
-							Containers: []corev1.Container{ // Use corev1.Container
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
 								{
 									Name:  "nginx",
 									Image: "nginx:latest",
@@ -278,14 +273,13 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			EvictionAutoScaler.Spec.TargetKind = "statefulset"
 			Expect(k8sClient.Update(ctx, EvictionAutoScaler)).To(Succeed())
 
-			By("scaling up on reconcile")
+			By("reconciling and verifying StatefulSet is skipped")
 			controllerReconciler := &EvictionAutoScalerReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 				Filter: &evictionTestFilter{},
 			}
 
-			// run it once to populate target genration
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
@@ -295,7 +289,7 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			err = k8sClient.Get(ctx, typeNamespacedName, EvictionAutoScaler)
 			Expect(err).NotTo(HaveOccurred())
 			EvictionAutoScaler.Spec.LastEviction = v1.Eviction{
-				PodName:      "somepod", //
+				PodName:      "somepod",
 				EvictionTime: metav1.Now(),
 			}
 			Expect(k8sClient.Update(ctx, EvictionAutoScaler)).To(Succeed())
@@ -305,16 +299,10 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Verify EvictionAutoScaler resource
-			err = k8sClient.Get(ctx, typeNamespacedName, EvictionAutoScaler)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(EvictionAutoScaler.Spec.LastEviction.PodName).To(Equal("somepod"))
-			Expect(EvictionAutoScaler.Spec.LastEviction.EvictionTime).To(Equal(EvictionAutoScaler.Spec.LastEviction.EvictionTime))
-
-			// Verify Deployment scaling if necessary
+			// Verify StatefulSet replicas are unchanged (skip, no surge)
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: statefulSetName, Namespace: namespace}, statefulSet)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(*statefulSet.Spec.Replicas).To(Equal(int32(2))) // Change as needed to verify scaling
+			Expect(*statefulSet.Spec.Replicas).To(Equal(int32(1)))
 		})
 
 		//should this be merged with above?


### PR DESCRIPTION
This pull request updates the `EvictionAutoScaler` controller to explicitly skip handling `StatefulSet` targets, as their ordered pod management is incompatible with the eviction surge strategy. The main change ensures that only supported target types (e.g., Deployments) are processed.

Changes to target handling:

* Updated the `Reconcile` method in `evictionautoscaler_controller.go` to detect when the `EvictionAutoScaler` resource targets a `StatefulSet`, log an informational message, and exit early without attempting to scale or evict pods for that target. (`[internal/controller/evictionautoscaler_controller.goL98-R106](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddL98-R106)`)