### PR TITLE
feat: add readiness-aware surge retry with time-to-ready annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Your app might also experience issues for unrelated reasons, and a maintenance e
 - **Eviction-autoscaler Controller**: Watches eviction-autoscale resources. If there a recent eviction singals and the PDB's AllowedDisruotions is zero, it triggers a surge in the corresponding deployment. Once evitions have stopped for some cooldown period and allowed diruptions has rised above zero it scales down.
 - **HPA-aware surge**: When an HPA targets the deployment, the controller surges by temporarily raising the HPA's `minReplicas` instead of mutating deployment replicas directly. This prevents the HPA from immediately scaling the deployment back down during a surge. On revert, the original `minReplicas` floor is restored.
 - **KEDA-aware surge**: When a KEDA ScaledObject targets the deployment, the controller surges by temporarily raising the ScaledObject's `minReplicaCount`. The same pattern applies — annotations on the ScaledObject track the surge state and original value for safe revert.
+- **Readiness-aware surge revert**: The controller waits for all surged pods to become Ready before reverting to the original replica count. Reverting while pods are still starting would kill them on their new nodes and lose drain progress. Use the `eviction-autoscaler.azure.com/time-to-ready` deployment annotation to tell the controller how long your pods typically take to start (default: 5 minutes, maximum: 10 minutes). Once the wait limit is reached the controller reverts regardless, so a slow start never blocks drain indefinitely.
 - **PDB Controller** (Optional): Automatically creates eviction-autoscalers Custom Resources for existing PDBs. When an HPA or KEDA ScaledObject targets the deployment, PDB `minAvailable` is set from the autoscaler's min replicas floor rather than `deployment.spec.replicas`.
 - **Autoscaler-to-PDB Controller** (Optional): Watches HPA and KEDA ScaledObject changes and updates PDB `minAvailable` to track the autoscaler's min replicas floor, even when deployment replicas don't change.
 - **Deployment Controller** (Optional): Creates PDBs for deployments that don't already have them and keeps min available matching the deployments replicas (not counting any surged in by eviction autoscaler). Defers to the Autoscaler-to-PDB controller when an HPA or KEDA ScaledObject is present.
@@ -524,8 +525,56 @@ During a surge, the eviction autoscaler places annotations on the **autoscaler o
 | `evictionSurgeReplicas` | HPA or ScaledObject | Surged replica count (e.g., `"3"`) | Marks that a surge is active |
 | `eviction-autoscaler.azure.com/original-min-replicas` | HPA or ScaledObject | Pre-surge min replicas (e.g., `"1"`) | Stores the original value for safe revert |
 | `evictionSurgeReplicas` | Deployment | Surged replica count | Only used when **no** HPA/KEDA is present |
+| `eviction-autoscaler.azure.com/time-to-ready` | **Deployment** | Minutes pods take to become Ready (e.g., `"3"`) | Configures how long the controller waits before reverting (see below) |
 
-These annotations are managed automatically by the controller. They are set atomically with the `minReplicas`/`minReplicaCount` change during surge and removed during revert. You should not modify them manually.
+The first three annotations are managed automatically by the controller. They are set atomically with the `minReplicas`/`minReplicaCount` change during surge and removed during revert. You should not modify them manually.
+
+The `time-to-ready` annotation is set by you on the **Deployment** to tune how long the controller waits for surged pods before reverting — see the next section.
+
+### Tuning Surge Revert: `time-to-ready` Annotation
+
+After scaling up, the controller waits for all surged pods to become `Ready` before reverting to the original replica count. Reverting early would kill pods that are still starting on the new nodes, losing drain progress.
+
+The `eviction-autoscaler.azure.com/time-to-ready` annotation on the **Deployment** controls the maximum wait:
+
+| Setting | Behaviour |
+|---|---|
+| Annotation absent | Waits up to **5 minutes** (default) |
+| `"1"` – `"10"` | Waits up to that many minutes |
+| Value outside 1–10 | EA CR is marked **Degraded** (`InvalidTimeToReadyAnnotation`) and no surge is attempted |
+
+> **TODO:** The current maximum of 10 minutes covers most typical web services and JVM apps, but is too low for workloads that legitimately take longer to start — for example, ML inference servers loading large models (GPT, BERT, etc.) can need 10–30 minutes. Consider raising the cap or removing it entirely and relying on documentation to guide sensible values. The safety guarantee (revert even if pods never become Ready) holds regardless of the chosen limit.
+
+**Apply the annotation:**
+
+```bash
+kubectl annotate deployment <name> -n <namespace> \
+  eviction-autoscaler.azure.com/time-to-ready="8"
+```
+
+Or in the Deployment manifest:
+
+```yaml
+metadata:
+  annotations:
+    eviction-autoscaler.azure.com/time-to-ready: "8"   # pods take ~8 min to start
+```
+
+**How it works:**
+
+The controller wakes up once per cooldown period (1 minute). Each wake-up counts as one attempt. When the number of attempts reaches the `time-to-ready` value the controller reverts the surge even if some pods are not yet Ready, so a slow-starting deployment never blocks a node drain indefinitely.
+
+If all pods become Ready *before* the limit is reached the controller reverts immediately without burning the remaining attempts.
+
+**Inspecting progress:**
+
+```bash
+# How many requeue attempts have been used so far
+kubectl get evictionautoscaler <name> -n <namespace> \
+  -o jsonpath='{.status.surgeAttempts}'
+```
+
+A `surgeAttempts` value of `0` means no surge is in progress (or it has been successfully reverted).
 
 **Inspecting surge state:**
 

