### PR TITLE
feat: add force_override input flag to release pipeline

### DIFF
--- a/.github/workflows/build-publish-mcr.yaml
+++ b/.github/workflows/build-publish-mcr.yaml
@@ -9,7 +9,12 @@ on:
       tag:
         description: 'Production tag to build (e.g., 0.0.17, 1.0.0). Must match X.Y.Z format, no dev tags allowed.'
         required: true
-        type: string    
+        type: string
+      force_override:
+        description: 'Override an existing version in ACR/MCR (use with caution — the existing image will be replaced).'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -112,7 +117,7 @@ jobs:
         az login --identity
         az acr login -n $RELEASE_ACR
         if [ -n "$TAG_VERSION" ]; then
-          ./hack/release.sh "$TAG_VERSION"
+          FORCE_OVERRIDE="${{ inputs.force_override || 'false' }}" ./hack/release.sh "$TAG_VERSION"
         else
           ./hack/release.sh
         fi

--- a/.github/workflows/build-publish-mcr.yaml
+++ b/.github/workflows/build-publish-mcr.yaml
@@ -1,9 +1,6 @@
 name: Build and publish to ACR
 
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       tag:
@@ -11,7 +8,7 @@ on:
         required: true
         type: string
       force_override:
-        description: 'Override an existing version in ACR/MCR (use with caution — the existing image will be replaced).'
+        description: 'Force re-release an existing ACR version (unlocks and overwrites). Use when re-tagging with a fixed Dockerfile.'
         required: false
         type: boolean
         default: false

--- a/.github/workflows/manual-release-tag.yaml
+++ b/.github/workflows/manual-release-tag.yaml
@@ -7,6 +7,11 @@ on:
         description: 'Version to release (e.g., 1.0.0). Leave empty to auto-bump minor version.'
         required: false
         type: string
+      force_override:
+        description: 'Force re-tag an existing version (moves the tag to the current HEAD). Use to re-release a version with a fixed Dockerfile.'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   create-tag:
@@ -65,8 +70,14 @@ jobs:
       - name: Check if tag already exists
         run: |
           if git rev-parse "${{ env.new_tag }}" >/dev/null 2>&1; then
-            echo "Error: Tag ${{ env.new_tag }} already exists"
-            exit 1
+            if [ "${{ inputs.force_override }}" = "true" ]; then
+              echo "WARNING: Tag ${{ env.new_tag }} already exists. force_override=true — deleting and re-creating."
+              git push origin --delete "${{ env.new_tag }}" || true
+              git tag -d "${{ env.new_tag }}" || true
+            else
+              echo "Error: Tag ${{ env.new_tag }} already exists"
+              exit 1
+            fi
           fi
 
       - name: Create and push production tag

--- a/.github/workflows/manual-release-tag.yaml
+++ b/.github/workflows/manual-release-tag.yaml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout code
@@ -87,4 +88,13 @@ jobs:
           git tag -a "${{ env.new_tag }}" -m "Release ${{ env.new_tag }}"
           git push origin "${{ env.new_tag }}"
           echo "Created production release tag: ${{ env.new_tag }}"
-          echo "This will trigger the ACR build and publish workflow."
+
+      - name: Trigger build and publish
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          gh workflow run build-publish-mcr.yaml \
+            --repo ${{ github.repository }} \
+            --field tag=${{ env.new_tag }} \
+            --field force_override=${{ inputs.force_override || 'false' }}
+          echo "Triggered build-publish-mcr.yaml for tag ${{ env.new_tag }} (force_override=${{ inputs.force_override || 'false' }})"

