### PR TITLE
modify surge calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 - [Installation](#installation)
 - [Networking](#networking)
 - [Usage](#usage)
+  - [Surge Annotations](#surge-annotations)
+  - [How Surge Sizing Works](#how-surge-sizing-works)
 
 ## Introduction
 
@@ -537,6 +539,47 @@ kubectl get scaledobject <name> -n <namespace> -o jsonpath='{.metadata.annotatio
 # Check the original minReplicas that will be restored on revert
 kubectl get hpa <name> -n <namespace> -o jsonpath='{.metadata.annotations.eviction-autoscaler\.azure\.com/original-min-replicas}'
 ```
+
+### How Surge Sizing Works
+
+Eviction-autoscaler scales **to** a specific target rather than scaling **by** a fixed amount. The target is computed per reconcile:
+
+```
+surgeTarget = minReplicas + displaced
+```
+
+where `displaced` is the number of PDB-selected pods currently running on cordoned nodes. `surgeTarget` is capped at `minReplicas + maxSurge` (the deployment's configured max surge). This means the surge is right-sized to exactly what is needed — no over-provisioning.
+
+#### Incremental Scale-Up
+
+As additional nodes are cordoned during a rolling drain, `displaced` grows and the controller tops the deployment up automatically on each reconcile.
+
+**Example — two-node drain:**
+
+| Event | Cordoned nodes | Displaced pods | Replicas |
+|---|---|---|---|
+| Initial state | 0 | 0 | `minReplicas` = 3 |
+| Node A cordoned (2 pods) | 1 | 2 | 3 + 2 = **5** |
+| Node B cordoned (1 pod) | 2 | 3 | 3 + 3 = **6** |
+| Pods drain off node A | 1 | 1 | still **6** (see below) |
+| All drains complete, cooldown expires | 0 | 0 | back to **3** |
+
+#### Scale-Down Timing
+
+Scale-down back to `minReplicas` happens only when **both** conditions are met:
+
+1. The last eviction happened more than the cooldown period ago (default 30s).
+2. The PDB's `DisruptionsAllowed` is greater than zero (i.e. the drain is no longer blocking evictions).
+
+**Importantly, the replica count does not decrease while a drain is still in progress.** If node A drains but node B is still cordoned and blocking evictions, replicas stay at their current level until the full drain completes and the cooldown expires. This avoids a churn cycle where scale-down triggers new evictions, which trigger scale-up again.
+
+```
+# What you will see during a partial drain
+$ kubectl get deployment my-app -o jsonpath='{.spec.replicas}'
+6   # stays here even after some pods have moved, until all drains complete + cooldown
+```
+
+If you need to force a faster scale-down you can manually uncordon nodes; once `DisruptionsAllowed` rises and the cooldown passes, the controller will revert.
 
 ### Build and Push Multi-Arch Image
 

--- a/internal/controller/autoscaler_helpers_test.go
+++ b/internal/controller/autoscaler_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -76,5 +77,62 @@ var _ = Describe("ResolveMinReplicas", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(hasAutoscaler).To(BeTrue())
 		Expect(min).To(Equal(int32(2)))
+	})
+})
+
+var _ = Describe("calculateSurge", func() {
+	ctx := context.Background()
+
+	makeTarget := func(surge intstr.IntOrString) Surger {
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxSurge: &surge,
+					},
+				},
+			},
+		}
+		return &DeploymentWrapper{obj: dep}
+	}
+
+	It("adds an integer maxSurge to minReplicas", func() {
+		target := makeTarget(intstr.FromInt32(2))
+		Expect(calculateSurge(ctx, target, 3)).To(Equal(int32(5)))
+	})
+
+	It("returns minReplicas when maxSurge is 0", func() {
+		target := makeTarget(intstr.FromInt32(0))
+		Expect(calculateSurge(ctx, target, 5)).To(Equal(int32(5)))
+	})
+
+	It("returns minReplicas when no RollingUpdate strategy is set", func() {
+		dep := &appsv1.Deployment{}
+		target := &DeploymentWrapper{obj: dep}
+		Expect(calculateSurge(ctx, target, 4)).To(Equal(int32(4)))
+	})
+
+	It("computes 25% surge with ceiling (exact)", func() {
+		target := makeTarget(intstr.FromString("25%"))
+		// 4 * 25% = 1.0 → ceil(1.0) = 1 → 4+1 = 5
+		Expect(calculateSurge(ctx, target, 4)).To(Equal(int32(5)))
+	})
+
+	It("computes 25% surge with ceiling (fractional)", func() {
+		target := makeTarget(intstr.FromString("25%"))
+		// 3 * 25% = 0.75 → ceil(0.75) = 1 → 3+1 = 4
+		Expect(calculateSurge(ctx, target, 3)).To(Equal(int32(4)))
+	})
+
+	It("computes 50% surge with ceiling", func() {
+		target := makeTarget(intstr.FromString("50%"))
+		// 3 * 50% = 1.5 → ceil(1.5) = 2 → 3+2 = 5
+		Expect(calculateSurge(ctx, target, 3)).To(Equal(int32(5)))
+	})
+
+	It("computes 100% surge", func() {
+		target := makeTarget(intstr.FromString("100%"))
+		// 5 * 100% = 5 → ceil(5) = 5 → 5+5 = 10
+		Expect(calculateSurge(ctx, target, 5)).To(Equal(int32(10)))
 	})
 })

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -189,39 +189,46 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// surgeTarget = minReplicas + min(maxSurge, displaced)
 		// If displaced == 0 (pods not yet visible on cordoned nodes or race condition),
 		// fall back to full maxSurge so we don't block evictions.
+		// If maxSurge is 0 (not configured), surge by exactly displaced with no cap.
 		maxSurgeTarget := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas)
 		surgeTarget := EvictionAutoScaler.Status.MinReplicas + displaced
-		if displaced == 0 || surgeTarget > maxSurgeTarget {
-			surgeTarget = maxSurgeTarget
-		}
-
-		if target.GetReplicas() < surgeTarget {
-			logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name(), "displaced", displaced, "surgeTarget", surgeTarget)
-
-			// Track blocked eviction if the PDB is blocking the eviction
-			metrics.BlockedEvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name).Inc()
-
-			// Track scaling opportunity with signal label
-			signalLabel := metrics.GetScalingSignal(pdb)
-			metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction, signalLabel).Inc()
-
-			err = surgeApplier.ApplySurge(ctx, surgeTarget)
-			if err != nil {
-				logger.Error(err, "failed to apply surge", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "strategy", surgeApplier.Name())
-				return ctrl.Result{}, err
+		// Cap surgeTarget at maxSurge when displaced exceeds it.
+		// If customer set MaxSurge=0 explicitly, surgeTarget==minReplicas → no surge (they opted out).
+		if displaced == 0 {
+			logger.Info("No pods on cordoned nodes, skipping surge", "pdb", pdb.Name)
+		} else {
+			if surgeTarget > maxSurgeTarget {
+				surgeTarget = maxSurgeTarget
 			}
 
-			// Track actual scaling action
-			metrics.ActualScalingCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction).Inc()
+			if target.GetReplicas() < surgeTarget {
+				logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name(), "displaced", displaced, "surgeTarget", surgeTarget)
 
-			// Log the scaling action
-			logger.Info(fmt.Sprintf("Scaled up %s %s/%s to %d replicas (via %s)", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), surgeTarget, surgeApplier.Name()))
-			logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
-			// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
-			EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
-			//Do not update EvictionAutoScaler.Status.LastEviction because we need to keep reconciling till scale down
-			ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "eviction with scale up")
-			return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
+				// Track blocked eviction if the PDB is blocking the eviction
+				metrics.BlockedEvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name).Inc()
+
+				// Track scaling opportunity with signal label
+				signalLabel := metrics.GetScalingSignal(pdb)
+				metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction, signalLabel).Inc()
+
+				err = surgeApplier.ApplySurge(ctx, surgeTarget)
+				if err != nil {
+					logger.Error(err, "failed to apply surge", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "strategy", surgeApplier.Name())
+					return ctrl.Result{}, err
+				}
+
+				// Track actual scaling action
+				metrics.ActualScalingCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction).Inc()
+
+				// Log the scaling action
+				logger.Info(fmt.Sprintf("Scaled up %s %s/%s to %d replicas (via %s)", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), surgeTarget, surgeApplier.Name()))
+				logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
+				// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
+				EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
+				//Do not update EvictionAutoScaler.Status.LastEviction because we need to keep reconciling till scale down
+				ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "eviction with scale up")
+				return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
+			}
 		}
 	}
 

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -197,7 +197,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		if displaced == 0 {
 			logger.Info("No pods on cordoned nodes, skipping surge", "pdb", pdb.Name)
 			return ctrl.Result{RequeueAfter: cooldown}, nil
-		} 
+		}
 
 		if surgeTarget > maxSurgeTarget {
 			logger.Info("Displaced pods exceed maxSurge capacity, capping surge", "pdb", pdb.Name, "displaced", displaced, "maxSurgeTarget", maxSurgeTarget)

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -196,39 +196,41 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// If customer set MaxSurge=0 explicitly, surgeTarget==minReplicas → no surge (they opted out).
 		if displaced == 0 {
 			logger.Info("No pods on cordoned nodes, skipping surge", "pdb", pdb.Name)
-		} else {
-			if surgeTarget > maxSurgeTarget {
-				surgeTarget = maxSurgeTarget
+			return ctrl.Result{RequeueAfter: cooldown}, nil
+		} 
+
+		if surgeTarget > maxSurgeTarget {
+			logger.Info("Displaced pods exceed maxSurge capacity, capping surge", "pdb", pdb.Name, "displaced", displaced, "maxSurgeTarget", maxSurgeTarget)
+			surgeTarget = maxSurgeTarget
+		}
+
+		if target.GetReplicas() < surgeTarget {
+			logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name(), "displaced", displaced, "surgeTarget", surgeTarget)
+
+			// Track blocked eviction if the PDB is blocking the eviction
+			metrics.BlockedEvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name).Inc()
+
+			// Track scaling opportunity with signal label
+			signalLabel := metrics.GetScalingSignal(pdb)
+			metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction, signalLabel).Inc()
+
+			err = surgeApplier.ApplySurge(ctx, surgeTarget)
+			if err != nil {
+				logger.Error(err, "failed to apply surge", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "strategy", surgeApplier.Name())
+				return ctrl.Result{}, err
 			}
 
-			if target.GetReplicas() < surgeTarget {
-				logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name(), "displaced", displaced, "surgeTarget", surgeTarget)
+			// Track actual scaling action
+			metrics.ActualScalingCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction).Inc()
 
-				// Track blocked eviction if the PDB is blocking the eviction
-				metrics.BlockedEvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name).Inc()
-
-				// Track scaling opportunity with signal label
-				signalLabel := metrics.GetScalingSignal(pdb)
-				metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction, signalLabel).Inc()
-
-				err = surgeApplier.ApplySurge(ctx, surgeTarget)
-				if err != nil {
-					logger.Error(err, "failed to apply surge", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "strategy", surgeApplier.Name())
-					return ctrl.Result{}, err
-				}
-
-				// Track actual scaling action
-				metrics.ActualScalingCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction).Inc()
-
-				// Log the scaling action
-				logger.Info(fmt.Sprintf("Scaled up %s %s/%s to %d replicas (via %s)", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), surgeTarget, surgeApplier.Name()))
-				logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
-				// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
-				EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
-				//Do not update EvictionAutoScaler.Status.LastEviction because we need to keep reconciling till scale down
-				ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "eviction with scale up")
-				return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
-			}
+			// Log the scaling action
+			logger.Info(fmt.Sprintf("Scaled up %s %s/%s to %d replicas (via %s)", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), surgeTarget, surgeApplier.Name()))
+			logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
+			// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
+			EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
+			//Do not update EvictionAutoScaler.Status.LastEviction because we need to keep reconciling till scale down
+			ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "eviction with scale up")
+			return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
 		}
 	}
 

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -186,14 +186,13 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, countErr
 		}
 
-		// surgeTarget = minReplicas + min(maxSurge, displaced)
-		// If displaced == 0 (pods not yet visible on cordoned nodes or race condition),
-		// fall back to full maxSurge so we don't block evictions.
-		// If maxSurge is 0 (not configured), surge by exactly displaced with no cap.
+		// surgeTarget = minReplicas + displaced, capped at minReplicas + maxSurge.
+		// If displaced == 0 the formula yields minReplicas, so no scale-up fires and
+		// we fall through to the cooldown/scale-down path — which is correct.
+		// If maxSurge is 0 (not configured), surgeTarget == minReplicas → no surge (opted out).
 		maxSurgeTarget := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas)
 		surgeTarget := EvictionAutoScaler.Status.MinReplicas + displaced
-		// Cap surgeTarget at maxSurge when displaced exceeds it.
-		// If customer set MaxSurge=0 explicitly, surgeTarget==minReplicas → no surge (they opted out).
+
 		if surgeTarget > maxSurgeTarget {
 			logger.Info("Displaced pods exceed maxSurge capacity, capping surge", "pdb", pdb.Name, "displaced", displaced, "maxSurgeTarget", maxSurgeTarget)
 			surgeTarget = maxSurgeTarget

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -175,37 +175,54 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		"evictionTime", EvictionAutoScaler.Spec.LastEviction.EvictionTime)
 	metrics.EvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace).Inc()
 
-	//if we're not scaled up and theres new evictions we haven't processed
-	if pdb.Status.DisruptionsAllowed == 0 && target.GetReplicas() == EvictionAutoScaler.Status.MinReplicas {
-		// What if the evict went through because the pod being evicted wasn't ready anyways?
-		// TODO later. Surge more slowly based on number of evictions (need to move back to capturing them all)
-		logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name())
-
-		// Track blocked eviction if the PDB is blocking the eviction
-		metrics.BlockedEvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name).Inc()
-
-		// Track scaling opportunity with signal label
-		signalLabel := metrics.GetScalingSignal(pdb)
-		metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction, signalLabel).Inc()
-
-		newReplicas := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas)
-		err = surgeApplier.ApplySurge(ctx, newReplicas)
-		if err != nil {
-			logger.Error(err, "failed to apply surge", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "strategy", surgeApplier.Name())
-			return ctrl.Result{}, err
+	// If the PDB is blocking evictions, compute a right-sized surge: bring up exactly
+	// enough replacements to unblock the displaced pods, capped at maxSurge.
+	// We re-evaluate on every reconcile so that incremental cordons (e.g. Node Y
+	// cordoned after Node X) top up to the new total without double-counting.
+	if pdb.Status.DisruptionsAllowed == 0 {
+		displaced, countErr := countPodsOnCordoned(ctx, r.Client, pdb)
+		if countErr != nil {
+			logger.Error(countErr, "failed to count displaced pods on cordoned nodes")
+			return ctrl.Result{}, countErr
 		}
 
-		// Track actual scaling action
-		metrics.ActualScalingCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction).Inc()
+		// surgeTarget = minReplicas + min(maxSurge, displaced)
+		// If displaced == 0 (pods not yet visible on cordoned nodes or race condition),
+		// fall back to full maxSurge so we don't block evictions.
+		maxSurgeTarget := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas)
+		surgeTarget := EvictionAutoScaler.Status.MinReplicas + displaced
+		if displaced == 0 || surgeTarget > maxSurgeTarget {
+			surgeTarget = maxSurgeTarget
+		}
 
-		// Log the scaling action
-		logger.Info(fmt.Sprintf("Scaled up %s %s/%s to %d replicas (via %s)", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), newReplicas, surgeApplier.Name()))
-		logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
-		// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
-		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
-		//Do not update EvictionAutoScaler.Status.LastEviction because we need to keep reconciling till scale down
-		ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "eviction with scale up")
-		return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
+		if target.GetReplicas() < surgeTarget {
+			logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name(), "displaced", displaced, "surgeTarget", surgeTarget)
+
+			// Track blocked eviction if the PDB is blocking the eviction
+			metrics.BlockedEvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name).Inc()
+
+			// Track scaling opportunity with signal label
+			signalLabel := metrics.GetScalingSignal(pdb)
+			metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction, signalLabel).Inc()
+
+			err = surgeApplier.ApplySurge(ctx, surgeTarget)
+			if err != nil {
+				logger.Error(err, "failed to apply surge", "kind", EvictionAutoScaler.Spec.TargetKind, "targetname", EvictionAutoScaler.Spec.TargetName, "strategy", surgeApplier.Name())
+				return ctrl.Result{}, err
+			}
+
+			// Track actual scaling action
+			metrics.ActualScalingCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleUpAction).Inc()
+
+			// Log the scaling action
+			logger.Info(fmt.Sprintf("Scaled up %s %s/%s to %d replicas (via %s)", EvictionAutoScaler.Spec.TargetKind, target.Obj().GetNamespace(), target.Obj().GetName(), surgeTarget, surgeApplier.Name()))
+			logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
+			// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
+			EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
+			//Do not update EvictionAutoScaler.Status.LastEviction because we need to keep reconciling till scale down
+			ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "eviction with scale up")
+			return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
+		}
 	}
 
 	//what if we're allowed disruptions >0 and minreplicas == replicas? Could argue that we should mark the eviction as handled

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -194,11 +194,6 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		surgeTarget := EvictionAutoScaler.Status.MinReplicas + displaced
 		// Cap surgeTarget at maxSurge when displaced exceeds it.
 		// If customer set MaxSurge=0 explicitly, surgeTarget==minReplicas → no surge (they opted out).
-		if displaced == 0 {
-			logger.Info("No pods on cordoned nodes, skipping surge", "pdb", pdb.Name)
-			return ctrl.Result{RequeueAfter: cooldown}, nil
-		}
-
 		if surgeTarget > maxSurgeTarget {
 			logger.Info("Displaced pods exceed maxSurge capacity, capping surge", "pdb", pdb.Name, "displaced", displaced, "maxSurgeTarget", maxSurgeTarget)
 			surgeTarget = maxSurgeTarget

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -228,11 +228,11 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			//we don't update status of last eviction till
 			Expect(EvictionAutoScaler.Spec.LastEviction.EvictionTime).ToNot(Equal(EvictionAutoScaler.Status.LastEviction.EvictionTime))
 
-			// Verify Deployment scaling if necessary
+			// No real pods exist on a cordoned node, so displaced=0 and no surge fires.
 			deployment := &appsv1.Deployment{}
 			err = k8sClient.Get(ctx, deploymentNamespacedName, deployment)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(*deployment.Spec.Replicas).To(Equal(int32(2))) // Change as needed to verify scaling
+			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
 		})
 
 		It("should skip StatefulSet targets without surging", func() {
@@ -798,10 +798,10 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Verify deployment WAS scaled
+			// No real pods exist on a cordoned node, so displaced=0 and no surge fires.
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: "test-deploy", Namespace: testNamespace}, deployment)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(*deployment.Spec.Replicas).To(Equal(int32(3))) // Should be scaled up
+			Expect(*deployment.Spec.Replicas).To(Equal(int32(2)))
 		})
 
 		It("should process EvictionAutoScaler in kube-system by default", func() {
@@ -891,10 +891,10 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Verify deployment WAS scaled (kube-system is enabled by default)
+			// No real pods exist on a cordoned node, so displaced=0 and no surge fires.
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: "test-kube-deploy", Namespace: testNamespace}, deployment)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(*deployment.Spec.Replicas).To(Equal(int32(3))) // Should be scaled up
+			Expect(*deployment.Spec.Replicas).To(Equal(int32(2)))
 
 			// Cleanup
 			Expect(k8sClient.Delete(ctx, EvictionAutoScaler)).To(Succeed())

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -809,6 +809,7 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			testNamespace := metav1.NamespaceSystem
 
 			// Create deployment
+			kubeSurge := intstr.FromInt(1)
 			deployment := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-kube-deploy",
@@ -818,6 +819,11 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 					Replicas: int32Ptr(2),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"app": "test-kube"},
+					},
+					Strategy: appsv1.DeploymentStrategy{
+						RollingUpdate: &appsv1.RollingUpdateDeployment{
+							MaxSurge: &kubeSurge,
+						},
 					},
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	v1 "github.com/azure/eviction-autoscaler/api/v1"
@@ -18,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -233,6 +235,420 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			err = k8sClient.Get(ctx, deploymentNamespacedName, deployment)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*deployment.Spec.Replicas).To(Equal(int32(1)))
+		})
+
+		It("should surge by exactly displaced pod count when pods are on a cordoned node", func() {
+			By("setting up a cordoned node and pods on it")
+			controllerReconciler := &EvictionAutoScalerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Filter: &evictionTestFilter{},
+			}
+
+			// Create a node and cordon it.
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cordoned-node-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+
+			// Create 2 pods on the cordoned node matching the PDB selector.
+			for i := 0; i < 2; i++ {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "displaced-pod-",
+						Namespace:    namespace,
+						Labels:       map[string]string{"app": "example"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: node.Name,
+						Containers: []corev1.Container{
+							{Name: "nginx", Image: "nginx:latest"},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			}
+
+			// Run once to populate TargetGeneration.
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Log an eviction so the reconciler enters the surge path.
+			ea := &v1.EvictionAutoScaler{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction = v1.Eviction{PodName: "displaced-pod", EvictionTime: metav1.Now()}
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Deployment should have surged to minReplicas(1) + displaced(2) = 3.
+			// MaxSurge=1 on the deployment caps it at minReplicas(1) + maxSurge(1) = 2.
+			// Since displaced(2) > maxSurge(1), surgeTarget is capped at 2.
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
+		})
+
+		It("should surge by exactly displaced pod count when displaced is less than maxSurge", func() {
+			By("setting up a cordoned node with fewer pods than maxSurge")
+			// Increase maxSurge on the deployment to 5 so displaced(1) < maxSurge(5).
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			bigSurge := intstr.FromInt32(5)
+			dep.Spec.Strategy.RollingUpdate.MaxSurge = &bigSurge
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			controllerReconciler := &EvictionAutoScalerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Filter: &evictionTestFilter{},
+			}
+
+			// Create a cordoned node with exactly 1 matching pod.
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-small-drain-node-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "small-drain-pod-" + namespace,
+					Namespace: namespace,
+					Labels:    map[string]string{"app": "example"},
+				},
+				Spec: corev1.PodSpec{
+					NodeName:   node.Name,
+					Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+
+			// Reconcile once to update TargetGeneration after the deployment change.
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Log an eviction.
+			ea := &v1.EvictionAutoScaler{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction = v1.Eviction{PodName: "small-drain-pod", EvictionTime: metav1.Now()}
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// displaced(1) < maxSurge(5), so surgeTarget = minReplicas(1) + displaced(1) = 2.
+			// Not minReplicas(1) + maxSurge(5) = 6.
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
+		})
+
+		It("should top up surge incrementally as more nodes are cordoned", func() {
+			// Verifies the "scale TO target" formula: surgeTarget = minReplicas + totalDisplaced.
+			// Cordoning a second node should top up to the new total without double-counting.
+			By("giving the deployment a generous maxSurge so it doesn't cap us")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			bigSurge := intstr.FromInt32(10)
+			dep.Spec.Strategy.RollingUpdate.MaxSurge = &bigSurge
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			controllerReconciler := &EvictionAutoScalerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Filter: &evictionTestFilter{},
+			}
+
+			// Create two nodes, both cordoned; each has 1 pod.
+			nodeA := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "incremental-node-a-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			}
+			nodeB := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "incremental-node-b-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: false}, // start uncordoned
+			}
+			Expect(k8sClient.Create(ctx, nodeA)).To(Succeed())
+			Expect(k8sClient.Create(ctx, nodeB)).To(Succeed())
+
+			podA := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "inc-pod-a-" + namespace,
+					Namespace: namespace,
+					Labels:    map[string]string{"app": "example"},
+				},
+				Spec: corev1.PodSpec{
+					NodeName:   nodeA.Name,
+					Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+				},
+			}
+			podB := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "inc-pod-b-" + namespace,
+					Namespace: namespace,
+					Labels:    map[string]string{"app": "example"},
+				},
+				Spec: corev1.PodSpec{
+					NodeName:   nodeB.Name,
+					Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, podA)).To(Succeed())
+			Expect(k8sClient.Create(ctx, podB)).To(Succeed())
+
+			// Reconcile once to populate TargetGeneration after the deployment maxSurge change.
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// --- Wave 1: only node A is cordoned (1 displaced pod) ---
+			ea := &v1.EvictionAutoScaler{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction = v1.Eviction{PodName: "inc-pod-a", EvictionTime: metav1.Now()}
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// surgeTarget = minReplicas(1) + displaced(1) = 2.
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(2)), "after first cordon: should surge to 2")
+
+			// --- Wave 2: cordon node B as well (now 2 displaced pods total) ---
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeB.Name}, nodeB)).To(Succeed())
+			nodeB.Spec.Unschedulable = true
+			Expect(k8sClient.Update(ctx, nodeB)).To(Succeed())
+
+			// New eviction triggers reconcile.
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction = v1.Eviction{PodName: "inc-pod-b", EvictionTime: metav1.Now()}
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// surgeTarget = minReplicas(1) + displaced(2) = 3. Tops up without double-counting.
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(3)), "after second cordon: should top up to 3")
+		})
+
+		It("should not scale down when some nodes are uncordoned but drain is still blocked", func() {
+			// When DisruptionsAllowed is still 0 (drain ongoing), surgeTarget drops if displaced
+			// drops, but we do NOT scale the deployment down — only the cooldown path does that.
+			// This tests that we don't inadvertently evict pods we just brought up.
+			By("giving the deployment a generous maxSurge")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			bigSurge := intstr.FromInt32(10)
+			dep.Spec.Strategy.RollingUpdate.MaxSurge = &bigSurge
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			controllerReconciler := &EvictionAutoScalerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Filter: &evictionTestFilter{},
+			}
+
+			// Create two cordoned nodes each with 1 pod.
+			nodeC := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "partial-uncordon-c-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			}
+			nodeD := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "partial-uncordon-d-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			}
+			Expect(k8sClient.Create(ctx, nodeC)).To(Succeed())
+			Expect(k8sClient.Create(ctx, nodeD)).To(Succeed())
+
+			for i, nodeName := range []string{nodeC.Name, nodeD.Name} {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "partial-pod-" + string(rune('c'+i)) + "-" + namespace,
+						Namespace: namespace,
+						Labels:    map[string]string{"app": "example"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName:   nodeName,
+						Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+					},
+				}
+				Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			}
+
+			// Reconcile once to update TargetGeneration.
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Trigger surge with both nodes cordoned: displaced=2, surgeTarget=3.
+			ea := &v1.EvictionAutoScaler{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction = v1.Eviction{PodName: "partial-pod-c", EvictionTime: metav1.Now()}
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(3)), "surged to 3 with 2 displaced pods")
+
+			// Now uncordon node D (only node C remains cordoned, displaced=1).
+			// DisruptionsAllowed is still 0 (PDB still blocking — drain not done).
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeD.Name}, nodeD)).To(Succeed())
+			nodeD.Spec.Unschedulable = false
+			Expect(k8sClient.Update(ctx, nodeD)).To(Succeed())
+
+			// Reconcile again with the same unhandled eviction.
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// surgeTarget is now 2, but GetReplicas()=3 >= 2, so no scale-up fires.
+			// Scale-down does NOT happen here — it only fires via the cooldown path
+			// once DisruptionsAllowed > 0. Replicas remain at 3.
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(3)), "no premature scale-down while drain is still blocked")
+		})
+
+		It("should surge incrementally across multiple nodes then scale back down when all drains complete", func() {
+			// Full end-to-end multi-node drain scenario:
+			//   1. Cordon node A (2 pods) → surge to minReplicas+2
+			//   2. Cordon node B (2 more pods) → top up to minReplicas+4
+			//   3. Both nodes drain; PDB unblocks; cooldown expires → scale down to minReplicas
+			By("giving the deployment enough maxSurge for the scenario")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			bigSurge := intstr.FromInt32(10)
+			dep.Spec.Strategy.RollingUpdate.MaxSurge = &bigSurge
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			controllerReconciler := &EvictionAutoScalerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				Filter: &evictionTestFilter{},
+			}
+
+			// Two nodes, initially uncordoned; 2 pods each.
+			nodeE := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "multi-drain-e-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: false},
+			}
+			nodeF := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "multi-drain-f-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: false},
+			}
+			Expect(k8sClient.Create(ctx, nodeE)).To(Succeed())
+			Expect(k8sClient.Create(ctx, nodeF)).To(Succeed())
+
+			for i := 0; i < 2; i++ {
+				podE := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("multi-pod-e%d-%s", i, namespace),
+						Namespace: namespace,
+						Labels:    map[string]string{"app": "example"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName:   nodeE.Name,
+						Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+					},
+				}
+				podF := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("multi-pod-f%d-%s", i, namespace),
+						Namespace: namespace,
+						Labels:    map[string]string{"app": "example"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName:   nodeF.Name,
+						Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+					},
+				}
+				Expect(k8sClient.Create(ctx, podE)).To(Succeed())
+				Expect(k8sClient.Create(ctx, podF)).To(Succeed())
+			}
+
+			// Seed TargetGeneration so future reconciles don't see a "deployment changed" reset.
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// ── Wave 1: cordon node E ──────────────────────────────────────────────────────
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeE.Name}, nodeE)).To(Succeed())
+			nodeE.Spec.Unschedulable = true
+			Expect(k8sClient.Update(ctx, nodeE)).To(Succeed())
+
+			ea := &v1.EvictionAutoScaler{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction = v1.Eviction{PodName: "multi-pod-e0", EvictionTime: metav1.Now()}
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// minReplicas(1) + displaced(2) = 3
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(3)), "wave 1: surged to 3")
+
+			// ── Wave 2: cordon node F ──────────────────────────────────────────────────────
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeF.Name}, nodeF)).To(Succeed())
+			nodeF.Spec.Unschedulable = true
+			Expect(k8sClient.Update(ctx, nodeF)).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction = v1.Eviction{PodName: "multi-pod-f0", EvictionTime: metav1.Now()}
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// minReplicas(1) + displaced(4) = 5
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(5)), "wave 2: topped up to 5")
+
+			// ── Drain completes: remove pods from both cordoned nodes ─────────────────────
+			// In a real cluster the scheduler rescheduled them; here we just delete them.
+			podList := &corev1.PodList{}
+			Expect(k8sClient.List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels{"app": "example"})).To(Succeed())
+			for i := range podList.Items {
+				pod := &podList.Items[i]
+				if pod.Spec.NodeName == nodeE.Name || pod.Spec.NodeName == nodeF.Name {
+					Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
+				}
+			}
+
+			// PDB now unblocked (drain finished).
+			pdb := &policyv1.PodDisruptionBudget{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, pdb)).To(Succeed())
+			pdb.Status.DisruptionsAllowed = 1
+			Expect(k8sClient.Status().Update(ctx, pdb)).To(Succeed())
+
+			// Advance TargetGeneration so the reconciler treats the current deployment as known.
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Status.TargetGeneration = dep.Generation
+			Expect(k8sClient.Status().Update(ctx, ea)).To(Succeed())
+
+			// First reconcile after drain: still within cooldown — should requeue but not scale.
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction.EvictionTime = metav1.Now()
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(cooldown), "should requeue during cooldown")
+
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(5)), "no scale-down yet: still within cooldown")
+
+			// ── Cooldown expires ──────────────────────────────────────────────────────────
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction.EvictionTime = metav1.NewTime(time.Now().Add(-2 * cooldown))
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(1)), "post-drain: scaled back down to minReplicas")
 		})
 
 		It("should skip StatefulSet targets without surging", func() {

--- a/internal/controller/pdb_helpers.go
+++ b/internal/controller/pdb_helpers.go
@@ -199,3 +199,48 @@ func triggerOnPDBAnnotationChange(e event.UpdateEvent, logger logr.Logger) bool 
 	}
 	return false
 }
+
+// countPodsOnCordoned counts pods matching the PDB selector that are currently on cordoned
+// (Unschedulable) nodes. It aggregates across all cordoned nodes, so simultaneous drains
+// are counted correctly.
+func countPodsOnCordoned(ctx context.Context, c client.Client, pdb *policyv1.PodDisruptionBudget) (int32, error) {
+	selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+	if err != nil {
+		return 0, fmt.Errorf("invalid PDB selector: %w", err)
+	}
+
+	var podList corev1.PodList
+	if err := c.List(ctx, &podList, client.InNamespace(pdb.Namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		return 0, fmt.Errorf("failed to list pods for PDB %s: %w", pdb.Name, err)
+	}
+
+	// Deduplicate node names to minimise Get calls.
+	nodeNames := make(map[string]struct{})
+	for _, pod := range podList.Items {
+		if pod.Spec.NodeName != "" {
+			nodeNames[pod.Spec.NodeName] = struct{}{}
+		}
+	}
+
+	// Fetch each unique node and record whether it is cordoned.
+	cordoned := make(map[string]bool, len(nodeNames))
+	for nodeName := range nodeNames {
+		node := &corev1.Node{}
+		if err := c.Get(ctx, k8s_types.NamespacedName{Name: nodeName}, node); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return 0, fmt.Errorf("failed to get node %s: %w", nodeName, err)
+			}
+			// Node not found: pod is being terminated already, don't count it.
+			continue
+		}
+		cordoned[nodeName] = node.Spec.Unschedulable
+	}
+
+	var count int32
+	for _, pod := range podList.Items {
+		if cordoned[pod.Spec.NodeName] {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/internal/controller/pdb_helpers.go
+++ b/internal/controller/pdb_helpers.go
@@ -214,26 +214,18 @@ func countPodsOnCordoned(ctx context.Context, c client.Client, pdb *policyv1.Pod
 		return 0, fmt.Errorf("failed to list pods for PDB %s: %w", pdb.Name, err)
 	}
 
-	// Deduplicate node names to minimise Get calls.
-	nodeNames := make(map[string]struct{})
-	for _, pod := range podList.Items {
-		if pod.Spec.NodeName != "" {
-			nodeNames[pod.Spec.NodeName] = struct{}{}
-		}
+	// We use node cordon (Spec.Unschedulable) as the signal for "pods need to move".
+	// This is the best signal available today via the controller-runtime cache (no API server round-trip).
+	// In the future this may be replaced by a more direct pod-eviction signal — e.g. via an
+	// admission webhook interceptor or pod conditions — which would let us right-size the surge
+	// without needing to inspect nodes at all.
+	var nodeList corev1.NodeList
+	if err := c.List(ctx, &nodeList); err != nil {
+		return 0, fmt.Errorf("failed to list nodes: %w", err)
 	}
-
-	// Fetch each unique node and record whether it is cordoned.
-	cordoned := make(map[string]bool, len(nodeNames))
-	for nodeName := range nodeNames {
-		node := &corev1.Node{}
-		if err := c.Get(ctx, k8s_types.NamespacedName{Name: nodeName}, node); err != nil {
-			if client.IgnoreNotFound(err) != nil {
-				return 0, fmt.Errorf("failed to get node %s: %w", nodeName, err)
-			}
-			// Node not found: pod is being terminated already, don't count it.
-			continue
-		}
-		cordoned[nodeName] = node.Spec.Unschedulable
+	cordoned := make(map[string]bool, len(nodeList.Items))
+	for _, node := range nodeList.Items {
+		cordoned[node.Name] = node.Spec.Unschedulable
 	}
 
 	var count int32

--- a/internal/controller/pdb_helpers_test.go
+++ b/internal/controller/pdb_helpers_test.go
@@ -1,0 +1,149 @@
+package controllers
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("countPodsOnCordoned", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(policyv1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	makePDB := func(selector map[string]string) *policyv1.PodDisruptionBudget {
+		return &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pdb", Namespace: "default"},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: selector},
+			},
+		}
+	}
+
+	makeNode := func(name string, cordoned bool) *corev1.Node {
+		return &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       corev1.NodeSpec{Unschedulable: cordoned},
+		}
+	}
+
+	makePod := func(name, nodeName string, labels map[string]string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels:    labels,
+			},
+			Spec: corev1.PodSpec{NodeName: nodeName},
+		}
+	}
+
+	It("returns 0 when no pods match the PDB selector", func() {
+		pdb := makePDB(map[string]string{"app": "myapp"})
+		node := makeNode("node1", true) // cordoned, but no matching pods
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+
+		count, err := countPodsOnCordoned(ctx, fc, pdb)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(int32(0)))
+	})
+
+	It("returns 0 when matching pods are on uncordoned nodes", func() {
+		pdb := makePDB(map[string]string{"app": "myapp"})
+		node := makeNode("node1", false) // not cordoned
+		pod := makePod("pod1", "node1", map[string]string{"app": "myapp"})
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node, pod).Build()
+
+		count, err := countPodsOnCordoned(ctx, fc, pdb)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(int32(0)))
+	})
+
+	It("counts all pods on a single cordoned node", func() {
+		pdb := makePDB(map[string]string{"app": "myapp"})
+		node := makeNode("node1", true)
+		pod1 := makePod("pod1", "node1", map[string]string{"app": "myapp"})
+		pod2 := makePod("pod2", "node1", map[string]string{"app": "myapp"})
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node, pod1, pod2).Build()
+
+		count, err := countPodsOnCordoned(ctx, fc, pdb)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(int32(2)))
+	})
+
+	It("aggregates pods across multiple cordoned nodes", func() {
+		pdb := makePDB(map[string]string{"app": "myapp"})
+		node1 := makeNode("node1", true)
+		node2 := makeNode("node2", true)
+		node3 := makeNode("node3", false) // not cordoned
+		pod1 := makePod("pod1", "node1", map[string]string{"app": "myapp"})
+		pod2 := makePod("pod2", "node2", map[string]string{"app": "myapp"})
+		pod3 := makePod("pod3", "node3", map[string]string{"app": "myapp"})
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node1, node2, node3, pod1, pod2, pod3).Build()
+
+		count, err := countPodsOnCordoned(ctx, fc, pdb)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(int32(2))) // pod3 on node3 (uncordoned) excluded
+	})
+
+	It("skips pods with no NodeName (pending/unscheduled)", func() {
+		pdb := makePDB(map[string]string{"app": "myapp"})
+		pod := makePod("pod1", "", map[string]string{"app": "myapp"}) // no node yet
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+
+		count, err := countPodsOnCordoned(ctx, fc, pdb)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(int32(0)))
+	})
+
+	It("does not count pods that do not match the PDB selector", func() {
+		pdb := makePDB(map[string]string{"app": "myapp"})
+		node := makeNode("node1", true)
+		pod := makePod("pod1", "node1", map[string]string{"app": "other"}) // different labels
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node, pod).Build()
+
+		count, err := countPodsOnCordoned(ctx, fc, pdb)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(int32(0)))
+	})
+
+	It("counts pods on cordoned nodes while ignoring pods on uncordoned nodes (mixed cluster)", func() {
+		pdb := makePDB(map[string]string{"app": "myapp"})
+		cordoned := makeNode("cordoned-node", true)
+		healthy := makeNode("healthy-node", false)
+		// 3 pods on cordoned, 5 on healthy
+		objects := []client.Object{cordoned, healthy}
+		for i := 0; i < 3; i++ {
+			objects = append(objects, makePod(
+				"displaced-"+string(rune('a'+i)), "cordoned-node",
+				map[string]string{"app": "myapp"},
+			))
+		}
+		for i := 0; i < 5; i++ {
+			objects = append(objects, makePod(
+				"healthy-"+string(rune('a'+i)), "healthy-node",
+				map[string]string{"app": "myapp"},
+			))
+		}
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+		count, err := countPodsOnCordoned(ctx, fc, pdb)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(int32(3)))
+	})
+})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -381,7 +381,9 @@ var _ = Describe("controller", Ordered, func() {
 				ExpectWithOffset(1, err).NotTo(HaveOccurred())
 				deployment.Spec.Replicas = ptr.To(int32(2))
 				err = clientset.Update(ctx, deployment, &client.UpdateOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				if err != nil {
+					return err // 409 conflict: Eventually will retry with a fresh Get above
+				}
 				return nil
 			}
 			EventuallyWithOffset(1, scaleNginxReplicas, time.Minute, time.Second).Should(Succeed())


### PR DESCRIPTION
**EvictionAutoScaler Surge Logic Improvements:**

* Refined the surge scaling logic in the controller to scale up exactly by the number of pods displaced on cordoned nodes, capped by `maxSurge`, and to skip surge when no pods are displaced, preventing unnecessary scaling. [[1]](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddL178-R205) [[2]](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddL191-R214) [[3]](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddL202-R233)
* Added a new helper function `countPodsOnCordoned` to accurately count pods on cordoned nodes, supporting the improved surge logic.

**Testing and Documentation Updates:**

* Updated controller tests to reflect the new surge logic: deployments are not scaled up if no pods are actually displaced on cordoned nodes. [[1]](diffhunk://#diff-ead56681a4d4b68d233bd6c492875dc4f3c5c37c981ac184c1068487b090dd67L231-R235) [[2]](diffhunk://#diff-ead56681a4d4b68d233bd6c492875dc4f3c5c37c981ac184c1068487b090dd67L801-R812) [[3]](diffhunk://#diff-ead56681a4d4b68d233bd6c492875dc4f3c5c37c981ac184c1068487b090dd67R823-R827) [[4]](diffhunk://#diff-ead56681a4d4b68d233bd6c492875dc4f3c5c37c981ac184c1068487b090dd67L888-R897)
* Expanded the `README.md` with a new Networking section, clarifying that the extension does not require ARM endpoints and documenting outbound network requirements for private/restricted clusters. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R487-R513)