--- a/api/v1/evictionautoscaler_types.go
+++ b/api/v1/evictionautoscaler_types.go
@@ -20,9 +20,10 @@ type EvictionAutoScalerSpec struct {
 
 // EvictionAutoScalerStatus defines the observed state of EvictionAutoScaler
 type EvictionAutoScalerStatus struct {
-	LastEviction     Eviction           `json:"lastEviction,omitempty"` //this is the last one the controller has processed.
-	MinReplicas      int32              `json:"minReplicas"`            // Minimum number of replicas to maintain
-	TargetGeneration int64              `json:"deploymentGeneration"`   // generation (spec hash) of deployment or statefulse
+	LastEviction     Eviction           `json:"lastEviction,omitempty"`  //this is the last one the controller has processed.
+	MinReplicas      int32              `json:"minReplicas"`             // Minimum number of replicas to maintain
+	TargetGeneration int64              `json:"deploymentGeneration"`    // generation (spec hash) of deployment or statefulse
+	SurgeAttempts    int32              `json:"surgeAttempts,omitempty"` // Number of times we have requeued waiting for surged pods to become ready
 	Conditions       []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/config/crd/bases/eviction-autoscaler.azure.com_evictionautoscalers.yaml
+++ b/config/crd/bases/eviction-autoscaler.azure.com_evictionautoscalers.yaml
@@ -133,6 +133,9 @@ spec:
               minReplicas:
                 format: int32
                 type: integer
+              surgeAttempts:
+                format: int32
+                type: integer
             required:
             - deploymentGeneration
             - minReplicas

--- a/internal/controller/autoscaler_helpers_test.go
+++ b/internal/controller/autoscaler_helpers_test.go
@@ -14,6 +14,111 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+var _ = Describe("getMaxSurgeAttempts", func() {
+	makeTarget := func(annotations map[string]string) Surger {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Annotations: annotations},
+		}
+		return &DeploymentWrapper{obj: dep}
+	}
+
+	It("returns the default when no annotation is set", func() {
+		target := makeTarget(nil)
+		Expect(getMaxSurgeAttempts(target)).To(Equal(int32(defaultTimeToReadyMinutes)))
+	})
+
+	It("returns the value from the time-to-ready annotation", func() {
+		target := makeTarget(map[string]string{TimeToReadyAnnotationKey: "10"})
+		Expect(getMaxSurgeAttempts(target)).To(Equal(int32(10)))
+	})
+
+	It("returns 1 from a time-to-ready annotation of 1", func() {
+		target := makeTarget(map[string]string{TimeToReadyAnnotationKey: "1"})
+		Expect(getMaxSurgeAttempts(target)).To(Equal(int32(1)))
+	})
+
+	It("returns the default when the annotation value is not a number", func() {
+		target := makeTarget(map[string]string{TimeToReadyAnnotationKey: "invalid"})
+		Expect(getMaxSurgeAttempts(target)).To(Equal(int32(defaultTimeToReadyMinutes)))
+	})
+
+	It("returns the default when the annotation value is zero", func() {
+		target := makeTarget(map[string]string{TimeToReadyAnnotationKey: "0"})
+		Expect(getMaxSurgeAttempts(target)).To(Equal(int32(defaultTimeToReadyMinutes)))
+	})
+
+	It("returns the default when the annotation value is negative", func() {
+		target := makeTarget(map[string]string{TimeToReadyAnnotationKey: "-5"})
+		Expect(getMaxSurgeAttempts(target)).To(Equal(int32(defaultTimeToReadyMinutes)))
+	})
+})
+
+var _ = Describe("validateTimeToReadyAnnotation", func() {
+	makeTarget := func(annotations map[string]string) Surger {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Annotations: annotations},
+		}
+		return &DeploymentWrapper{obj: dep}
+	}
+
+	It("returns nil when annotation is absent", func() {
+		Expect(validateTimeToReadyAnnotation(makeTarget(nil))).To(Succeed())
+	})
+
+	It("returns nil when annotation is absent from a non-nil map", func() {
+		Expect(validateTimeToReadyAnnotation(makeTarget(map[string]string{"other": "val"}))).To(Succeed())
+	})
+
+	It("returns nil for minimum valid value 1", func() {
+		Expect(validateTimeToReadyAnnotation(makeTarget(map[string]string{TimeToReadyAnnotationKey: "1"}))).To(Succeed())
+	})
+
+	It("returns nil for maximum valid value 10", func() {
+		Expect(validateTimeToReadyAnnotation(makeTarget(map[string]string{TimeToReadyAnnotationKey: "10"}))).To(Succeed())
+	})
+
+	It("returns nil for a value in the middle of the range", func() {
+		Expect(validateTimeToReadyAnnotation(makeTarget(map[string]string{TimeToReadyAnnotationKey: "5"}))).To(Succeed())
+	})
+
+	It("returns an error for value 0", func() {
+		Expect(validateTimeToReadyAnnotation(makeTarget(map[string]string{TimeToReadyAnnotationKey: "0"}))).To(HaveOccurred())
+	})
+
+	It("returns an error for value 11 (above maximum)", func() {
+		Expect(validateTimeToReadyAnnotation(makeTarget(map[string]string{TimeToReadyAnnotationKey: "11"}))).To(HaveOccurred())
+	})
+
+	It("returns an error for a negative value", func() {
+		Expect(validateTimeToReadyAnnotation(makeTarget(map[string]string{TimeToReadyAnnotationKey: "-1"}))).To(HaveOccurred())
+	})
+
+	It("returns an error for a non-numeric value", func() {
+		Expect(validateTimeToReadyAnnotation(makeTarget(map[string]string{TimeToReadyAnnotationKey: "fast"}))).To(HaveOccurred())
+	})
+
+	It("error message names the annotation key and the bad value", func() {
+		err := validateTimeToReadyAnnotation(makeTarget(map[string]string{TimeToReadyAnnotationKey: "99"}))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(TimeToReadyAnnotationKey))
+		Expect(err.Error()).To(ContainSubstring("99"))
+	})
+})
+
+var _ = Describe("GetReadyReplicas", func() {
+	It("returns ReadyReplicas from deployment status", func() {
+		dep := &appsv1.Deployment{
+			Status: appsv1.DeploymentStatus{ReadyReplicas: 3},
+		}
+		Expect((&DeploymentWrapper{obj: dep}).GetReadyReplicas()).To(Equal(int32(3)))
+	})
+
+	It("returns 0 when no pods are ready", func() {
+		dep := &appsv1.Deployment{}
+		Expect((&DeploymentWrapper{obj: dep}).GetReadyReplicas()).To(Equal(int32(0)))
+	})
+})
+
 var _ = Describe("ResolveMinReplicas", func() {
 	It("should return 0 when KEDA ScaledObject has nil minReplicaCount (scale-to-zero)", func() {
 		ctx := context.Background()

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -307,28 +307,8 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		// If the surged pods are not all ready yet, give them more time before reverting.
 		// Reverting early would kill not-yet-ready pods on new nodes and lose drain progress.
-		// We requeue up to maxSurgeAttempts times (each waits one cooldown period) to handle
-		// pods that are slow to start. Once all desired pods are ready the drain can proceed,
-		// so we revert immediately rather than burning unnecessary attempts.
-		maxAttempts := getMaxSurgeAttempts(target)
-		if target.GetReadyReplicas() < target.GetReplicas() && EvictionAutoScaler.Status.SurgeAttempts < maxAttempts {
-			EvictionAutoScaler.Status.SurgeAttempts++
-			logger.Info("Surge active, waiting for pods to become ready before reverting",
-				"readyReplicas", target.GetReadyReplicas(),
-				"desiredReplicas", target.GetReplicas(),
-				"surgeAttempts", EvictionAutoScaler.Status.SurgeAttempts,
-				"maxSurgeAttempts", maxAttempts,
-				"target", EvictionAutoScaler.Spec.TargetName)
-			ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", fmt.Sprintf("waiting for surged pods to become ready (attempt %d/%d)", EvictionAutoScaler.Status.SurgeAttempts, maxAttempts))
-			return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
-		}
-
-		if EvictionAutoScaler.Status.SurgeAttempts >= maxAttempts {
-			logger.Info("Max surge attempts reached, reverting surge",
-				"readyReplicas", target.GetReadyReplicas(),
-				"desiredReplicas", target.GetReplicas(),
-				"surgeAttempts", EvictionAutoScaler.Status.SurgeAttempts,
-				"target", EvictionAutoScaler.Spec.TargetName)
+		if result, err, done := r.waitForSurgePodReadiness(ctx, EvictionAutoScaler, target); done {
+			return result, err
 		}
 
 		//okay we aren't at allowed disruptions Revert Target to the original state
@@ -358,6 +338,39 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "last eviction did not need scaling")
 	logger.Info(fmt.Sprintf("Handled eviction %s", EvictionAutoScaler.Spec.LastEviction))
 	return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler) //should we go rety in case there is also an eviction or just wait till the next eviction
+}
+
+// waitForSurgePodReadiness checks whether the surged pods are ready before allowing
+// a revert. If pods are not all ready and the retry budget is not exhausted it
+// increments SurgeAttempts, requeues with cooldown, and returns done=true.
+// If the budget is exhausted it logs a warning and returns done=false so the
+// caller proceeds with the unconditional revert.
+func (r *EvictionAutoScalerReconciler) waitForSurgePodReadiness(
+	ctx context.Context,
+	ea *myappsv1.EvictionAutoScaler,
+	target Surger,
+) (ctrl.Result, error, bool) {
+	logger := log.FromContext(ctx)
+	maxAttempts := getMaxSurgeAttempts(target)
+	if target.GetReadyReplicas() < target.GetReplicas() && ea.Status.SurgeAttempts < maxAttempts {
+		ea.Status.SurgeAttempts++
+		logger.Info("Surge active, waiting for pods to become ready before reverting",
+			"readyReplicas", target.GetReadyReplicas(),
+			"desiredReplicas", target.GetReplicas(),
+			"surgeAttempts", ea.Status.SurgeAttempts,
+			"maxSurgeAttempts", maxAttempts,
+			"target", ea.Spec.TargetName)
+		ready(&ea.Status.Conditions, "Reconciled", fmt.Sprintf("waiting for surged pods to become ready (attempt %d/%d)", ea.Status.SurgeAttempts, maxAttempts))
+		return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, ea), true
+	}
+	if ea.Status.SurgeAttempts >= maxAttempts {
+		logger.Info("Max surge attempts reached, reverting surge",
+			"readyReplicas", target.GetReadyReplicas(),
+			"desiredReplicas", target.GetReplicas(),
+			"surgeAttempts", ea.Status.SurgeAttempts,
+			"target", ea.Spec.TargetName)
+	}
+	return ctrl.Result{}, nil, false
 }
 
 func ready(conditions *[]metav1.Condition, reason string, message string) {

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -42,6 +42,55 @@ type EvictionAutoScalerReconciler struct {
 
 const cooldown = 1 * time.Minute
 
+// defaultTimeToReadyMinutes is used when the deployment does not have the
+// eviction-autoscaler.azure.com/time-to-ready annotation. The controller requeues
+// once per cooldown period, so this is also the default number of retries.
+const defaultTimeToReadyMinutes = 5
+
+// TimeToReadyAnnotationKey is a deployment annotation that tells the controller how
+// many minutes the deployment's pods typically take to become Ready. The controller
+// uses this to determine how many times to requeue (one per cooldown minute) before
+// giving up and reverting the surge.
+// Example: eviction-autoscaler.azure.com/time-to-ready: "10"
+const TimeToReadyAnnotationKey = "eviction-autoscaler.azure.com/time-to-ready"
+
+// getMaxSurgeAttempts returns the maximum number of requeue attempts before the
+// controller gives up waiting for surged pods to become ready and reverts the surge.
+// It reads the time-to-ready annotation from the target deployment (in minutes) and
+// divides by the cooldown period. Falls back to defaultTimeToReadyMinutes.
+// Callers must have already validated the annotation with validateTimeToReadyAnnotation.
+func getMaxSurgeAttempts(target Surger) int32 {
+	if annotations := target.Obj().GetAnnotations(); annotations != nil {
+		if val, ok := annotations[TimeToReadyAnnotationKey]; ok {
+			if parsed, err := strconv.ParseInt(val, 10, 32); err == nil && parsed > 0 {
+				return int32(math.Ceil(float64(parsed) / cooldown.Minutes()))
+			}
+		}
+	}
+	return int32(math.Ceil(float64(defaultTimeToReadyMinutes) / cooldown.Minutes()))
+}
+
+// validateTimeToReadyAnnotation checks the TimeToReadyAnnotationKey annotation on the
+// target. If present the value must be an integer in [1, 10] (inclusive). Returns a
+// non-nil error with a human-readable message when the annotation is invalid so the
+// caller can mark the EA CR as Degraded.
+func validateTimeToReadyAnnotation(target Surger) error {
+	annotations := target.Obj().GetAnnotations()
+	if annotations == nil {
+		return nil
+	}
+	val, ok := annotations[TimeToReadyAnnotationKey]
+	if !ok {
+		return nil
+	}
+	parsed, err := strconv.ParseInt(val, 10, 32)
+	if err != nil || parsed < 1 || parsed > 10 {
+		return fmt.Errorf("invalid %s annotation %q: must be an integer between 1 and 10",
+			TimeToReadyAnnotationKey, val)
+	}
+	return nil
+}
+
 // +kubebuilder:rbac:groups=eviction-autoscaler.azure.com,resources=evictionautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=eviction-autoscaler.azure.com,resources=evictionautoscalers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=eviction-autoscaler.azure.com,resources=evictionautoscalers/finalizers,verbs=update
@@ -120,6 +169,16 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler)
 		}
 		return ctrl.Result{}, err
+	}
+
+	// Validate the time-to-ready annotation before doing any surge work.
+	// An out-of-range value is a misconfiguration that would produce confusing behaviour,
+	// so we surface it immediately as a Degraded condition and stop reconciling.
+	if err := validateTimeToReadyAnnotation(target); err != nil {
+		logger.Error(err, "invalid time-to-ready annotation, marking EA as degraded",
+			"target", EvictionAutoScaler.Spec.TargetName)
+		degraded(&EvictionAutoScaler.Status.Conditions, "InvalidTimeToReadyAnnotation", err.Error())
+		return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler)
 	}
 
 	// TODO: Move PDB configuration tracking to PDB controller with aggregate labels
