### PR TITLE
Partial revert pending pods

### DIFF
--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -225,6 +225,52 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Track scaling opportunity
 		metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleDownAction, metrics.CooldownElapsedSignal).Inc()
 
+		// Before doing a full revert, check whether surge pods are still Pending due to
+		// capacity pressure (new node pool warming up, cluster autoscaler still ramping).
+		// If so, trim to partialTarget — the minimum replicas that keep the PDB open by 1
+		// disruption — rather than holding the full surge batch in Pending state. This
+		// releases scheduler slots and CA pressure. The trim fires at most once per surge
+		// cycle: on the next reconcile target.GetReplicas() == partialTarget, so the
+		// condition target.GetReplicas() > partialTarget is false and we fall through to a
+		// normal full revert.
+		pendingCount, pendingErr := countUnschedulablePodsForTarget(ctx, r.Client, EvictionAutoScaler.Namespace, pdb)
+		if pendingErr != nil {
+			logger.Error(pendingErr, "failed to count pending pods, proceeding with full revert")
+		}
+
+		// resolveMinAvailableInt computes against MinReplicas (pre-surge baseline), NOT the
+		// current surged replica count. For percentage PDBs this gives the smallest valid
+		// partialTarget: the percentage is evaluated at the pre-surge level, so after
+		// trimming, Kubernetes recomputes DesiredHealthy against the smaller count and the
+		// result is equal or smaller — keeping DisruptionsAllowed >= 1. Using the surged
+		// count (or pdb.Status.DesiredHealthy, which is the same thing) would overshoot and
+		// trim less aggressively than needed, leaving more pods Pending unnecessarily.
+		minAvailable := resolveMinAvailableInt(pdb, EvictionAutoScaler.Status.MinReplicas)
+		// partialTarget satisfies both constraints:
+		//   minAvailable+1    — minimum replicas to open the PDB by exactly 1 disruption
+		//   MinReplicas+1     — stay at least 1 above the pre-surge baseline so we remain
+		//                       in surge state and never accidentally drop to or below baseline
+		partialTarget := max(minAvailable+1, EvictionAutoScaler.Status.MinReplicas+1)
+
+		if pendingErr == nil && pendingCount > 0 && target.GetReplicas() > partialTarget {
+			// Trim excess surge pods to partialTarget. ApplySurge is used (not RevertSurge)
+			// so the HPA/KEDA floor is lowered atomically before the replica count drops,
+			// preventing the autoscaler from fighting back to the original surge level.
+			logger.Info("Unschedulable surge pods detected, trimming to minimum needed to reduce capacity pressure",
+				"unschedulableCount", pendingCount,
+				"currentReplicas", target.GetReplicas(),
+				"partialTarget", partialTarget,
+				"strategy", surgeApplier.Name())
+			if err = surgeApplier.ApplySurge(ctx, partialTarget); err != nil {
+				logger.Error(err, "failed to trim surge to partial target")
+				return ctrl.Result{}, err
+			}
+			metrics.ActualScalingCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleDownAction).Inc()
+			EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
+			ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", fmt.Sprintf("trimmed surge to %d (unschedulable pods detected)", partialTarget))
+			return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
+		}
+
 		//okay we aren't at allowed disruptions Revert Target to the original state
 		err = surgeApplier.RevertSurge(ctx, EvictionAutoScaler.Status.MinReplicas)
 		if err != nil {

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	v1 "github.com/azure/eviction-autoscaler/api/v1"
@@ -1023,5 +1024,212 @@ var _ = Describe("EvictionAutoScaler Controller - unsupported autoscaler config"
 		Expect(degradedCondition.Reason).To(Equal("UnsupportedAutoscalerConfiguration"))
 		Expect(degradedCondition.Message).To(ContainSubstring("KEDA ScaledObject"))
 		Expect(degradedCondition.Message).To(ContainSubstring("standalone HPA"))
+	})
+})
+
+// --- helpers ---
+
+func makePartialRevertNamespace(ctx context.Context) string {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "partial-revert-",
+			Annotations: map[string]string{
+				namespacefilter.EnableEvictionAutoscalerAnnotationKey: "true",
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+	return ns.Name
+}
+
+// buildSurgedState creates and wires up a deployment+PDB+EA in the given namespace,
+// sets the deployment to surgedReplicas, creates pendingPodCount Pending pods matching
+// the PDB selector, and positions the EA so the next reconcile enters the scale-down
+// block (past cooldown, Spec.LastEviction != Status.LastEviction).
+// Returns the EvictionAutoScalerReconciler and the NamespacedName of the EA.
+func buildSurgedState(ctx context.Context, namespace string, surgedReplicas int32, pendingPodCount int) (
+	*EvictionAutoScalerReconciler, types.NamespacedName,
+) {
+	const depName = "surged-deploy"
+	const pdbEAName = "surged-pdb"
+	appLabel := pdbEAName
+
+	surge := intstr.FromInt32(3)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: depName, Namespace: namespace},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
+			Strategy: appsv1.DeploymentStrategy{
+				RollingUpdate: &appsv1.RollingUpdateDeployment{MaxSurge: &surge},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": appLabel}},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx:latest"}}},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: pdbEAName, Namespace: namespace},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &intstr.IntOrString{IntVal: 1},
+			Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
+		},
+	}
+	Expect(k8sClient.Create(ctx, pdb)).To(Succeed())
+
+	ea := &v1.EvictionAutoScaler{
+		ObjectMeta: metav1.ObjectMeta{Name: pdbEAName, Namespace: namespace},
+		Spec: v1.EvictionAutoScalerSpec{TargetName: depName, TargetKind: "deployment"},
+	}
+	Expect(k8sClient.Create(ctx, ea)).To(Succeed())
+
+	reconciler := &EvictionAutoScalerReconciler{
+		Client: k8sClient,
+		Scheme: k8sClient.Scheme(),
+		Filter: &evictionTestFilter{},
+	}
+	nn := types.NamespacedName{Name: pdbEAName, Namespace: namespace}
+
+	// First reconcile initialises TargetGeneration and MinReplicas.
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Simulate a surge: bump deployment replicas to surgedReplicas.
+	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: depName, Namespace: namespace}, dep)).To(Succeed())
+	dep.Spec.Replicas = &surgedReplicas
+	Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+	// Wire EA: old eviction (past cooldown), MinReplicas=1, TargetGeneration matches
+	// the post-surge deployment generation so the reconciler skips the generation block.
+	Expect(k8sClient.Get(ctx, nn, ea)).To(Succeed())
+	ea.Spec.LastEviction = v1.Eviction{
+		PodName:      "drained-pod",
+		EvictionTime: metav1.NewTime(time.Now().Add(-2 * cooldown)),
+	}
+	Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+	ea.Status.MinReplicas = 1
+	ea.Status.TargetGeneration = dep.Generation
+	Expect(k8sClient.Status().Update(ctx, ea)).To(Succeed())
+
+	// PDB: DisruptionsAllowed=0 (blocks drain, consistent with a tight PDB).
+	Expect(k8sClient.Get(ctx, nn, pdb)).To(Succeed())
+	pdb.Status.DisruptionsAllowed = 0
+	Expect(k8sClient.Status().Update(ctx, pdb)).To(Succeed())
+
+	// Create pendingPodCount pods in Pending phase matching the PDB selector.
+	// Set the PodScheduled condition to Unschedulable so countUnschedulablePodsForTarget
+	// counts them (Phase==Pending alone is not sufficient).
+	for i := range pendingPodCount {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("surge-pod-%d", i),
+				Namespace: namespace,
+				Labels:    map[string]string{"app": appLabel},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx:latest"}}},
+		}
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		pod.Status.Phase = corev1.PodPending
+		pod.Status.Conditions = []corev1.PodCondition{{
+			Type:    corev1.PodScheduled,
+			Status:  corev1.ConditionFalse,
+			Reason:  corev1.PodReasonUnschedulable,
+			Message: "0/2 nodes are available: 2 nodes are cordoned",
+		}}
+		Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+	}
+
+	return reconciler, nn
+}
+
+var _ = Describe("EvictionAutoScaler partial revert", func() {
+	ctx := context.Background()
+
+	It("should trim surge to partialTarget when surge pods are Pending", func() {
+		// minAvailable=1, MinReplicas=1 → partialTarget = max(2, 2) = 2
+		// surgedReplicas=4 > partialTarget=2 → trim fires
+		namespace := makePartialRevertNamespace(ctx)
+		reconciler, nn := buildSurgedState(ctx, namespace, 4, 3)
+
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+		// Requeued for another cooldown — eviction not yet marked handled.
+		Expect(result.RequeueAfter).To(Equal(cooldown))
+
+		var dep appsv1.Deployment
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "surged-deploy", Namespace: namespace}, &dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(2)), "should trim to partialTarget=2, not full revert to 1")
+
+		// Surge annotation must still be present — we're still in a surged state.
+		Expect(dep.Annotations).To(HaveKey(EvictionSurgeReplicasAnnotationKey))
+
+		// Eviction must NOT be marked handled yet.
+		var ea v1.EvictionAutoScaler
+		Expect(k8sClient.Get(ctx, nn, &ea)).To(Succeed())
+		Expect(ea.Status.LastEviction.PodName).To(BeEmpty())
+	})
+
+	It("should do full revert when already at partialTarget (one-shot trim)", func() {
+		// surgedReplicas=2 == partialTarget=2 → trim condition false → full revert
+		namespace := makePartialRevertNamespace(ctx)
+		reconciler, nn := buildSurgedState(ctx, namespace, 2, 1)
+
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero(), "full revert should not requeue")
+
+		var dep appsv1.Deployment
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "surged-deploy", Namespace: namespace}, &dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(1)), "should fully revert to MinReplicas=1")
+
+		// Eviction marked handled.
+		var ea v1.EvictionAutoScaler
+		Expect(k8sClient.Get(ctx, nn, &ea)).To(Succeed())
+		Expect(ea.Status.LastEviction.PodName).To(Equal("drained-pod"))
+	})
+
+	It("should do full revert immediately when no Pending pods exist", func() {
+		// surgedReplicas=4, but no pending pods → skip trim, full revert
+		namespace := makePartialRevertNamespace(ctx)
+		reconciler, nn := buildSurgedState(ctx, namespace, 4, 0)
+
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero(), "full revert should not requeue")
+
+		var dep appsv1.Deployment
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "surged-deploy", Namespace: namespace}, &dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(1)), "should fully revert to MinReplicas=1")
+	})
+})
+
+var _ = Describe("resolveMinAvailableInt", func() {
+	It("returns IntVal directly for integer-type spec", func() {
+		pdb := &policyv1.PodDisruptionBudget{
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MinAvailable: &intstr.IntOrString{Type: intstr.Int, IntVal: 3},
+			},
+		}
+		Expect(resolveMinAvailableInt(pdb, 10)).To(Equal(int32(3)))
+	})
+
+	It("computes ceiling percentage of baseline replicas", func() {
+		pdb := &policyv1.PodDisruptionBudget{
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MinAvailable: &intstr.IntOrString{Type: intstr.String, StrVal: "50%"},
+			},
+		}
+		// ceil(0.5 * 3) = 2
+		Expect(resolveMinAvailableInt(pdb, 3)).To(Equal(int32(2)))
+		// ceil(0.5 * 4) = 2
+		Expect(resolveMinAvailableInt(pdb, 4)).To(Equal(int32(2)))
+	})
+
+	It("returns 0 for nil MinAvailable", func() {
+		pdb := &policyv1.PodDisruptionBudget{}
+		Expect(resolveMinAvailableInt(pdb, 5)).To(Equal(int32(0)))
 	})
 })

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -1065,7 +1065,7 @@ func buildSurgedState(ctx context.Context, namespace string, surgedReplicas int3
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": appLabel}},
-				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx:latest"}}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx:latest"}}},
 			},
 		},
 	}
