### PR TITLE
Remove Helm installation instructions from README and create a separa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,90 +70,7 @@ graph TD;
 
 ### Install
 
-You can install Eviction-Autoscaler using the Azure Kubernetes Extension Resource Provider (RP) or via Helm.
-
-### Install via Helm
-
-1. Add the eviction-autoscaler Helm repository:
-
-    ```bash
-    helm repo add eviction-autoscaler https://azure.github.io/eviction-autoscaler/charts
-    helm repo update
-    ```
-
-2. Install the chart into your cluster:
-
-    ```bash
-    helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
-          --namespace eviction-autoscaler --create-namespace \
-          --set controllerConfig.pdb.create=true
-    ```
-
-**Configuration Examples:**
-
-Enable PDB creation and specify target namespaces:
-```bash
-helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
-      --namespace eviction-autoscaler --create-namespace \
-      --set controllerConfig.pdb.create=true \
-      --set controllerConfig.namespaces.actionedNamespaces="{kube-system,default}"
-```
-
-Enable eviction-autoscaler for all namespaces by default:
-```bash
-helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
-      --namespace eviction-autoscaler --create-namespace \
-      --set controllerConfig.pdb.create=false \
-      --set controllerConfig.namespaces.enabledByDefault=true
-```
-
-> **Note:** Setting `pdb.create=true` will automatically create a PodDisruptionBudget (PDB) for deployments that do not already have one, ensuring your workloads are protected and enabling eviction-autoscaler to manage disruptions effectively.
->
-> If a deployment already has a PDB whose label selector matches the deployment's pod template labels, eviction-autoscaler will **not** create a new PDB—even if `pdb.create=true`. This avoids duplicate PDBs and ensures existing disruption budgets are respected.
->
-> For example, if you deploy an app without a PDB:
->
-> ```yaml
-> apiVersion: apps/v1
-> kind: Deployment
-> metadata:
->   name: my-app
->   namespace: default
-> spec:
->   replicas: 2
->   selector:
->     matchLabels:
->       app: my-app
->   template:
->     metadata:
->       labels:
->         app: my-app
->     spec:
->       containers:
->       - name: my-app
->         image: nginx
-> ```
->
-> With `pdb.create=true`, eviction-autoscaler will automatically create a matching PDB:
->
-> ```yaml
-> apiVersion: policy/v1
-> kind: PodDisruptionBudget
-> metadata:
->   name: my-app
->   namespace: default
-> spec:
->   minAvailable: 2
->   selector:
->     matchLabels:
->       app: my-app
-> ```
->
-> If a matching PDB already exists, eviction-autoscaler will not create another. If you later disable `pdb.create`, eviction-autoscaler will not delete any existing PDBs—it will simply stop creating new ones.
-
-3. (Optional) Customize values by passing `--values my-values.yaml` or using `--set key=value`.
-
-Refer to the [Helm Values](https://github.com/Azure/eviction-autoscaler/blob/main/helm/eviction-autoscaler/values.yaml) for configuration options.
+You can install Eviction-Autoscaler using the Azure Kubernetes Extension Resource Provider (RP).
 
 ### Install via Azure Kubernetes Extension RP
 
@@ -289,7 +206,7 @@ metadata:
         eviction-autoscaler.azure.com/pdb-create: "false"
 ```
 
-This annotation instructs eviction-autoscaler not to create a PDB for that deployment, regardless of whether you installed via Helm or the Azure Kubernetes Extension Resource Provider.
+This annotation instructs eviction-autoscaler not to create a PDB for that deployment, regardless of whether you installed via the Azure Kubernetes Extension Resource Provider.
 
 ### Deployments with MaxUnavailable
 
@@ -341,30 +258,6 @@ When `ENABLED_BY_DEFAULT=false` (the default), eviction autoscaler operates as f
 - Other namespaces can be **enabled** by adding the annotation `eviction-autoscaler.azure.com/enable: "true"`
 - Namespaces in `ACTIONED_NAMESPACES` can be **overridden** with annotation `eviction-autoscaler.azure.com/enable: "false"`
 
-**Configuration via Helm:**
-
-```bash
-helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
-  --namespace eviction-autoscaler --create-namespace \
-  --set controllerConfig.pdb.create=true \
-  --set controllerConfig.namespaces.enabledByDefault=false \
-  --set-json 'controllerConfig.namespaces.actionedNamespaces=["kube-system","production","staging"]'
-```
-
-Or via values.yaml:
-
-```yaml
-controllerConfig:
-  pdb:
-    create: true
-  namespaces:
-    enabledByDefault: false  # Namespaces disabled by default (default)
-    actionedNamespaces:
-      - kube-system
-      - production
-      - staging
-```
-
 **Configuration via environment variables:**
 
 ```bash
@@ -397,26 +290,6 @@ When `ENABLED_BY_DEFAULT=true` is set, eviction autoscaler operates as follows:
 - **`ACTIONED_NAMESPACES` is ignored** - only annotations control which namespaces are disabled
 - Namespaces can be **disabled** by adding the annotation `eviction-autoscaler.azure.com/enable: "false"`
 - Namespaces can be **explicitly enabled** with annotation `eviction-autoscaler.azure.com/enable: "true"` (though they're already enabled by default)
-
-**Configuration via Helm:**
-
-```bash
-helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
-  --namespace eviction-autoscaler --create-namespace \
-  --set controllerConfig.pdb.create=true \
-  --set controllerConfig.namespaces.enabledByDefault=true
-```
-
-Or via values.yaml:
-
-```yaml
-controllerConfig:
-  pdb:
-    create: true
-  namespaces:
-    enabledByDefault: true  # Namespaces enabled by default
-    actionedNamespaces: []   # Ignored when enabled_by_default=true
-```
 
 **Configuration via environment variables:**
 
@@ -532,16 +405,6 @@ Namespace watches trigger reconciliation by listing all deployments/PDBs in that
 - Fast local memory operations
 
 #### Example: enabled_by_default=false Configuration
-
-**Via Helm:**
-
-```bash
-helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
-  --namespace eviction-autoscaler --create-namespace \
-  --set controllerConfig.pdb.create=true \
-  --set controllerConfig.namespaces.enabledByDefault=true \
-  --set-json 'controllerConfig.namespaces.actionedNamespaces=["kube-system","production"]'
-```
 
 **Via environment variables:**
 

--- a/private/helm-instructions.md
+++ b/private/helm-instructions.md
@@ -1,0 +1,140 @@
+# Eviction-Autoscaler Helm Installation
+
+## Install via Helm
+
+1. Add the eviction-autoscaler Helm repository:
+
+    ```bash
+    helm repo add eviction-autoscaler https://azure.github.io/eviction-autoscaler/charts
+    helm repo update
+    ```
+
+2. Install the chart into your cluster:
+
+    ```bash
+    helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
+          --namespace eviction-autoscaler --create-namespace \
+          --set controllerConfig.pdb.create=true
+    ```
+
+**Configuration Examples:**
+
+Enable PDB creation and specify target namespaces:
+```bash
+helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
+      --namespace eviction-autoscaler --create-namespace \
+      --set controllerConfig.pdb.create=true \
+      --set controllerConfig.namespaces.actionedNamespaces="{kube-system,default}"
+```
+
+Enable eviction-autoscaler for all namespaces by default:
+```bash
+helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
+      --namespace eviction-autoscaler --create-namespace \
+      --set controllerConfig.pdb.create=false \
+      --set controllerConfig.namespaces.enabledByDefault=true
+```
+
+> **Note:** Setting `pdb.create=true` will automatically create a PodDisruptionBudget (PDB) for deployments that do not already have one, ensuring your workloads are protected and enabling eviction-autoscaler to manage disruptions effectively.
+>
+> If a deployment already has a PDB whose label selector matches the deployment's pod template labels, eviction-autoscaler will **not** create a new PDB—even if `pdb.create=true`. This avoids duplicate PDBs and ensures existing disruption budgets are respected.
+>
+> For example, if you deploy an app without a PDB:
+>
+> ```yaml
+> apiVersion: apps/v1
+> kind: Deployment
+> metadata:
+>   name: my-app
+>   namespace: default
+> spec:
+>   replicas: 2
+>   selector:
+>     matchLabels:
+>       app: my-app
+>   template:
+>     metadata:
+>       labels:
+>         app: my-app
+>     spec:
+>       containers:
+>       - name: my-app
+>         image: nginx
+> ```
+>
+> With `pdb.create=true`, eviction-autoscaler will automatically create a matching PDB:
+>
+> ```yaml
+> apiVersion: policy/v1
+> kind: PodDisruptionBudget
+> metadata:
+>   name: my-app
+>   namespace: default
+> spec:
+>   minAvailable: 2
+>   selector:
+>     matchLabels:
+>       app: my-app
+> ```
+>
+> If a matching PDB already exists, eviction-autoscaler will not create another. If you later disable `pdb.create`, eviction-autoscaler will not delete any existing PDBs—it will simply stop creating new ones.
+
+3. (Optional) Customize values by passing `--values my-values.yaml` or using `--set key=value`.
+
+Refer to the [Helm Values](https://github.com/Azure/eviction-autoscaler/blob/main/helm/eviction-autoscaler/values.yaml) for configuration options.
+
+## Namespace Configuration via Helm
+
+### Mode 1: `ENABLED_BY_DEFAULT=false` (Default)
+
+```bash
+helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
+  --namespace eviction-autoscaler --create-namespace \
+  --set controllerConfig.pdb.create=true \
+  --set controllerConfig.namespaces.enabledByDefault=false \
+  --set-json 'controllerConfig.namespaces.actionedNamespaces=["kube-system","production","staging"]'
+```
+
+Or via values.yaml:
+
+```yaml
+controllerConfig:
+  pdb:
+    create: true
+  namespaces:
+    enabledByDefault: false  # Namespaces disabled by default (default)
+    actionedNamespaces:
+      - kube-system
+      - production
+      - staging
+```
+
+### Mode 2: `ENABLED_BY_DEFAULT=true`
+
+```bash
+helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
+  --namespace eviction-autoscaler --create-namespace \
+  --set controllerConfig.pdb.create=true \
+  --set controllerConfig.namespaces.enabledByDefault=true
+```
+
+Or via values.yaml:
+
+```yaml
+controllerConfig:
+  pdb:
+    create: true
+  namespaces:
+    enabledByDefault: true  # Namespaces enabled by default
+    actionedNamespaces: []   # Ignored when enabled_by_default=true
+```
+
+### Example: enabled_by_default=false Configuration
+
+```bash
+helm install eviction-autoscaler eviction-autoscaler/eviction-autoscaler \
+  --namespace eviction-autoscaler --create-namespace \
+  --set controllerConfig.pdb.create=true \
+  --set controllerConfig.namespaces.enabledByDefault=true \
+  --set-json 'controllerConfig.namespaces.actionedNamespaces=["kube-system","production"]'
+```


### PR DESCRIPTION
…te helm-instructions.md file
This pull request restructures the installation documentation for Eviction-Autoscaler by moving all Helm-specific installation and configuration instructions from the main `README.md` into a new, dedicated file (`private/helm-instructions.md`). The main `README.md` now focuses on installation via the Azure Kubernetes Extension Resource Provider (RP), reducing duplication and clarifying the primary installation path. References to Helm installation and configuration examples have been removed from the `README.md` and consolidated in the new file.

**Documentation Restructuring:**

* All Helm installation and configuration instructions, including example commands and configuration options, have been removed from `README.md` and placed into a new file `private/helm-instructions.md`. This centralizes Helm-related guidance and keeps the main documentation focused on the recommended installation method. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L344-L367) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L401-L420) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L536-L545) [[5]](diffhunk://#diff-4185e4343d75e949c7fd76aec520e5b25f2e5ea9cefb5e9bb2c085204e5ab59aR1-R140)
* The annotation documentation and examples in `README.md` have been updated to remove references to Helm, ensuring consistency with the new documentation structure.

These changes improve the clarity and maintainability of the documentation by separating concerns and reducing redundancy.