@@ -222,6 +281,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
 			// Save ResourceVersion to EvictionAutoScaler status this will cause another reconcile.
 			EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
+			EvictionAutoScaler.Status.SurgeAttempts = 1
 			//Do not update EvictionAutoScaler.Status.LastEviction because we need to keep reconciling till scale down
 			ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "eviction with scale up")
 			return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
@@ -245,6 +305,32 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Track scaling opportunity
 		metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleDownAction, metrics.CooldownElapsedSignal).Inc()
 
+		// If the surged pods are not all ready yet, give them more time before reverting.
+		// Reverting early would kill not-yet-ready pods on new nodes and lose drain progress.
+		// We requeue up to maxSurgeAttempts times (each waits one cooldown period) to handle
+		// pods that are slow to start. Once all desired pods are ready the drain can proceed,
+		// so we revert immediately rather than burning unnecessary attempts.
+		maxAttempts := getMaxSurgeAttempts(target)
+		if target.GetReadyReplicas() < target.GetReplicas() && EvictionAutoScaler.Status.SurgeAttempts < maxAttempts {
+			EvictionAutoScaler.Status.SurgeAttempts++
+			logger.Info("Surge active, waiting for pods to become ready before reverting",
+				"readyReplicas", target.GetReadyReplicas(),
+				"desiredReplicas", target.GetReplicas(),
+				"surgeAttempts", EvictionAutoScaler.Status.SurgeAttempts,
+				"maxSurgeAttempts", maxAttempts,
+				"target", EvictionAutoScaler.Spec.TargetName)
+			ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", fmt.Sprintf("waiting for surged pods to become ready (attempt %d/%d)", EvictionAutoScaler.Status.SurgeAttempts, maxAttempts))
+			return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
+		}
+
+		if EvictionAutoScaler.Status.SurgeAttempts >= maxAttempts {
+			logger.Info("Max surge attempts reached, reverting surge",
+				"readyReplicas", target.GetReadyReplicas(),
+				"desiredReplicas", target.GetReplicas(),
+				"surgeAttempts", EvictionAutoScaler.Status.SurgeAttempts,
+				"target", EvictionAutoScaler.Spec.TargetName)
+		}
+
 		//okay we aren't at allowed disruptions Revert Target to the original state
 		err = surgeApplier.RevertSurge(ctx, EvictionAutoScaler.Status.MinReplicas)
 		if err != nil {
@@ -260,6 +346,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		logger.Info(fmt.Sprintf("TargetGeneration moving from %d->%d", EvictionAutoScaler.Status.TargetGeneration, target.Obj().GetGeneration()))
 		EvictionAutoScaler.Status.TargetGeneration = target.Obj().GetGeneration()
 		EvictionAutoScaler.Status.LastEviction = EvictionAutoScaler.Spec.LastEviction //we could still keep a log here if thats useful
+		EvictionAutoScaler.Status.SurgeAttempts = 0
 		logger.Info(fmt.Sprintf("Handled eviction %s", EvictionAutoScaler.Spec.LastEviction))
 
 		ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "evictions hit cooldown so scaled down")

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -783,6 +783,14 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			Expect(k8sClient.Update(ctx, EvictionAutoScaler)).To(Succeed())
 			Expect(EvictionAutoScaler.Spec.LastEviction.EvictionTime).ToNot(Equal(EvictionAutoScaler.Status.LastEviction.EvictionTime))
 