@@ -1082,7 +1082,7 @@ func buildSurgedState(ctx context.Context, namespace string, surgedReplicas int3
 
 	ea := &v1.EvictionAutoScaler{
 		ObjectMeta: metav1.ObjectMeta{Name: pdbEAName, Namespace: namespace},
-		Spec: v1.EvictionAutoScalerSpec{TargetName: depName, TargetKind: "deployment"},
+		Spec:       v1.EvictionAutoScalerSpec{TargetName: depName, TargetKind: "deployment"},
 	}
 	Expect(k8sClient.Create(ctx, ea)).To(Succeed())
 

--- a/internal/controller/pdb_helpers.go
+++ b/internal/controller/pdb_helpers.go
@@ -3,7 +3,9 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/apps/v1"
@@ -180,6 +182,63 @@ func tryGet(m map[string]string, key string) string {
 		return ""
 	}
 	return m[key]
+}
+
+// resolveMinAvailableInt returns the absolute (integer) minAvailable count for the PDB.
+// For integer-type specs the value is used directly. For percentage-type specs it is
+// computed against baselineReplicas (the pre-surge replica count) using ceiling division,
+// matching how the PDB controller computes desiredHealthy.
+func resolveMinAvailableInt(pdb *policyv1.PodDisruptionBudget, baselineReplicas int32) int32 {
+	if pdb.Spec.MinAvailable == nil {
+		return 0
+	}
+	ma := pdb.Spec.MinAvailable
+	if ma.Type == intstr.Int {
+		return ma.IntVal
+	}
+	// Percentage: e.g. "50%" → ceil(0.5 × baselineReplicas)
+	pct, err := strconv.Atoi(strings.TrimSuffix(ma.StrVal, "%"))
+	if err != nil || pct < 0 {
+		return 0
+	}
+	return int32(math.Ceil(float64(baselineReplicas) * float64(pct) / 100.0))
+}
+
+// countUnschedulablePodsForTarget counts pods matched by the PDB's selector that are
+// Pending AND have a PodScheduled condition with Status=False and Reason=Unschedulable.
+// This precisely identifies capacity-bound surge pods (scheduler tried but could not
+// place them) rather than pods that are transiently Pending for other reasons such as
+// image pulls, init containers, or volume binding.
+func countUnschedulablePodsForTarget(ctx context.Context, c client.Client, namespace string, pdb *policyv1.PodDisruptionBudget) (int, error) {
+	if pdb.Spec.Selector == nil {
+		return 0, nil
+	}
+	selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+	if err != nil {
+		return 0, fmt.Errorf("invalid PDB selector: %w", err)
+	}
+	var podList corev1.PodList
+	if err := c.List(ctx, &podList,
+		client.InNamespace(namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return 0, fmt.Errorf("listing pods for unschedulable check: %w", err)
+	}
+	count := 0
+	for _, pod := range podList.Items {
+		if pod.Status.Phase != corev1.PodPending {
+			continue
+		}
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodScheduled &&
+				cond.Status == corev1.ConditionFalse &&
+				cond.Reason == corev1.PodReasonUnschedulable {
+				count++
+				break
+			}
+		}
+	}
+	return count, nil
 }
 
 // triggerOnPDBAnnotationChange checks if a PDB update event should trigger reconciliation

