### PR TITLE
Implement surge revert behavior based on PodDisruptionBudget status

### DIFF
--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -245,7 +245,17 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Track scaling opportunity
 		metrics.ScalingOpportunityCounter.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, metrics.ScaleDownAction, metrics.CooldownElapsedSignal).Inc()
 
-		//okay we aren't at allowed disruptions Revert Target to the original state
+		// Wait until the PDB allows disruptions before reverting.
+		// DisruptionsAllowed > 0 means enough pods are healthy to absorb the scale-down.
+		if pdb.Status.DisruptionsAllowed == 0 {
+			logger.Info("Waiting for PDB to allow disruptions before reverting surge",
+				"pdb", pdb.Name,
+				"target", EvictionAutoScaler.Spec.TargetName)
+			ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "waiting for PDB to allow disruptions before reverting")
+			return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
+		}
+
+		//okay we have allowed disruptions, revert target to the original state
 		err = surgeApplier.RevertSurge(ctx, EvictionAutoScaler.Status.MinReplicas)
 		if err != nil {
 			return ctrl.Result{}, err

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -1324,6 +1324,124 @@ func int32Ptr(i int32) *int32 {
 	return &i
 }
 
+var _ = Describe("EvictionAutoScaler Controller - surge revert behavior", func() {
+	ctx := context.Background()
+
+	var (
+		surgeNs         string
+		eaNsName        types.NamespacedName
+		deployNsName    types.NamespacedName
+		surgeReconciler *EvictionAutoScalerReconciler
+	)
+
+	BeforeEach(func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-surge-",
+				Annotations: map[string]string{
+					namespacefilter.EnableEvictionAutoscalerAnnotationKey: "true",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		surgeNs = ns.Name
+		eaNsName = types.NamespacedName{Name: "surge-ea", Namespace: surgeNs}
+		deployNsName = types.NamespacedName{Name: "surge-deploy", Namespace: surgeNs}
+
+		// Create a deployment already in the surged state (spec.replicas=2).
+		surge := intstr.FromInt(1)
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "surge-deploy",
+				Namespace: surgeNs,
+				Annotations: map[string]string{
+					EvictionSurgeReplicasAnnotationKey: "2",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: int32Ptr(2),
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "surge-test"}},
+				Strategy: appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{MaxSurge: &surge},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "surge-test"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{Name: "surge-ea", Namespace: surgeNs},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MinAvailable: &intstr.IntOrString{IntVal: 1},
+				Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "surge-test"}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pdb)).To(Succeed())
+
+		// Create EA with a past eviction (beyond cooldown) so the cooldown gate is already open.
+		ea := &v1.EvictionAutoScaler{
+			ObjectMeta: metav1.ObjectMeta{Name: "surge-ea", Namespace: surgeNs},
+			Spec: v1.EvictionAutoScalerSpec{
+				TargetName: "surge-deploy",
+				TargetKind: "deployment",
+				LastEviction: v1.Eviction{
+					PodName:      "evicted-pod",
+					EvictionTime: metav1.NewTime(time.Now().Add(-2 * cooldown)),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ea)).To(Succeed())
+
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		ea.Status.MinReplicas = 1
+		ea.Status.TargetGeneration = dep.Generation
+		Expect(k8sClient.Status().Update(ctx, ea)).To(Succeed())
+
+		surgeReconciler = &EvictionAutoScalerReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+			Filter: &evictionTestFilter{},
+		}
+	})
+
+	It("requeues without reverting when PDB DisruptionsAllowed is 0", func() {
+		pdb := &policyv1.PodDisruptionBudget{}
+		Expect(k8sClient.Get(ctx, eaNsName, pdb)).To(Succeed())
+		pdb.Status.DisruptionsAllowed = 0
+		Expect(k8sClient.Status().Update(ctx, pdb)).To(Succeed())
+
+		result, err := surgeReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: eaNsName})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(cooldown))
+
+		// Deployment must NOT be reverted.
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
+	})
+
+	It("reverts immediately when PDB DisruptionsAllowed is > 0", func() {
+		pdb := &policyv1.PodDisruptionBudget{}
+		Expect(k8sClient.Get(ctx, eaNsName, pdb)).To(Succeed())
+		pdb.Status.DisruptionsAllowed = 1
+		Expect(k8sClient.Status().Update(ctx, pdb)).To(Succeed())
+
+		result, err := surgeReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: eaNsName})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+		// Deployment must be reverted to the original minReplicas.
+		dep := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, deployNsName, dep)).To(Succeed())
+		Expect(*dep.Spec.Replicas).To(Equal(int32(1)))
+	})
+})
+
 var _ = Describe("EvictionAutoScaler Controller - unsupported autoscaler config", func() {
 	ctx := context.Background()
 


### PR DESCRIPTION
This pull request improves the surge revert logic in the `EvictionAutoScaler` controller to ensure that deployments are only reverted from a surge state when the PodDisruptionBudget (PDB) allows it. Additionally, new tests are added to verify this behavior. The main focus is on preventing premature scale-downs that could violate PDB constraints, thereby improving reliability during eviction scenarios.

**Surge Revert Logic Improvements:**

* The controller now checks `pdb.Status.DisruptionsAllowed` before reverting a deployment from a surge state. If disruptions are not allowed (`DisruptionsAllowed == 0`), it logs a message, updates the status, and requeues the reconciliation after the cooldown period instead of reverting immediately. This ensures that scale-down only happens when it is safe according to the PDB.

**Testing Enhancements:**

* Added a new test suite to `evictionautoscaler_controller_test.go` to verify the surge revert behavior:
  - Tests that the controller does not revert the deployment when `DisruptionsAllowed` is 0 and requeues instead.
  - Tests that the controller reverts the deployment immediately when `DisruptionsAllowed` is greater than 0.