+			// All surged pods are now ready — the new retry logic only reverts when
+			// readyReplicas >= desiredReplicas (or max attempts exhausted).
+			err = k8sClient.Get(ctx, deploymentNamespacedName, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			deployment.Status.Replicas = 2
+			deployment.Status.ReadyReplicas = 2
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
 			//second reconcile should scaledown.
 			result, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -1324,6 +1332,223 @@ func int32Ptr(i int32) *int32 {
 	return &i
 }
 
+var _ = Describe("EvictionAutoScaler Controller - surge retry behavior", func() {
+	ctx := context.Background()
+
+	var (
+		surgeNs         string
+		eaNsName        types.NamespacedName
+		deployNsName    types.NamespacedName
+		surgeReconciler *EvictionAutoScalerReconciler
+	)
+
+	BeforeEach(func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-surge-",
+				Annotations: map[string]string{
+					namespacefilter.EnableEvictionAutoscalerAnnotationKey: "true",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		surgeNs = ns.Name
+		eaNsName = types.NamespacedName{Name: "surge-ea", Namespace: surgeNs}
+		deployNsName = types.NamespacedName{Name: "surge-deploy", Namespace: surgeNs}
+
+		// Create a deployment that is already in the surged state (spec.replicas=2, surge annotation present).
+		surge := intstr.FromInt(1)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "surge-deploy",
+				Namespace: surgeNs,
+				Annotations: map[string]string{
+					EvictionSurgeReplicasAnnotationKey: "2",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: int32Ptr(2),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "surge-test"}},
+				Strategy: appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{MaxSurge: &surge},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "surge-test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{Name: "surge-ea", Namespace: surgeNs},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MinAvailable: &intstr.IntOrString{IntVal: 1},
+				Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "surge-test"}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pdb)).To(Succeed())
+		// DisruptionsAllowed > 0 so the reconciler skips the scale-up path and goes straight to revert logic.
+		pdb.Status.DisruptionsAllowed = 1
+		Expect(k8sClient.Status().Update(ctx, pdb)).To(Succeed())
+
+		// Create EA with a past eviction (beyond cooldown) so the cooldown gate is already open.
+		ea := &v1.EvictionAutoScaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "surge-ea", Namespace: surgeNs},
+			Spec: v1.EvictionAutoScalerSpec{
+				TargetName: "surge-deploy",
+				TargetKind: "deployment",
+				LastEviction: v1.Eviction{
+					PodName:      "evicted-pod",
+					EvictionTime: metav1.NewTime(time.Now().Add(-2 * cooldown)),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ea)).To(Succeed())
+
+		// Set EA status to reflect the surged state: minReplicas=1, attempt 1 already recorded.
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		ea.Status.MinReplicas = 1
+		ea.Status.TargetGeneration = dep.Generation
+		ea.Status.SurgeAttempts = 1
+		Expect(k8sClient.Status().Update(ctx, ea)).To(Succeed())
+
+		surgeReconciler = &EvictionAutoScalerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			Filter: &evictionTestFilter{},
+		}
+	})
+
+	It("requeues and increments SurgeAttempts when pods are not ready and under max attempts", func() {
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		dep.Status.Replicas = 2
+		dep.Status.ReadyReplicas = 1 // 1 of 2 desired pods ready
+		Expect(k8sClient.Status().Update(ctx, dep)).To(Succeed())
+
+		result, err := surgeReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: eaNsName})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(cooldown))
+
+		// Deployment must NOT be reverted.
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
+
+		// SurgeAttempts must be incremented.
+		ea := &v1.EvictionAutoScaler{}
+		Expect(k8sClient.Get(ctx, eaNsName, ea)).To(Succeed())
+		Expect(ea.Status.SurgeAttempts).To(Equal(int32(2)))
+	})
+
+	It("reverts immediately when all surged pods are ready before max attempts", func() {
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		dep.Status.Replicas = 2
+		dep.Status.ReadyReplicas = 2 // all desired pods ready
+		Expect(k8sClient.Status().Update(ctx, dep)).To(Succeed())
+
+		result, err := surgeReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: eaNsName})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+		// Deployment must be reverted to the original minReplicas.
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(1)))
+
+		// SurgeAttempts must be reset.
+		ea := &v1.EvictionAutoScaler{}
+		Expect(k8sClient.Get(ctx, eaNsName, ea)).To(Succeed())
+		Expect(ea.Status.SurgeAttempts).To(Equal(int32(0)))
+	})
+
+	It("gives up and reverts after max surge attempts when pods remain not ready", func() {
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		dep.Status.ReadyReplicas = 0 // pods still not ready
+		Expect(k8sClient.Status().Update(ctx, dep)).To(Succeed())
+
+		// Advance SurgeAttempts to the default maximum.
+		ea := &v1.EvictionAutoScaler{}
+		Expect(k8sClient.Get(ctx, eaNsName, ea)).To(Succeed())
+		ea.Status.SurgeAttempts = defaultTimeToReadyMinutes
+		Expect(k8sClient.Status().Update(ctx, ea)).To(Succeed())
+
+		result, err := surgeReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: eaNsName})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+		// Deployment must be reverted despite pods not being ready.
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(1)))
+
+		Expect(k8sClient.Get(ctx, eaNsName, ea)).To(Succeed())
+		Expect(ea.Status.SurgeAttempts).To(Equal(int32(0)))
+	})
+
+	It("uses the time-to-ready annotation on the deployment to determine max attempts", func() {
+		// Annotate the deployment with time-to-ready=2 → max 2 attempts.
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		dep.Annotations[TimeToReadyAnnotationKey] = "2"
+		Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed()) // refresh RV
+		dep.Status.Replicas = 2
+		dep.Status.ReadyReplicas = 0
+		Expect(k8sClient.Status().Update(ctx, dep)).To(Succeed())
+
+		// SurgeAttempts is at the annotation-based max (2).
+		// Re-sync TargetGeneration in case annotating the deployment bumped the generation.
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		ea := &v1.EvictionAutoScaler{}
+		Expect(k8sClient.Get(ctx, eaNsName, ea)).To(Succeed())
+		ea.Status.SurgeAttempts = 2
+		ea.Status.TargetGeneration = dep.Generation
+		Expect(k8sClient.Status().Update(ctx, ea)).To(Succeed())
+
+		result, err := surgeReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: eaNsName})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(1)))
+	})
+
+	It("keeps waiting when time-to-ready annotation allows more attempts", func() {
+		// Annotate the deployment with time-to-ready=10 → max 10 attempts.
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		dep.Annotations[TimeToReadyAnnotationKey] = "10"
+		Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		dep.Status.Replicas = 2
+		dep.Status.ReadyReplicas = 1 // still not fully ready
+		Expect(k8sClient.Status().Update(ctx, dep)).To(Succeed())
+
+		// SurgeAttempts is well under the annotation-based max.
+		// Re-sync TargetGeneration in case annotating the deployment bumped the generation.
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		ea := &v1.EvictionAutoScaler{}
+		Expect(k8sClient.Get(ctx, eaNsName, ea)).To(Succeed())
+		ea.Status.SurgeAttempts = 3
+		ea.Status.TargetGeneration = dep.Generation
+		Expect(k8sClient.Status().Update(ctx, ea)).To(Succeed())
+
+		result, err := surgeReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: eaNsName})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(cooldown))
+
+		// Deployment must NOT be reverted.
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
+
+		Expect(k8sClient.Get(ctx, eaNsName, ea)).To(Succeed())
+		Expect(ea.Status.SurgeAttempts).To(Equal(int32(4)))
+	})
+})
+
 var _ = Describe("EvictionAutoScaler Controller - unsupported autoscaler config", func() {
 	ctx := context.Background()
 
@@ -1445,5 +1670,113 @@ var _ = Describe("EvictionAutoScaler Controller - unsupported autoscaler config"
 		Expect(degradedCondition.Reason).To(Equal("UnsupportedAutoscalerConfiguration"))
 		Expect(degradedCondition.Message).To(ContainSubstring("KEDA ScaledObject"))
 		Expect(degradedCondition.Message).To(ContainSubstring("standalone HPA"))
+	})
+})
+
+var _ = Describe("EvictionAutoScaler Controller - invalid time-to-ready annotation", func() {
+	ctx := context.Background()
+
+	// buildInvalidAnnotationScenario creates all necessary resources and returns a
+	// ready-to-use reconciler plus the EA namespaced name.
+	buildScenario := func(annotationValue string) (*EvictionAutoScalerReconciler, types.NamespacedName) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-ttr-invalid-",
+				Annotations:  map[string]string{"eviction-autoscaler.azure.com/enable": "true"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		namespace := ns.Name
+
+		surge := intstr.FromInt(1)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ttr-deploy",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					TimeToReadyAnnotationKey: annotationValue,
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "ttr"}},
+				Strategy: appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{MaxSurge: &surge},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "ttr"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{Name: "ttr-ea", Namespace: namespace},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MinAvailable: &intstr.IntOrString{IntVal: 1},
+				Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "ttr"}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pdb)).To(Succeed())
+
+		ea := &v1.EvictionAutoScaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "ttr-ea", Namespace: namespace},
+			Spec: v1.EvictionAutoScalerSpec{
+				TargetName: "ttr-deploy",
+				TargetKind: "deployment",
+			},
+		}
+		Expect(k8sClient.Create(ctx, ea)).To(Succeed())
+
+		reconciler := &EvictionAutoScalerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			Filter: &evictionTestFilter{},
+		}
+		eaNsName := types.NamespacedName{Name: "ttr-ea", Namespace: namespace}
+		return reconciler, eaNsName
+	}
+
+	checkDegraded := func(eaNsName types.NamespacedName) {
+		var updated v1.EvictionAutoScaler
+		Expect(k8sClient.Get(ctx, eaNsName, &updated)).To(Succeed())
+		var cond *metav1.Condition
+		for i := range updated.Status.Conditions {
+			if updated.Status.Conditions[i].Type == "Degraded" {
+				cond = &updated.Status.Conditions[i]
+				break
+			}
+		}
+		Expect(cond).ToNot(BeNil(), "expected Degraded condition")
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(cond.Reason).To(Equal("InvalidTimeToReadyAnnotation"))
+		Expect(cond.Message).To(ContainSubstring(TimeToReadyAnnotationKey))
+	}
+
+	It("marks EA degraded when time-to-ready is above the maximum (11)", func() {
+		reconciler, eaNsName := buildScenario("11")
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: eaNsName})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero())
+		checkDegraded(eaNsName)
+	})
+
+	It("marks EA degraded when time-to-ready is 0", func() {
+		reconciler, eaNsName := buildScenario("0")
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: eaNsName})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero())
+		checkDegraded(eaNsName)
+	})
+
+	It("marks EA degraded when time-to-ready is not a number", func() {
+		reconciler, eaNsName := buildScenario("fast")
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: eaNsName})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero())
+		checkDegraded(eaNsName)
 	})
 })

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -639,6 +639,11 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
 			Expect(*dep.Spec.Replicas).To(Equal(int32(5)), "no scale-down yet: still within cooldown")
 