--- a/test/e2e/e2e_helpers.go
+++ b/test/e2e/e2e_helpers.go
@@ -40,6 +40,7 @@ type deploymentConfig struct {
 	Namespace      string
 	Replicas       int32
 	MaxUnavailable int
+	MaxSurge       int // optional; 0 means use Kubernetes default (25%)
 	Annotations    map[string]string
 	CPURequest     string // optional, e.g. "10m"
 }
@@ -51,6 +52,11 @@ func createDeployment(cfg deploymentConfig) error {
 		maxUnavailable = "0"
 	} else {
 		maxUnavailable = fmt.Sprintf("%d", cfg.MaxUnavailable)
+	}
+
+	var maxSurge string
+	if cfg.MaxSurge > 0 {
+		maxSurge = fmt.Sprintf("%d", cfg.MaxSurge)
 	}
 
 	tmpl := `apiVersion: apps/v1
@@ -70,6 +76,9 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: {{.MaxUnavailable}}
+      {{- if .MaxSurge}}
+      maxSurge: {{.MaxSurge}}
+      {{- end}}
   selector:
     matchLabels:
       app: {{.Name}}
@@ -98,6 +107,7 @@ spec:
 		Namespace      string
 		Replicas       int32
 		MaxUnavailable string
+		MaxSurge       string
 		Annotations    map[string]string
 		CPURequest     string
 	}{
@@ -105,6 +115,7 @@ spec:
 		Namespace:      cfg.Namespace,
 		Replicas:       cfg.Replicas,
 		MaxUnavailable: maxUnavailable,
+		MaxSurge:       maxSurge,
 		Annotations:    cfg.Annotations,
 		CPURequest:     cfg.CPURequest,
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1515,5 +1515,149 @@ var _ = Describe("controller", Ordered, func() {
 			_, _ = utils.Run(cmd)
 			uninstallKEDA()
 		})
+
+		// Test 3: Partial revert — when surge pods are Pending due to capacity pressure
+		// the controller should trim to minAvailable+1 rather than holding the full
+		// surge batch in Pending state.
+		It("should trim surge to minAvailable+1 when surge pods cannot be scheduled", func() {
+			ctx := context.Background()
+			const partialRevertNs = "partial-revert-e2e"
+			const depName = "nginx-partial-revert"
+
+			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+			Expect(err).NotTo(HaveOccurred())
+			clientset, err := client.New(config, client.Options{Scheme: scheme})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating test namespace with eviction autoscaler enabled")
+			cmd := exec.Command("kubectl", "create", "namespace", partialRevertNs)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			cmd = exec.Command("kubectl", "annotate", "namespace", partialRevertNs,
+				"eviction-autoscaler.azure.com/enable=true")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Cleanup deferred so nodes are always uncordoned even on test failure.
+			var cordonedNodes []string
+			defer func() {
+				for _, n := range cordonedNodes {
+					cmd = exec.Command("kubectl", "uncordon", n)
+					_, _ = utils.Run(cmd)
+				}
+				cmd = exec.Command("kubectl", "delete", "namespace", partialRevertNs, "--ignore-not-found")
+				_, _ = utils.Run(cmd)
+			}()
+
+			By("creating deployment with maxSurge=3 so surge goes to 4 replicas")
+			err = createDeployment(deploymentConfig{
+				Name:           depName,
+				Namespace:      partialRevertNs,
+				Replicas:       1,
+				MaxUnavailable: 0,
+				MaxSurge:       3,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for the deployment pod to be running and noting its node")
+			var podNodeName string
+			EventuallyWithOffset(1, func() error {
+				var pods corev1.PodList
+				if err := clientset.List(ctx, &pods, client.InNamespace(partialRevertNs)); err != nil {
+					return err
+				}
+				for _, p := range pods.Items {
+					if p.Status.Phase == corev1.PodRunning && p.Spec.NodeName != "" {
+						podNodeName = p.Spec.NodeName
+						return nil
+					}
+				}
+				return fmt.Errorf("no running pod found yet")
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("waiting for PDB and EvictionAutoScaler to be created")
+			EventuallyWithOffset(1, func() error {
+				return verifyPdbCreated(ctx, clientset, partialRevertNs, depName)
+			}, time.Minute, time.Second).Should(Succeed())
+			EventuallyWithOffset(1, func() error {
+				return verifyEvictionAutoScalerCreated(ctx, clientset, partialRevertNs, depName)
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("cordoning all worker nodes so surge pods cannot be scheduled")
+			var allNodes corev1.NodeList
+			Expect(clientset.List(ctx, &allNodes)).To(Succeed())
+			for _, n := range allNodes.Items {
+				if _, isCP := n.Labels["node-role.kubernetes.io/control-plane"]; isCP {
+					continue // leave control-plane alone
+				}
+				if n.Name == podNodeName {
+					continue // cordon pod's node last (it triggers the surge)
+				}
+				cmd = exec.Command("kubectl", "cordon", n.Name)
+				_, err = utils.Run(cmd)
+				Expect(err).NotTo(HaveOccurred())
+				cordonedNodes = append(cordonedNodes, n.Name)
+			}
+
+			By(fmt.Sprintf("cordoning pod's node %s to trigger node reconciler", podNodeName))
+			cmd = exec.Command("kubectl", "cordon", podNodeName)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			cordonedNodes = append(cordonedNodes, podNodeName)
+
+			By("waiting for surge: deployment should scale to 4 replicas")
+			var dep appsv1.Deployment
+			EventuallyWithOffset(1, func() error {
+				if err := clientset.Get(ctx, client.ObjectKey{Name: depName, Namespace: partialRevertNs}, &dep); err != nil {
+					return err
+				}
+				if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 4 {
+					return fmt.Errorf("expected 4 replicas, got %v", dep.Spec.Replicas)
+				}
+				if _, ok := dep.Annotations["evictionSurgeReplicas"]; !ok {
+					return fmt.Errorf("evictionSurgeReplicas annotation not yet set")
+				}
+				return nil
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			By("waiting for partial trim: deployment should drop to 2 (minAvailable+1) after cooldown")
+			// The controller waits one cooldown period (~1 min) then checks pending pods.
+			// With all workers cordoned, the 3 surge pods remain Pending → partial trim fires.
+			EventuallyWithOffset(1, func() error {
+				if err := clientset.Get(ctx, client.ObjectKey{Name: depName, Namespace: partialRevertNs}, &dep); err != nil {
+					return err
+				}
+				if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 2 {
+					return fmt.Errorf("expected 2 replicas after partial trim, got %v", dep.Spec.Replicas)
+				}
+				// Surge annotation must still be present — not yet fully reverted.
+				if _, ok := dep.Annotations["evictionSurgeReplicas"]; !ok {
+					return fmt.Errorf("evictionSurgeReplicas annotation should still be present after partial trim")
+				}
+				return nil
+			}, 3*time.Minute, time.Second).Should(Succeed())
+
+			By("uncordoning all nodes so the remaining surge pod can schedule")
+			for _, n := range cordonedNodes {
+				cmd = exec.Command("kubectl", "uncordon", n)
+				_, err = utils.Run(cmd)
+				Expect(err).NotTo(HaveOccurred())
+			}
+			cordonedNodes = nil
+
+			By("waiting for full revert to 1 after second cooldown")
+			EventuallyWithOffset(1, func() error {
+				if err := clientset.Get(ctx, client.ObjectKey{Name: depName, Namespace: partialRevertNs}, &dep); err != nil {
+					return err
+				}
+				if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 1 {
+					return fmt.Errorf("expected 1 replica after full revert, got %v", dep.Spec.Replicas)
+				}
+				if _, ok := dep.Annotations["evictionSurgeReplicas"]; ok {
+					return fmt.Errorf("evictionSurgeReplicas annotation should be gone after full revert")
+				}
+				return nil
+			}, 3*time.Minute, time.Second).Should(Succeed())
+		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1528,6 +1528,8 @@ var _ = Describe("controller", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			clientset, err := client.New(config, client.Options{Scheme: scheme})
 			Expect(err).NotTo(HaveOccurred())
+			evictionClient, err := kubernetes.NewForConfig(config)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("creating test namespace with eviction autoscaler enabled")
 			cmd := exec.Command("kubectl", "create", "namespace", partialRevertNs)
@@ -1612,7 +1614,7 @@ var _ = Describe("controller", Ordered, func() {
 					return err
 				}
 				if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 4 {
-					return fmt.Errorf("expected 4 replicas, got %v", dep.Spec.Replicas)
+					return fmt.Errorf("expected 4 replicas, got %d", *dep.Spec.Replicas)
 				}
 				if _, ok := dep.Annotations["evictionSurgeReplicas"]; !ok {
 					return fmt.Errorf("evictionSurgeReplicas annotation not yet set")
@@ -1628,7 +1630,7 @@ var _ = Describe("controller", Ordered, func() {
 					return err
 				}
 				if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 2 {
-					return fmt.Errorf("expected 2 replicas after partial trim, got %v", dep.Spec.Replicas)
+					return fmt.Errorf("expected 2 replicas after partial trim, got %d", *dep.Spec.Replicas)
 				}
 				// Surge annotation must still be present — not yet fully reverted.
 				if _, ok := dep.Annotations["evictionSurgeReplicas"]; !ok {
@@ -1645,13 +1647,57 @@ var _ = Describe("controller", Ordered, func() {
 			}
 			cordonedNodes = nil
 
+			// Wait for the surge pod to schedule and become Running so DA >= 1 before
+			// attempting the eviction (PDB blocks eviction when DA == 0).
+			By("waiting for surge pod to be running so eviction is allowed (DA >= 1)")
+			EventuallyWithOffset(1, func() error {
+				var pods corev1.PodList
+				if err := clientset.List(ctx, &pods, client.InNamespace(partialRevertNs)); err != nil {
+					return err
+				}
+				running := 0
+				for _, p := range pods.Items {
+					if p.Status.Phase == corev1.PodRunning {
+						running++
+					}
+				}
+				if running < 2 {
+					return fmt.Errorf("waiting for 2 running pods, got %d", running)
+				}
+				return nil
+			}, time.Minute, time.Second).Should(Succeed())
+
+			// Evicting the pod stops the node reconciler from continuously resetting
+			// Spec.LastEviction.EvictionTime, which would otherwise prevent the EA
+			// cooldown from elapsing and the full revert from firing.
+			By("draining pod from podNodeName so the node reconciler stops resetting EvictionTime")
+			EventuallyWithOffset(1, func() error {
+				var podList corev1.PodList
+				if err := clientset.List(ctx, &podList, client.InNamespace(partialRevertNs),
+					client.MatchingFields{"spec.nodeName": podNodeName}); err != nil {
+					return err
+				}
+				for _, p := range podList.Items {
+					err := evictionClient.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policy.Eviction{
+						ObjectMeta: p.ObjectMeta,
+					})
+					if errors.IsTooManyRequests(err) {
+						return fmt.Errorf("eviction blocked by PDB, retrying: %w", err)
+					}
+					if err != nil {
+						return fmt.Errorf("failed to evict %s: %w", p.Name, err)
+					}
+				}
+				return nil
+			}, time.Minute, time.Second).Should(Succeed())
+
 			By("waiting for full revert to 1 after second cooldown")
 			EventuallyWithOffset(1, func() error {
 				if err := clientset.Get(ctx, client.ObjectKey{Name: depName, Namespace: partialRevertNs}, &dep); err != nil {
 					return err
 				}
 				if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 1 {
-					return fmt.Errorf("expected 1 replica after full revert, got %v", dep.Spec.Replicas)
+					return fmt.Errorf("expected 1 replica after full revert, got %d", *dep.Spec.Replicas)
 				}
 				if _, ok := dep.Annotations["evictionSurgeReplicas"]; ok {
 					return fmt.Errorf("evictionSurgeReplicas annotation should be gone after full revert")


### PR DESCRIPTION
This pull request introduces a "partial revert" feature to the EvictionAutoScaler controller, allowing it to trim surge pods to the minimum required when capacity pressure prevents scheduling, rather than reverting all the way to baseline immediately. This reduces unnecessary Pending pods and cluster autoscaler pressure. The implementation includes new helpers, comprehensive unit and e2e tests, and minor supporting changes.

**EvictionAutoScaler partial revert logic:**

* The controller now checks for unschedulable (Pending and Unschedulable) surge pods before a full revert. If such pods exist, it trims the deployment to `partialTarget` (the minimum needed to keep the PDB open by one disruption), rather than reverting to baseline immediately. This logic is only applied once per surge cycle. (`internal/controller/evictionautoscaler_controller.go`)

* Added helper functions:
  - `resolveMinAvailableInt`: Calculates the absolute minAvailable count for a PDB, supporting both integer and percentage types, using the pre-surge baseline for percentage calculations.
  - `countUnschedulablePodsForTarget`: Counts Pending pods with the Unschedulable condition, accurately identifying capacity-bound surge pods.
  (`internal/controller/pdb_helpers.go`)

**Testing improvements:**

* Comprehensive unit tests for the partial revert logic, including scenarios for trimming, full revert after trim, and immediate full revert when no Pending pods exist. Also added tests for `resolveMinAvailableInt`. (`internal/controller/evictionautoscaler_controller_test.go`)

* Added an end-to-end (e2e) test that simulates capacity pressure by cordoning nodes, verifying that the controller trims surge pods to `minAvailable+1` and only fully reverts after pressure is relieved. (`test/e2e/e2e_test.go`)

**Deployment config/test support:**

* Enhanced deployment test helpers to allow specifying `maxSurge` explicitly, supporting the new e2e test scenario. (`test/e2e/e2e_helpers.go`) [[1]](diffhunk://#diff-11b53a7a4c93acf196e8a4a06af0efbce21ea669cdabff13362ed63c98198345R43) [[2]](diffhunk://#diff-11b53a7a4c93acf196e8a4a06af0efbce21ea669cdabff13362ed63c98198345R57-R61) [[3]](diffhunk://#diff-11b53a7a4c93acf196e8a4a06af0efbce21ea669cdabff13362ed63c98198345R79-R81) [[4]](diffhunk://#diff-11b53a7a4c93acf196e8a4a06af0efbce21ea669cdabff13362ed63c98198345R110-R118)

**Minor changes:**

* Added necessary imports for new helper logic and tests. (`internal/controller/evictionautoscaler_controller_test.go`, `internal/controller/pdb_helpers.go`) [[1]](diffhunk://#diff-ead56681a4d4b68d233bd6c492875dc4f3c5c37c981ac184c1068487b090dd67R5) [[2]](diffhunk://#diff-6156a46afdfce576c66fb574f56e927aa9af5e5adb455423f85ae10ef69265cfR6-R8)