### PR TITLE
fix: standardize ServiceAccount name to 'eviction-autoscaler'

### DIFF
--- a/helm/eviction-autoscaler/templates/clusterrole.yaml
+++ b/helm/eviction-autoscaler/templates/clusterrole.yaml
@@ -121,5 +121,5 @@ roleRef:
   name: {{ include "eviction-autoscaler.fullname" . }}-manager-role
 subjects:
 - kind: ServiceAccount
-  name: {{ include "eviction-autoscaler.fullname" . }}
+  name: eviction-autoscaler
   namespace: {{ .Release.Namespace }}

--- a/helm/eviction-autoscaler/templates/deployment.yaml
+++ b/helm/eviction-autoscaler/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ include "eviction-autoscaler.fullname" . }}
+      serviceAccountName: eviction-autoscaler
       terminationGracePeriodSeconds: 30
       securityContext:
         runAsNonRoot: true

--- a/helm/eviction-autoscaler/templates/leader-election-rbac.yaml
+++ b/helm/eviction-autoscaler/templates/leader-election-rbac.yaml
@@ -57,5 +57,5 @@ roleRef:
   name: {{ include "eviction-autoscaler.fullname" . }}-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: {{ include "eviction-autoscaler.fullname" . }}
+  name: eviction-autoscaler
   namespace: {{ .Release.Namespace }}

--- a/helm/eviction-autoscaler/templates/serviceaccount.yaml
+++ b/helm/eviction-autoscaler/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "eviction-autoscaler.fullname" . }}
+  name: eviction-autoscaler
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: eviction-autoscaler


### PR DESCRIPTION
This pull request standardizes the service account name used by the `eviction-autoscaler` Helm chart templates. Instead of using a templated name, all references now use the fixed name `eviction-autoscaler`. This change ensures consistency across resource definitions and simplifies resource referencing.

**Helm chart resource updates:**

* [`helm/eviction-autoscaler/templates/serviceaccount.yaml`](diffhunk://#diff-729bf66e8b163b13195c223ff76175de78b7e4b794b4fb650a1117df9014d64eL4-R4): Changed the service account name to the fixed value `eviction-autoscaler` instead of a templated name.
* [`helm/eviction-autoscaler/templates/deployment.yaml`](diffhunk://#diff-5f139f5160ac21191404843a50aaf7c8f086f3b37f25f1aee8c8c49c5248da54L27-R27): Updated the `serviceAccountName` field to use the fixed name `eviction-autoscaler`.

**RBAC and role binding updates:**

* [`helm/eviction-autoscaler/templates/clusterrole.yaml`](diffhunk://#diff-698aab4cef18204d0f22b56bcbc3bb0d67a950859fb20bb57b8408ce3f1a3701L124-R124): Updated the `subjects` section to reference the fixed service account name.
* [`helm/eviction-autoscaler/templates/leader-election-rbac.yaml`](diffhunk://#diff-3e0305ce4dd84ef4793d1ac95ce4728c04f97d687eca8947d980d62487a256efL60-R60): Updated the `subjects` section to reference the fixed service account name.