--- a/.github/workflows/manual-release-tag.yaml
+++ b/.github/workflows/manual-release-tag.yaml
@@ -93,8 +93,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-          gh workflow run build-publish-mcr.yaml \
-            --repo ${{ github.repository }} \
-            --field tag=${{ env.new_tag }} \
-            --field force_override=${{ inputs.force_override || 'false' }}
+          # Only pass force_override field if true — older versions of the workflow
+          # don't define this input and GitHub rejects unknown fields.
+          if [ "${{ inputs.force_override }}" = "true" ]; then
+            gh workflow run build-publish-mcr.yaml \
+              --repo ${{ github.repository }} \
+              --ref ${{ github.ref_name }} \
+              --field tag=${{ env.new_tag }} \
+              --field force_override=true
+          else
+            gh workflow run build-publish-mcr.yaml \
+              --repo ${{ github.repository }} \
+              --ref ${{ github.ref_name }} \
+              --field tag=${{ env.new_tag }}
+          fi
           echo "Triggered build-publish-mcr.yaml for tag ${{ env.new_tag }} (force_override=${{ inputs.force_override || 'false' }})"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -142,9 +142,13 @@ existing_tag=$(az acr repository show-tags -n "$RELEASE_ACR" --repository "$repo
 set -e
 
 if [[ -n "$existing_tag" ]]; then
+  echo "Version $version already exists in ACR."
   if [[ "${FORCE_OVERRIDE:-false}" == "true" ]]; then
-    echo "WARNING: Version $version already exists in ACR. FORCE_OVERRIDE=true — proceeding with override."
-    echo "The existing image and Helm chart will be replaced in ACR and replicated to MCR."
+    echo "WARNING: FORCE_OVERRIDE=true — proceeding with override."
+    echo "Unlocking existing image and Helm chart tags in ACR to allow overwrite..."
+    az acr repository update -n "${RELEASE_ACR}" --image "${repo_path}:${version}" --write-enabled true --delete-enabled true
+    az acr repository update -n "${RELEASE_ACR}" --image "${repo_path}/helm/eviction-autoscaler:${version}" --write-enabled true --delete-enabled true || true
+    echo "Successfully unlocked $version in ACR. The existing image and Helm chart will be replaced."
   else
     echo "Version $version already exists in ACR - skipping release"
     echo "To release a new version, create a new tag:"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -142,7 +142,8 @@ existing_tag=$(az acr repository show-tags -n "$RELEASE_ACR" --repository "$repo
 set -e
 
 if [[ -n "$existing_tag" ]]; then
-  echo "Version $version already exists in ACR."
+  existing_digest=$(crane digest "${IMAGE_REPO}:${version}" 2>/dev/null || true)
+  echo "Version $version already exists in ACR (digest: ${existing_digest:-unknown})."
   if [[ "${FORCE_OVERRIDE:-false}" == "true" ]]; then
     echo "WARNING: FORCE_OVERRIDE=true — proceeding with override."
     echo "Unlocking existing image and Helm chart tags in ACR to allow overwrite..."
@@ -180,6 +181,13 @@ IMG="${IMAGE_REPO}:${version}"
 img_digest="$(crane digest "$IMG")"
 IMG_REF="${IMAGE_REPO}@${img_digest}"
 echo "Image pushed: ${IMG_REF}"
+if [[ -n "${existing_digest:-}" ]]; then
+  if [[ "$img_digest" != "$existing_digest" ]]; then
+    echo "Image successfully replaced: ${existing_digest} → ${img_digest}"
+  else
+    echo "WARNING: Image digest unchanged after push: ${img_digest}"
+  fi
+fi
 
 echo "Verifying manifest contains platforms: ${RELEASE_PLATFORMS}..."
 manifest_output="$(docker buildx imagetools inspect "$IMG")"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -142,11 +142,17 @@ existing_tag=$(az acr repository show-tags -n "$RELEASE_ACR" --repository "$repo
 set -e
 
 if [[ -n "$existing_tag" ]]; then
-  echo "Version $version already exists in ACR - skipping release"
-  echo "To release a new version, create a new tag:"
-  echo "  git tag <new-version>  (e.g., 1.0.1)"
-  echo "  git push origin <new-version>"
-  exit 1
+  if [[ "${FORCE_OVERRIDE:-false}" == "true" ]]; then
+    echo "WARNING: Version $version already exists in ACR. FORCE_OVERRIDE=true — proceeding with override."
+    echo "The existing image and Helm chart will be replaced in ACR and replicated to MCR."
+  else
+    echo "Version $version already exists in ACR - skipping release"
+    echo "To release a new version, create a new tag:"
+    echo "  git tag <new-version>  (e.g., 1.0.1)"
+    echo "  git push origin <new-version>"
+    echo "To override the existing version, re-run the workflow with force_override=true."
+    exit 1
+  fi
 fi
 
 echo "Releasing eviction-autoscaler"


### PR DESCRIPTION
This pull request adds support for overriding existing container image versions in the release workflow. The main change is the introduction of a `force_override` input, which allows users to explicitly replace an existing image and Helm chart in the Azure Container Registry (ACR) and Microsoft Container Registry (MCR) when needed. The workflow and release script have been updated to respect this new option and provide clear warnings and instructions.

**Enhancements to release workflow:**

* Added a new `force_override` boolean input to the `build-publish-mcr.yaml` workflow, allowing users to override an existing version in ACR/MCR if necessary.
* Updated the workflow to pass the `FORCE_OVERRIDE` environment variable to the release script based on the `force_override` input.

**Improvements to release script behavior:**

* Modified `hack/release.sh` to check for the `FORCE_OVERRIDE` variable: if set to `true`, the script will proceed with overwriting the existing image and Helm chart, displaying a warning; otherwise, it will skip the release and provide instructions for overriding.