### PR TITLE
Add manual on-demand CVE scan workflow

### DIFF
--- a/.github/workflows/manual-cve-scan.yml
+++ b/.github/workflows/manual-cve-scan.yml
@@ -25,3 +25,4 @@ jobs:
 
       - name: Run govulncheck
         run: govulncheck ./...
+        

--- a/.github/workflows/manual-cve-scan.yml
+++ b/.github/workflows/manual-cve-scan.yml
@@ -1,0 +1,27 @@
+name: Manual CVE Scan
+
+# On-demand Go dependency CVE scan for hotfix pre-checks (manually triggered).
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck (Go dependencies)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/.github/workflows/manual-cve-scan.yml
+++ b/.github/workflows/manual-cve-scan.yml
@@ -21,7 +21,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
 
       - name: Run govulncheck
         run: govulncheck ./...


### PR DESCRIPTION
Adds `.github/workflows/manual-cve-scan.yml`, a manually-triggered
(`workflow_dispatch`) GitHub Actions workflow that runs an on-demand CVE
check of the project's Go dependencies.

## Why
Dependabot opens dependency-update PRs on a schedule (and immediate security
PRs once alerts are enabled), but it has no way to manually trigger a scan.
This workflow fills that gap: it lets us run a CVE check on demand — for
example, before shipping a hotfix or an out-of-band release.

## What it does
- Trigger: `workflow_dispatch` (run from the Actions tab)
- Installs Go using the version pinned in `go.mod`
- Installs `govulncheck` pinned to v1.5.0 (avoids `@latest` for reproducibility)
- Runs `govulncheck ./...` across the full module
- Fails the run if a reachable vulnerability is found, printing the affected
  package and fixed version in the logs

## Testing
Validated on a fork by running the workflow from the Actions tab. It completed
end-to-end and found 5 real, reachable vulnerabilities, failing the run as
intended:

- GO-2026-5039 — net/textproto (Go stdlib), fixed in go1.25.11
- GO-2026-5038 — mime (Go stdlib), fixed in go1.25.11
- GO-2026-5037 — crypto/x509 (Go stdlib), fixed in go1.25.11
- GO-2026-4971 — net (Go stdlib), fixed in go1.25.11
- GO-2026-5026 — golang.org/x/net/idna, fixed in golang.org/x/net v0.55.0

For each finding, govulncheck printed the CVE ID, the affected package, the
fixed version, and the call trace showing the vulnerability is actually reachable
from our code. This confirms the workflow runs, detects reachable CVEs, and gates
correctly. (The findings above are real and worth addressing separately — bumping
the Go toolchain to 1.25.11 and golang.org/x/net to v0.55.0.)

## Scope
Covers the Go dependency layer (govulncheck). Container base-image CVEs are
already handled by the release-time Trivy scan and by Managed DALEC, so they
are intentionally out of scope here.
