### PR TITLE
Add Dependabot auto-merge workflow for patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+
+# Requires branch protection with required status checks on the default branch;
+# gh pr merge --auto waits on those checks before merging.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.repository == 'Azure/eviction-autoscaler'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Auto-merge patch updates only; minor and major are left for human review.
+      - name: Enable auto-merge for patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
   dependabot-auto-merge:
     runs-on: ubuntu-latest
     if: >-
-      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.repository == 'Azure/eviction-autoscaler'
     steps:
       - name: Fetch Dependabot metadata


### PR DESCRIPTION
Adds `.github/workflows/dependabot-auto-merge.yml`, which auto-merges low-risk
Dependabot PRs after CI passes.

Based on GitHub's official guidance:
https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automate-dependabot-with-actions#enabling-automerge-on-a-pull-request

## Behavior
- Runs only on PRs authored by `dependabot[bot]` in this repo (never forks)
- Uses `dependabot/fetch-metadata` (pinned to a commit SHA) to read the update type
- Auto-merges **patch** version updates only; minor and major updates are left
  for human review
- Uses `gh pr merge --auto`, which waits for required status checks before merging

## Testing
Validated on a fork with branch protection and a required status check
configured, to mirror the real setup:

- Confirmed the workflow triggers on Dependabot PRs, passes the guard, and reads
  the update type via `dependabot/fetch-metadata`.
- Negative case: on grouped / non-patch PRs, the "enable auto-merge" step is
  correctly skipped, so only patch updates are eligible.
- Positive case (end-to-end): on a single patch update PR, the workflow enabled
  auto-merge, which then waited for the required CI check (`build`) to pass and
  merged the PR automatically once it was green — with no manual action.
- Also confirmed the merge does not happen before CI completes: auto-merge stays
  queued until the required check passes.

## Requires (admin, separate from this file)

**1. Enable auto-merge for the repo**
- Settings → General → Pull Requests → check **"Allow auto-merge"**.
  Without this, `gh pr merge --auto` errors and nothing is queued.

**2. Add a branch protection ruleset on `main`**
Settings → Rules → Rulesets → New branch ruleset, with:
- **Enforcement status:** Active
- **Target branches:** include the default branch (`main`)
- **Require status checks to pass** → add **`build`** (the CI job in `ci.yml`) as a
  required check. This is what auto-merge waits on; without a required check there
  is nothing to gate the merge.
- **Block force pushes:** on (default)
- **Bypass list:** leave empty (so the required check applies to everyone,
  including the auto-merge). Do not add Dependabot to the bypass list, or its
  merges would skip CI.
- Leave **"Require a pull request before merging"** and **"Require branches to be
  up to date before merging"** off — not needed, and the latter adds friction to
  auto-merge.

Note: the required check name (`build`) must have run at least once on the repo
before it appears in the ruleset's check picker.