+			// Simulate all surged pods becoming ready so the readiness check allows revert.
+			dep.Status.Replicas = 5
+			dep.Status.ReadyReplicas = 5
+			Expect(k8sClient.Status().Update(ctx, dep)).To(Succeed())
+
 			// ── Cooldown expires ──────────────────────────────────────────────────────────
 			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
 			ea.Spec.LastEviction.EvictionTime = metav1.NewTime(time.Now().Add(-2 * cooldown))

--- a/internal/controller/wrappers.go
+++ b/internal/controller/wrappers.go
@@ -11,6 +11,7 @@ import (
 type Surger interface {
 	//GetGeneration() int64
 	GetReplicas() int32
+	GetReadyReplicas() int32
 	SetReplicas(int32)
 	GetMaxSurge() intstr.IntOrString
 	Obj() client.Object
@@ -40,6 +41,10 @@ func (d *DeploymentWrapper) GetReplicas() int32 {
 		return 1 // Default value in Kubernetes if not set
 	}
 	return *d.obj.Spec.Replicas
+}
+
+func (d *DeploymentWrapper) GetReadyReplicas() int32 {
+	return d.obj.Status.ReadyReplicas
 }
 
 func (d *DeploymentWrapper) SetReplicas(replicas int32) {
@@ -85,6 +90,10 @@ func (s *StatefulSetWrapper) GetReplicas() int32 {
 		return 1 // Default value in Kubernetes if not set
 	}
 	return *s.obj.Spec.Replicas
+}
+
+func (s *StatefulSetWrapper) GetReadyReplicas() int32 {
+	return s.obj.Status.ReadyReplicas
 }
 
 func (s *StatefulSetWrapper) SetReplicas(replicas int32) {


### PR DESCRIPTION
- Add SurgeAttempts field to EvictionAutoScalerStatus to track retry count
- Add GetReadyReplicas() to Surger interface (DeploymentWrapper + StatefulSetWrapper)
- Add defaultTimeToReadyMinutes=5 and TimeToReadyAnnotationKey constants
- Add getMaxSurgeAttempts() to convert annotation minutes → retry count
- Add validateTimeToReadyAnnotation() enforcing valid range [1, 10]
- Revert logic now waits for pods to become Ready before scaling down; gives up after maxSurgeAttempts and reverts unconditionally
- Mark EA as Degraded (InvalidTimeToReadyAnnotation) for out-of-range values
- Regenerate CRD YAML to include surgeAttempts in status schema
- Add unit tests for getMaxSurgeAttempts, validateTimeToReadyAnnotation, GetReadyReplicas; integration tests for retry behavior and annotation validation
- Update README with feature docs and TODO note about 10-min cap for ML workloads