### PR TITLE
feat: add surge-override annotation to decouple drain surge from maxSurge

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,17 +550,19 @@ surgeTarget = minReplicas + displaced
 
 where `displaced` is the number of PDB-selected pods currently running on cordoned nodes. `surgeTarget` is capped at `minReplicas + maxSurge` (the deployment's configured max surge). This means the surge is right-sized to exactly what is needed — no over-provisioning.
 
-#### Surge Override (`maxSurge: 0` workloads)
+#### Drain-Time Surge Cap Override
 
-The surge budget defaults to the target's rolling-update `maxSurge`. Workloads that pin `maxSurge: 0` in their rollout strategy (for example, capacity-constrained or single-zone deployments that must never run extra pods during a normal rollout) therefore get **no** drain-time surge at all — `calculateSurge` returns an error and the controller cannot add replicas to relieve a PDB-blocked drain.
+The surge budget defaults to the target's rolling-update `maxSurge`. But rollout surge and **drain** surge are different operational events: a workload can legitimately want `maxSurge: 0` for **app rollouts** (serial, no extra pods during a version change) yet still want a small, bounded surge **during node maintenance**. With `maxSurge: 0` and no override, the workload gets **no** drain-time surge at all — `calculateSurge` returns an error and the controller cannot add replicas to relieve a PDB-blocked drain.
 
-To decouple the drain-time surge budget from the rollout `maxSurge`, set the following annotation on the **target workload** (Deployment or StatefulSet):
+To set a **drain-time surge cap** that is decoupled from the rollout `maxSurge`, annotate the **target workload** (Deployment or StatefulSet):
 
 | Annotation | Placed On | Value | Purpose |
 |---|---|---|---|
-| `eviction-autoscaler.azure.com/surge-override` | Deployment or StatefulSet | Int (e.g. `"3"`) or percentage (e.g. `"20%"`) | Surge budget to use during drains, **overriding** the target's `maxSurge` |
+| `eviction-autoscaler.azure.com/surge-override` | Deployment or StatefulSet | Int (e.g. `"3"`) or percentage (e.g. `"20%"`) | Drain-time surge cap, used **instead of** the target's rollout `maxSurge` |
 
-When present, the override **always wins** over `maxSurge`, so a workload can keep `maxSurge: 0` for its rollout strategy yet still surge on drain. The value is interpreted exactly like `maxSurge`: an integer is added to `minReplicas`; a percentage is applied to `minReplicas` and rounded up. A value of `0` (or `0%`) disables surge just like `maxSurge: 0`.
+When present, the override **always wins** over `maxSurge` for drain-time surge, so a workload can keep `maxSurge: 0` for its rollout strategy yet still surge during a drain. It is a **cap, not the amount**: the actual surge stays demand-driven (`minReplicas + displaced`), so a drain larger than the cap simply proceeds in **waves**. The value is interpreted exactly like `maxSurge` — an integer is added to `minReplicas`; a percentage is applied to `minReplicas` and rounded up — so each workload can tune the batch size to its own capacity (e.g. a large `maxSurge: 0` deployment can pin a small absolute cap like `"10"` rather than a percentage that would scale up with replica count). A value of `0` (or `0%`) disables surge just like `maxSurge: 0`.
+
+When the override drives a surge, the controller emits a `DrainSurgeOverride` event on the target workload (and a log line) noting that the drain-time cap overrode the rollout `maxSurge`.
 
 ```yaml
 apiVersion: apps/v1
@@ -568,7 +570,7 @@ kind: Deployment
 metadata:
   name: my-app
   annotations:
-    eviction-autoscaler.azure.com/surge-override: "3"   # surge by up to 3 on drain, even with maxSurge: 0
+    eviction-autoscaler.azure.com/surge-override: "10"  # drain-time cap of 10 extra pods, even with maxSurge: 0
 spec:
   strategy:
     rollingUpdate:

--- a/README.md
+++ b/README.md
@@ -550,6 +550,32 @@ surgeTarget = minReplicas + displaced
 
 where `displaced` is the number of PDB-selected pods currently running on cordoned nodes. `surgeTarget` is capped at `minReplicas + maxSurge` (the deployment's configured max surge). This means the surge is right-sized to exactly what is needed — no over-provisioning.
 
+#### Surge Override (`maxSurge: 0` workloads)
+
+The surge budget defaults to the target's rolling-update `maxSurge`. Workloads that pin `maxSurge: 0` in their rollout strategy (for example, capacity-constrained or single-zone deployments that must never run extra pods during a normal rollout) therefore get **no** drain-time surge at all — `calculateSurge` returns an error and the controller cannot add replicas to relieve a PDB-blocked drain.
+
+To decouple the drain-time surge budget from the rollout `maxSurge`, set the following annotation on the **target workload** (Deployment or StatefulSet):
+
+| Annotation | Placed On | Value | Purpose |
+|---|---|---|---|
+| `eviction-autoscaler.azure.com/surge-override` | Deployment or StatefulSet | Int (e.g. `"3"`) or percentage (e.g. `"20%"`) | Surge budget to use during drains, **overriding** the target's `maxSurge` |
+
+When present, the override **always wins** over `maxSurge`, so a workload can keep `maxSurge: 0` for its rollout strategy yet still surge on drain. The value is interpreted exactly like `maxSurge`: an integer is added to `minReplicas`; a percentage is applied to `minReplicas` and rounded up. A value of `0` (or `0%`) disables surge just like `maxSurge: 0`.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  annotations:
+    eviction-autoscaler.azure.com/surge-override: "3"   # surge by up to 3 on drain, even with maxSurge: 0
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 0        # rollout strategy still never surges
+      maxUnavailable: 1
+```
+
 #### Incremental Scale-Up
 
 As additional nodes are cordoned during a rolling drain, `displaced` grows and the controller tops the deployment up automatically on each reconcile.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,9 @@ Eviction autoscaler provides flexible namespace-level control with two operation
   - `true`: Namespaces enabled by default - all namespaces enabled unless disabled
 - **`ACTIONED_NAMESPACES`**: Comma-separated list of namespaces with special behavior
 - **`PDB_CREATE`**: Enable automatic PDB creation for deployments (default: `false`)
+- **`SURGE_OVERRIDE_ENABLED`**: Enable the drain-time surge-override annotation (`eviction-autoscaler.azure.com/surge-override`) fleet-wide (default: `false`). When `false`, the annotation is ignored and surge sizing falls through to the target's rollout `maxSurge`. Must be `true` or `false`.
+- **`SURGE_OVERRIDE_MAX_PERCENT`**: Safety cap bounding the surge-override annotation, as a percentage of `minReplicas` (default: `25`). The override-resolved surge amount is capped at this percent of `minReplicas` (rounded up). Must be a positive integer. Only applies when `SURGE_OVERRIDE_ENABLED=true`.
+- **`ENABLE_EVENT_RECORDING`**: Enable emission of Kubernetes events by the controller (default: `false`). An installation-time observability decision, orthogonal to feature flags — a single switch for all controller events (e.g. `DrainSurgeOverride`). When `false`, no events are emitted; structured logs and metrics remain the primary signal. Must be `true` or `false`.
 
 #### Mode 1: `ENABLED_BY_DEFAULT=false` (Default)
 
@@ -554,15 +557,19 @@ where `displaced` is the number of PDB-selected pods currently running on cordon
 
 The surge budget defaults to the target's rolling-update `maxSurge`. But rollout surge and **drain** surge are different operational events: a workload can legitimately want `maxSurge: 0` for **app rollouts** (serial, no extra pods during a version change) yet still want a small, bounded surge **during node maintenance**. With `maxSurge: 0` and no override, the workload gets **no** drain-time surge at all — `calculateSurge` returns an error and the controller cannot add replicas to relieve a PDB-blocked drain.
 
-To set a **drain-time surge cap** that is decoupled from the rollout `maxSurge`, annotate the **target workload** (Deployment or StatefulSet):
+To set a **drain-time surge cap** that is decoupled from the rollout `maxSurge`, first enable the feature on the controller (see the note below), then annotate the **target workload** (Deployment or StatefulSet):
 
 | Annotation | Placed On | Value | Purpose |
 |---|---|---|---|
 | `eviction-autoscaler.azure.com/surge-override` | Deployment or StatefulSet | Int (e.g. `"3"`) or percentage (e.g. `"20%"`) | Drain-time surge cap, used **instead of** the target's rollout `maxSurge` |
 
-When present, the override **always wins** over `maxSurge` for drain-time surge, so a workload can keep `maxSurge: 0` for its rollout strategy yet still surge during a drain. It is a **cap, not the amount**: the actual surge stays demand-driven (`minReplicas + displaced`), so a drain larger than the cap simply proceeds in **waves**. The value is interpreted exactly like `maxSurge` — an integer is added to `minReplicas`; a percentage is applied to `minReplicas` and rounded up — so each workload can tune the batch size to its own capacity (e.g. a large `maxSurge: 0` deployment can pin a small absolute cap like `"10"` rather than a percentage that would scale up with replica count). A value of `0` (or `0%`) disables surge just like `maxSurge: 0`.
+> **This feature is off by default and must be enabled fleet-wide on the controller** via `SURGE_OVERRIDE_ENABLED=true` (see [Environment Variables](#environment-variables)). While it is disabled, the annotation is a **no-op** — surge sizing falls through to the target's rollout `maxSurge` exactly as before. This ensures the platform operator, not individual workload owners, decides whether drain-time surge overrides are honored.
 
-When the override drives a surge, the controller emits a `DrainSurgeOverride` event on the target workload (and a log line) noting that the drain-time cap overrode the rollout `maxSurge`.
+When present (and the feature is enabled), the override **always wins** over `maxSurge` for drain-time surge, so a workload can keep `maxSurge: 0` for its rollout strategy yet still surge during a drain. It is a **cap, not the amount**: the actual surge stays demand-driven (`minReplicas + displaced`), so a drain larger than the cap simply proceeds in **waves**. The value is interpreted exactly like `maxSurge` — an integer is added to `minReplicas`; a percentage is applied to `minReplicas` and rounded up — so each workload can tune the batch size to its own capacity (e.g. a large `maxSurge: 0` deployment can pin a small absolute cap like `"10"` rather than a percentage that would scale up with replica count). A value of `0` (or `0%`) disables surge just like `maxSurge: 0`.
+
+Because the annotation is free-form and bypasses API-server admission validation, the override-resolved surge amount is bounded by a controller-level safety cap, **`SURGE_OVERRIDE_MAX_PERCENT`** (default `25`, i.e. 25% of `minReplicas`, rounded up); operators can raise it fleet-wide to allow larger drain-time surges. Only the free-form override path is capped — the rollout `maxSurge` path is already validated by the API server and is never capped.
+
+When the override drives a surge, the controller always logs a structured line noting that the drain-time cap overrode the rollout `maxSurge`, and — when event recording is enabled (`ENABLE_EVENT_RECORDING=true`, see [Environment Variables](#environment-variables)) — also emits a `DrainSurgeOverride` event on the target workload.
 
 ```yaml
 apiVersion: apps/v1

--- a/README.md
+++ b/README.md
@@ -251,8 +251,7 @@ Eviction autoscaler provides flexible namespace-level control with two operation
   - `true`: Namespaces enabled by default - all namespaces enabled unless disabled
 - **`ACTIONED_NAMESPACES`**: Comma-separated list of namespaces with special behavior
 - **`PDB_CREATE`**: Enable automatic PDB creation for deployments (default: `false`)
-- **`OVERRIDE_ZERO_MAXSURGE`**: When enabled, lets the controller surge a workload whose `maxSurge` resolves to 0 (an explicit `maxSurge: 0`, or a `Recreate` strategy) during a drain, using a fleet-wide percentage instead of refusing to surge (default: `false`). When `false`, such a workload cannot surge and the autoscaler degrades, as before. Must be `true` or `false`.
-- **`SURGE_OVERRIDE_MAX_PERCENT`**: The fleet-wide drain surge applied when `OVERRIDE_ZERO_MAXSURGE=true` and a workload's `maxSurge` resolves to 0, as a percentage of `minReplicas` (default: `25`; e.g. set to `10` at install time). The actual surge stays demand-driven (`minReplicas + displaced`) and is capped at this amount, so larger drains proceed in waves. Must be a positive integer.
+- **`ZERO_SURGE_OVERRIDE`**: Lets the controller surge a workload whose `maxSurge` resolves to 0 (an explicit `maxSurge: 0`, or a `Recreate` strategy) during a drain instead of refusing to surge. The value is an int-or-percentage, mirroring Kubernetes `maxSurge`: `"25%"` of `minReplicas` (rounded up) or an absolute `"10"`. Unset, or a value that resolves to zero (`"0"`/`"0%"`), leaves the feature off (default), so such a workload degrades as before; a negative or malformed value fails fast at startup. The actual surge stays demand-driven (`minReplicas + displaced`) and is capped at this amount, so larger drains proceed in waves.
 - **`ENABLE_EVENT_RECORDING`**: Enable emission of Kubernetes events by the controller (default: `false`). An installation-time observability decision, orthogonal to feature flags — a single switch for all controller events (e.g. `DrainSurgeOverride`). When `false`, no events are emitted; structured logs and metrics remain the primary signal. Must be `true` or `false`.
 
 #### Mode 1: `ENABLED_BY_DEFAULT=false` (Default)
@@ -561,15 +560,13 @@ The **zero-maxSurge override** is a fleet-wide setting that lets the controller 
 
 It is configured entirely on the controller — there is **no per-workload annotation** — so the platform operator, not individual workload owners, decides whether it applies:
 
-- **`OVERRIDE_ZERO_MAXSURGE`** (`true`/`false`, default `false`) — the fleet-wide opt-in. Off by default, preserving today's degrade behavior.
-- **`SURGE_OVERRIDE_MAX_PERCENT`** (positive integer, default `25`) — the drain surge as a percent of `minReplicas`, applied when the override fires (e.g. set to `10` at install time).
+- **`ZERO_SURGE_OVERRIDE`** — a single knob whose value is the drain surge applied when the override fires. It is an **int-or-percentage**, mirroring Kubernetes' own `maxSurge`: `"25%"` (a percent of `minReplicas`, rounded up) or `"10"` (an absolute number of extra pods). Unset, or a value that resolves to zero (`"0"`/`"0%"`), leaves the feature **off** (default), preserving today's degrade behavior. A negative or malformed value fails fast at startup. Set it (e.g. `"10%"`) at install time to enable.
 
-The surge stays **demand-driven**: the actual scale-up is `minReplicas + displaced`, capped at this percentage of `minReplicas`, so a drain larger than the cap simply proceeds in **waves**. When the override drives a surge, the controller logs a structured line and — when event recording is enabled (`ENABLE_EVENT_RECORDING=true`) — emits a `DrainSurgeOverride` event on the target workload.
+The surge stays **demand-driven**: the actual scale-up is `minReplicas + displaced`, capped at `minReplicas +` the override value, so a drain larger than the cap simply proceeds in **waves**. When the override drives a surge, the controller logs a structured line and — when event recording is enabled (`ENABLE_EVENT_RECORDING=true`) — emits a `DrainSurgeOverride` event on the target workload.
 
 ```yaml
 # No workload annotation is required. Enable fleet-wide on the controller:
-#   OVERRIDE_ZERO_MAXSURGE=true
-#   SURGE_OVERRIDE_MAX_PERCENT=10
+#   ZERO_SURGE_OVERRIDE=10%   # or an absolute count, e.g. ZERO_SURGE_OVERRIDE=5
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Eviction autoscaler provides flexible namespace-level control with two operation
   - `true`: Namespaces enabled by default - all namespaces enabled unless disabled
 - **`ACTIONED_NAMESPACES`**: Comma-separated list of namespaces with special behavior
 - **`PDB_CREATE`**: Enable automatic PDB creation for deployments (default: `false`)
-- **`ZERO_SURGE_OVERRIDE`**: Lets the controller surge a workload whose `maxSurge` resolves to 0 (an explicit `maxSurge: 0`, or a `Recreate` strategy) during a drain instead of refusing to surge. The value is an int-or-percentage, mirroring Kubernetes `maxSurge`: `"25%"` of `minReplicas` (rounded up) or an absolute `"10"`. Unset, or a value that resolves to zero (`"0"`/`"0%"`), leaves the feature off (default), so such a workload degrades as before; a negative or malformed value fails fast at startup. The actual surge stays demand-driven (`minReplicas + displaced`) and is capped at this amount, so larger drains proceed in waves.
+- **`ZERO_SURGE_OVERRIDE`**: Lets the controller surge a workload whose `maxSurge` resolves to 0 (an explicit `maxSurge: 0`, or a `Recreate` strategy) during a drain instead of refusing to surge. The value is an int-or-percentage, mirroring Kubernetes `maxSurge`: `"25%"` of `minReplicas` (rounded up) or an absolute `"10"`. Unset, or a value that resolves to zero (`"0"`/`"0%"`), leaves the feature off (default), so such a workload degrades as before; a negative or malformed value fails fast at startup. The actual surge stays demand-driven (`minReplicas + displaced`) and is capped at this amount, so larger drains proceed in waves. **Note:** workloads that omit `maxSurge` entirely (or omit the strategy altogether) are _not_ affected — Kubernetes defaults those to `25%` at admission time, so they already have a non-zero surge and the override does not apply.
 
 #### Mode 1: `ENABLED_BY_DEFAULT=false` (Default)
 
@@ -557,24 +557,79 @@ Drain surge normally comes from the target's rolling-update `maxSurge`. But safe
 
 The **zero-maxSurge override** is a fleet-wide setting that lets the controller surge these workloads during a drain. It applies **only** when the target's `maxSurge` resolves to 0 (an explicit `maxSurge: 0`, or a `Recreate` strategy); workloads with a non-zero `maxSurge` are unaffected and keep using their own `maxSurge`.
 
+> **Important:** Workloads that _omit_ `maxSurge` (or omit the strategy altogether) are **not** treated as zero-surge. Kubernetes defaults an unset RollingUpdate strategy to `maxSurge: 25%` at admission time, so those workloads already have a non-zero surge and the override does not fire.
+
 It is configured entirely on the controller — there is **no per-workload annotation** — so the platform operator, not individual workload owners, decides whether it applies:
 
 - **`ZERO_SURGE_OVERRIDE`** — a single knob whose value is the drain surge applied when the override fires. It is an **int-or-percentage**, mirroring Kubernetes' own `maxSurge`: `"25%"` (a percent of `minReplicas`, rounded up) or `"10"` (an absolute number of extra pods). Unset, or a value that resolves to zero (`"0"`/`"0%"`), leaves the feature **off** (default), preserving today's degrade behavior. A negative or malformed value fails fast at startup. Set it (e.g. `"10%"`) at install time to enable.
 
 The surge stays **demand-driven**: the actual scale-up is `minReplicas + displaced`, capped at `minReplicas +` the override value, so a drain larger than the cap simply proceeds in **waves**. When the override drives a surge, the controller emits a structured log line. Workloads whose rollout `maxSurge` resolves to 0 are also tracked by the `eviction_autoscaler_zero_maxsurge_workloads` metric (labels `namespace`, `name`), so operators can see how many such workloads exist in the cluster.
 
+**When does the override apply?**
+
+| Deployment strategy | maxSurge value | Kubernetes effective surge | Override applies? |
+|---|---|---|---|
+| `RollingUpdate` | `maxSurge: 0` | 0 | ✅ Yes |
+| `RollingUpdate` | `maxSurge: 5` | 5 | ❌ No (non-zero) |
+| `RollingUpdate` | `maxSurge: 25%` | 25% of replicas | ❌ No (non-zero) |
+| `RollingUpdate` | _(omitted)_ | 25% (k8s default) | ❌ No (default is non-zero) |
+| `Recreate` | _(n/a)_ | 0 | ✅ Yes |
+| _(strategy omitted entirely)_ | _(omitted)_ | 25% (k8s default) | ❌ No (default is non-zero) |
+
+**Examples:**
+
 ```yaml
-# No workload annotation is required. Enable fleet-wide on the controller:
+# Example 1: Explicit maxSurge: 0 — override WILL apply during drains.
+# The rollout never surges, but eviction-autoscaler can still add pods.
 #   ZERO_SURGE_OVERRIDE=10%   # or an absolute count, e.g. ZERO_SURGE_OVERRIDE=5
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: my-app
+  name: safe-deploy-app
 spec:
   strategy:
     rollingUpdate:
       maxSurge: 0        # rollout never surges; drains still get the fleet override
       maxUnavailable: 1
+```
+
+```yaml
+# Example 2: Recreate strategy — override WILL apply during drains.
+# Recreate has no rolling-update concept at all.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recreate-app
+spec:
+  strategy:
+    type: Recreate
+```
+
+```yaml
+# Example 3: maxSurge omitted — override will NOT apply.
+# Kubernetes defaults this to RollingUpdate with maxSurge: 25%, which is non-zero.
+# The eviction-autoscaler uses that 25% for drain surge sizing.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: default-strategy-app
+spec:
+  replicas: 4
+  # strategy not specified — k8s defaults to RollingUpdate, maxSurge: 25%
+```
+
+```yaml
+# Example 4: Explicit non-zero maxSurge — override will NOT apply.
+# The eviction-autoscaler uses the workload's own maxSurge (5) for drain surge.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: custom-surge-app
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 5
+      maxUnavailable: 0
 ```
 
 #### Incremental Scale-Up

--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ Eviction autoscaler provides flexible namespace-level control with two operation
   - `true`: Namespaces enabled by default - all namespaces enabled unless disabled
 - **`ACTIONED_NAMESPACES`**: Comma-separated list of namespaces with special behavior
 - **`PDB_CREATE`**: Enable automatic PDB creation for deployments (default: `false`)
-- **`SURGE_OVERRIDE_ENABLED`**: Enable the drain-time surge-override annotation (`eviction-autoscaler.azure.com/surge-override`) fleet-wide (default: `false`). When `false`, the annotation is ignored and surge sizing falls through to the target's rollout `maxSurge`. Must be `true` or `false`.
-- **`SURGE_OVERRIDE_MAX_PERCENT`**: Safety cap bounding the surge-override annotation, as a percentage of `minReplicas` (default: `25`). The override-resolved surge amount is capped at this percent of `minReplicas` (rounded up). Must be a positive integer. Only applies when `SURGE_OVERRIDE_ENABLED=true`.
+- **`OVERRIDE_ZERO_MAXSURGE`**: When enabled, lets the controller surge a workload whose `maxSurge` resolves to 0 (an explicit `maxSurge: 0`, or a `Recreate` strategy) during a drain, using a fleet-wide percentage instead of refusing to surge (default: `false`). When `false`, such a workload cannot surge and the autoscaler degrades, as before. Must be `true` or `false`.
+- **`SURGE_OVERRIDE_MAX_PERCENT`**: The fleet-wide drain surge applied when `OVERRIDE_ZERO_MAXSURGE=true` and a workload's `maxSurge` resolves to 0, as a percentage of `minReplicas` (default: `25`; e.g. set to `10` at install time). The actual surge stays demand-driven (`minReplicas + displaced`) and is capped at this amount, so larger drains proceed in waves. Must be a positive integer.
 - **`ENABLE_EVENT_RECORDING`**: Enable emission of Kubernetes events by the controller (default: `false`). An installation-time observability decision, orthogonal to feature flags — a single switch for all controller events (e.g. `DrainSurgeOverride`). When `false`, no events are emitted; structured logs and metrics remain the primary signal. Must be `true` or `false`.
 
 #### Mode 1: `ENABLED_BY_DEFAULT=false` (Default)
@@ -553,35 +553,31 @@ surgeTarget = minReplicas + displaced
 
 where `displaced` is the number of PDB-selected pods currently running on cordoned nodes. `surgeTarget` is capped at `minReplicas + maxSurge` (the deployment's configured max surge). This means the surge is right-sized to exactly what is needed — no over-provisioning.
 
-#### Drain-Time Surge Cap Override
+#### Zero-maxSurge Drain Override
 
-The surge budget defaults to the target's rolling-update `maxSurge`. But rollout surge and **drain** surge are different operational events: a workload can legitimately want `maxSurge: 0` for **app rollouts** (serial, no extra pods during a version change) yet still want a small, bounded surge **during node maintenance**. With `maxSurge: 0` and no override, the workload gets **no** drain-time surge at all — `calculateSurge` returns an error and the controller cannot add replicas to relieve a PDB-blocked drain.
+Drain surge normally comes from the target's rolling-update `maxSurge`. But safe-deployment guidance often mandates `maxSurge: 0` on the rollout strategy (serial rollouts, no extra pods during a version change), and a `Recreate` strategy has no surge either. With `maxSurge: 0` and nothing else, such a workload gets **no** drain-time surge — `calculateSurge` returns an error and the controller cannot add replicas to relieve a PDB-blocked drain.
 
-To set a **drain-time surge cap** that is decoupled from the rollout `maxSurge`, first enable the feature on the controller (see the note below), then annotate the **target workload** (Deployment or StatefulSet):
+The **zero-maxSurge override** is a fleet-wide setting that lets the controller surge these workloads during a drain. It applies **only** when the target's `maxSurge` resolves to 0 (an explicit `maxSurge: 0`, or a `Recreate` strategy); workloads with a non-zero `maxSurge` are unaffected and keep using their own `maxSurge`.
 
-| Annotation | Placed On | Value | Purpose |
-|---|---|---|---|
-| `eviction-autoscaler.azure.com/surge-override` | Deployment or StatefulSet | Int (e.g. `"3"`) or percentage (e.g. `"20%"`) | Drain-time surge cap, used **instead of** the target's rollout `maxSurge` |
+It is configured entirely on the controller — there is **no per-workload annotation** — so the platform operator, not individual workload owners, decides whether it applies:
 
-> **This feature is off by default and must be enabled fleet-wide on the controller** via `SURGE_OVERRIDE_ENABLED=true` (see [Environment Variables](#environment-variables)). While it is disabled, the annotation is a **no-op** — surge sizing falls through to the target's rollout `maxSurge` exactly as before. This ensures the platform operator, not individual workload owners, decides whether drain-time surge overrides are honored.
+- **`OVERRIDE_ZERO_MAXSURGE`** (`true`/`false`, default `false`) — the fleet-wide opt-in. Off by default, preserving today's degrade behavior.
+- **`SURGE_OVERRIDE_MAX_PERCENT`** (positive integer, default `25`) — the drain surge as a percent of `minReplicas`, applied when the override fires (e.g. set to `10` at install time).
 
-When present (and the feature is enabled), the override **always wins** over `maxSurge` for drain-time surge, so a workload can keep `maxSurge: 0` for its rollout strategy yet still surge during a drain. It is a **cap, not the amount**: the actual surge stays demand-driven (`minReplicas + displaced`), so a drain larger than the cap simply proceeds in **waves**. The value is interpreted exactly like `maxSurge` — an integer is added to `minReplicas`; a percentage is applied to `minReplicas` and rounded up — so each workload can tune the batch size to its own capacity (e.g. a large `maxSurge: 0` deployment can pin a small absolute cap like `"10"` rather than a percentage that would scale up with replica count). A value of `0` (or `0%`) disables surge just like `maxSurge: 0`.
-
-Because the annotation is free-form and bypasses API-server admission validation, the override-resolved surge amount is bounded by a controller-level safety cap, **`SURGE_OVERRIDE_MAX_PERCENT`** (default `25`, i.e. 25% of `minReplicas`, rounded up); operators can raise it fleet-wide to allow larger drain-time surges. Only the free-form override path is capped — the rollout `maxSurge` path is already validated by the API server and is never capped.
-
-When the override drives a surge, the controller always logs a structured line noting that the drain-time cap overrode the rollout `maxSurge`, and — when event recording is enabled (`ENABLE_EVENT_RECORDING=true`, see [Environment Variables](#environment-variables)) — also emits a `DrainSurgeOverride` event on the target workload.
+The surge stays **demand-driven**: the actual scale-up is `minReplicas + displaced`, capped at this percentage of `minReplicas`, so a drain larger than the cap simply proceeds in **waves**. When the override drives a surge, the controller logs a structured line and — when event recording is enabled (`ENABLE_EVENT_RECORDING=true`) — emits a `DrainSurgeOverride` event on the target workload.
 
 ```yaml
+# No workload annotation is required. Enable fleet-wide on the controller:
+#   OVERRIDE_ZERO_MAXSURGE=true
+#   SURGE_OVERRIDE_MAX_PERCENT=10
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: my-app
-  annotations:
-    eviction-autoscaler.azure.com/surge-override: "10"  # drain-time cap of 10 extra pods, even with maxSurge: 0
 spec:
   strategy:
     rollingUpdate:
-      maxSurge: 0        # rollout strategy still never surges
+      maxSurge: 0        # rollout never surges; drains still get the fleet override
       maxUnavailable: 1
 ```
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ Eviction autoscaler provides flexible namespace-level control with two operation
 - **`ACTIONED_NAMESPACES`**: Comma-separated list of namespaces with special behavior
 - **`PDB_CREATE`**: Enable automatic PDB creation for deployments (default: `false`)
 - **`ZERO_SURGE_OVERRIDE`**: Lets the controller surge a workload whose `maxSurge` resolves to 0 (an explicit `maxSurge: 0`, or a `Recreate` strategy) during a drain instead of refusing to surge. The value is an int-or-percentage, mirroring Kubernetes `maxSurge`: `"25%"` of `minReplicas` (rounded up) or an absolute `"10"`. Unset, or a value that resolves to zero (`"0"`/`"0%"`), leaves the feature off (default), so such a workload degrades as before; a negative or malformed value fails fast at startup. The actual surge stays demand-driven (`minReplicas + displaced`) and is capped at this amount, so larger drains proceed in waves.
-- **`ENABLE_EVENT_RECORDING`**: Enable emission of Kubernetes events by the controller (default: `false`). An installation-time observability decision, orthogonal to feature flags — a single switch for all controller events (e.g. `DrainSurgeOverride`). When `false`, no events are emitted; structured logs and metrics remain the primary signal. Must be `true` or `false`.
 
 #### Mode 1: `ENABLED_BY_DEFAULT=false` (Default)
 
@@ -562,7 +561,7 @@ It is configured entirely on the controller — there is **no per-workload annot
 
 - **`ZERO_SURGE_OVERRIDE`** — a single knob whose value is the drain surge applied when the override fires. It is an **int-or-percentage**, mirroring Kubernetes' own `maxSurge`: `"25%"` (a percent of `minReplicas`, rounded up) or `"10"` (an absolute number of extra pods). Unset, or a value that resolves to zero (`"0"`/`"0%"`), leaves the feature **off** (default), preserving today's degrade behavior. A negative or malformed value fails fast at startup. Set it (e.g. `"10%"`) at install time to enable.
 
-The surge stays **demand-driven**: the actual scale-up is `minReplicas + displaced`, capped at `minReplicas +` the override value, so a drain larger than the cap simply proceeds in **waves**. When the override drives a surge, the controller logs a structured line and — when event recording is enabled (`ENABLE_EVENT_RECORDING=true`) — emits a `DrainSurgeOverride` event on the target workload.
+The surge stays **demand-driven**: the actual scale-up is `minReplicas + displaced`, capped at `minReplicas +` the override value, so a drain larger than the cap simply proceeds in **waves**. When the override drives a surge, the controller emits a structured log line. Workloads whose rollout `maxSurge` resolves to 0 are also tracked by the `eviction_autoscaler_zero_maxsurge_workloads` metric (labels `namespace`, `name`), so operators can see how many such workloads exist in the cluster.
 
 ```yaml
 # No workload annotation is required. Enable fleet-wide on the controller:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -196,9 +196,10 @@ func main() {
 	setupLog.Info("PDB creation configuration", "pdbCreate", pdbCreate)
 
 	if err = (&controllers.EvictionAutoScalerReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Filter: nsfilter,
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Filter:   nsfilter,
+		Recorder: mgr.GetEventRecorderFor("eviction-autoscaler"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EvictionAutoScaler")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"crypto/tls"
 	"flag"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -210,35 +209,11 @@ func main() {
 	}
 	setupLog.Info("Zero-maxSurge override configuration", "zeroSurgeOverride", zeroSurgeOverride)
 
-	// Parse ENABLE_EVENT_RECORDING environment variable (defaults to false if not set).
-	// Controls whether the controller emits Kubernetes events at all — an
-	// installation-time observability decision, orthogonal to feature flags. When off,
-	// the Recorder is left nil and the `if r.Recorder != nil` guards throughout the
-	// controller skip all event emission (structured logs + metrics remain the primary
-	// signal). Strictly validated to "true"/"false"/empty so a typo fails fast.
-	eventRecordingEnabled := false
-	switch v := os.Getenv("ENABLE_EVENT_RECORDING"); v {
-	case "", "false":
-		eventRecordingEnabled = false
-	case "true":
-		eventRecordingEnabled = true
-	default:
-		setupLog.Error(fmt.Errorf("invalid value %q for ENABLE_EVENT_RECORDING (must be \"true\" or \"false\")", v),
-			"Failed to parse ENABLE_EVENT_RECORDING env variable")
-		os.Exit(1)
-	}
-	setupLog.Info("Event recording configuration", "eventRecordingEnabled", eventRecordingEnabled)
-
 	evictionAutoScalerReconciler := &controllers.EvictionAutoScalerReconciler{
-		Client:                  mgr.GetClient(),
-		Scheme:                  mgr.GetScheme(),
-		Filter:                  nsfilter,
-		ZeroSurgeOverride:       zeroSurgeOverride,
-	}
-	// Only wire the event recorder when event recording is enabled; otherwise the
-	// nil Recorder disables all event emission via the existing guards.
-	if eventRecordingEnabled {
-		evictionAutoScalerReconciler.Recorder = mgr.GetEventRecorderFor("eviction-autoscaler")
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Filter:            nsfilter,
+		ZeroSurgeOverride: zeroSurgeOverride,
 	}
 	if err = evictionAutoScalerReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EvictionAutoScaler")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -195,12 +196,71 @@ func main() {
 	}
 	setupLog.Info("PDB creation configuration", "pdbCreate", pdbCreate)
 
-	if err = (&controllers.EvictionAutoScalerReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Filter:   nsfilter,
-		Recorder: mgr.GetEventRecorderFor("eviction-autoscaler"),
-	}).SetupWithManager(mgr); err != nil {
+	// Parse SURGE_OVERRIDE_ENABLED environment variable (defaults to false if not set).
+	// Fleet-wide opt-in for honoring the drain-time surge-override annotation; when
+	// off, the annotation is a no-op and surge sizing falls through to maxSurge.
+	// Strictly validated to "true"/"false"/empty so a typo (e.g. "yes") fails fast at
+	// startup rather than silently disabling the feature.
+	surgeOverrideEnabled := false
+	switch v := os.Getenv("SURGE_OVERRIDE_ENABLED"); v {
+	case "", "false":
+		surgeOverrideEnabled = false
+	case "true":
+		surgeOverrideEnabled = true
+	default:
+		setupLog.Error(fmt.Errorf("invalid value %q for SURGE_OVERRIDE_ENABLED (must be \"true\" or \"false\")", v),
+			"Failed to parse SURGE_OVERRIDE_ENABLED env variable")
+		os.Exit(1)
+	}
+	setupLog.Info("Surge override configuration", "surgeOverrideEnabled", surgeOverrideEnabled)
+
+	// Parse SURGE_OVERRIDE_MAX_PERCENT environment variable (defaults to 25 if not set).
+	// Bounds the free-form surge-override annotation as a fleet-wide safety net; must be
+	// a positive integer. Operators can raise it to allow larger drain-time surges.
+	surgeOverrideMaxPercent := int32(25)
+	if v := os.Getenv("SURGE_OVERRIDE_MAX_PERCENT"); v != "" {
+		p, err := strconv.Atoi(v)
+		if err != nil || p <= 0 {
+			setupLog.Error(fmt.Errorf("SURGE_OVERRIDE_MAX_PERCENT must be a positive integer, got %q", v),
+				"Failed to parse SURGE_OVERRIDE_MAX_PERCENT env variable")
+			os.Exit(1)
+		}
+		surgeOverrideMaxPercent = int32(p)
+	}
+	setupLog.Info("Surge override max percent configuration", "surgeOverrideMaxPercent", surgeOverrideMaxPercent)
+
+	// Parse ENABLE_EVENT_RECORDING environment variable (defaults to false if not set).
+	// Controls whether the controller emits Kubernetes events at all — an
+	// installation-time observability decision, orthogonal to feature flags. When off,
+	// the Recorder is left nil and the `if r.Recorder != nil` guards throughout the
+	// controller skip all event emission (structured logs + metrics remain the primary
+	// signal). Strictly validated to "true"/"false"/empty so a typo fails fast.
+	eventRecordingEnabled := false
+	switch v := os.Getenv("ENABLE_EVENT_RECORDING"); v {
+	case "", "false":
+		eventRecordingEnabled = false
+	case "true":
+		eventRecordingEnabled = true
+	default:
+		setupLog.Error(fmt.Errorf("invalid value %q for ENABLE_EVENT_RECORDING (must be \"true\" or \"false\")", v),
+			"Failed to parse ENABLE_EVENT_RECORDING env variable")
+		os.Exit(1)
+	}
+	setupLog.Info("Event recording configuration", "eventRecordingEnabled", eventRecordingEnabled)
+
+	evictionAutoScalerReconciler := &controllers.EvictionAutoScalerReconciler{
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Filter:                  nsfilter,
+		SurgeOverrideEnabled:    surgeOverrideEnabled,
+		SurgeOverrideMaxPercent: surgeOverrideMaxPercent,
+	}
+	// Only wire the event recorder when event recording is enabled; otherwise the
+	// nil Recorder disables all event emission via the existing guards.
+	if eventRecordingEnabled {
+		evictionAutoScalerReconciler.Recorder = mgr.GetEventRecorderFor("eviction-autoscaler")
+	}
+	if err = evictionAutoScalerReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EvictionAutoScaler")
 		os.Exit(1)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -196,41 +196,19 @@ func main() {
 	}
 	setupLog.Info("PDB creation configuration", "pdbCreate", pdbCreate)
 
-	// Parse OVERRIDE_ZERO_MAXSURGE environment variable (defaults to false if not set).
-	// Fleet-wide opt-in: when on, a workload whose maxSurge resolves to 0 (an explicit
-	// maxSurge: 0 or a Recreate strategy) is surged by SURGE_OVERRIDE_MAX_PERCENT of
-	// minReplicas during a drain instead of being unable to surge. When off, such a
-	// workload degrades as today. Strictly validated to "true"/"false"/empty so a typo
-	// (e.g. "yes") fails fast at startup rather than silently disabling the feature.
-	overrideZeroMaxSurge := false
-	switch v := os.Getenv("OVERRIDE_ZERO_MAXSURGE"); v {
-	case "", "false":
-		overrideZeroMaxSurge = false
-	case "true":
-		overrideZeroMaxSurge = true
-	default:
-		setupLog.Error(fmt.Errorf("invalid value %q for OVERRIDE_ZERO_MAXSURGE (must be \"true\" or \"false\")", v),
-			"Failed to parse OVERRIDE_ZERO_MAXSURGE env variable")
+	// Parse ZERO_SURGE_OVERRIDE environment variable (unset/empty ⇒ feature off).
+	// Fleet-wide, install-time knob: when set, a workload whose maxSurge resolves to
+	// 0 (an explicit maxSurge: 0, a Recreate strategy, or an unset RollingUpdate) is
+	// surged by this value during a drain instead of degrading. The value is an
+	// int-or-percentage, mirroring Kubernetes maxSurge — "25%" of minReplicas
+	// (rounded up) or an absolute "10". A value that resolves to zero ("0"/"0%")
+	// leaves the feature off; a negative or malformed value fails fast at startup.
+	zeroSurgeOverride, zsErr := controllers.ParseZeroSurgeOverride(os.Getenv("ZERO_SURGE_OVERRIDE"))
+	if zsErr != nil {
+		setupLog.Error(zsErr, "Failed to parse ZERO_SURGE_OVERRIDE env variable")
 		os.Exit(1)
 	}
-	setupLog.Info("Zero-maxSurge override configuration", "overrideZeroMaxSurge", overrideZeroMaxSurge)
-
-	// Parse SURGE_OVERRIDE_MAX_PERCENT environment variable (defaults to 25 if not set).
-	// The fleet-wide drain surge, as a percent of minReplicas, applied when
-	// OVERRIDE_ZERO_MAXSURGE is on and a workload's maxSurge resolves to 0. Must be a
-	// positive integer (e.g. set to 10 at install time). The actual surge stays
-	// demand-driven and is capped at this amount, so larger drains proceed in waves.
-	surgeOverrideMaxPercent := int32(25)
-	if v := os.Getenv("SURGE_OVERRIDE_MAX_PERCENT"); v != "" {
-		p, err := strconv.Atoi(v)
-		if err != nil || p <= 0 {
-			setupLog.Error(fmt.Errorf("SURGE_OVERRIDE_MAX_PERCENT must be a positive integer, got %q", v),
-				"Failed to parse SURGE_OVERRIDE_MAX_PERCENT env variable")
-			os.Exit(1)
-		}
-		surgeOverrideMaxPercent = int32(p)
-	}
-	setupLog.Info("Surge override max percent configuration", "surgeOverrideMaxPercent", surgeOverrideMaxPercent)
+	setupLog.Info("Zero-maxSurge override configuration", "zeroSurgeOverride", zeroSurgeOverride)
 
 	// Parse ENABLE_EVENT_RECORDING environment variable (defaults to false if not set).
 	// Controls whether the controller emits Kubernetes events at all — an
@@ -255,8 +233,7 @@ func main() {
 		Client:                  mgr.GetClient(),
 		Scheme:                  mgr.GetScheme(),
 		Filter:                  nsfilter,
-		OverrideZeroMaxSurge:    overrideZeroMaxSurge,
-		SurgeOverrideMaxPercent: surgeOverrideMaxPercent,
+		ZeroSurgeOverride:       zeroSurgeOverride,
 	}
 	// Only wire the event recorder when event recording is enabled; otherwise the
 	// nil Recorder disables all event emission via the existing guards.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -196,27 +196,30 @@ func main() {
 	}
 	setupLog.Info("PDB creation configuration", "pdbCreate", pdbCreate)
 
-	// Parse SURGE_OVERRIDE_ENABLED environment variable (defaults to false if not set).
-	// Fleet-wide opt-in for honoring the drain-time surge-override annotation; when
-	// off, the annotation is a no-op and surge sizing falls through to maxSurge.
-	// Strictly validated to "true"/"false"/empty so a typo (e.g. "yes") fails fast at
-	// startup rather than silently disabling the feature.
-	surgeOverrideEnabled := false
-	switch v := os.Getenv("SURGE_OVERRIDE_ENABLED"); v {
+	// Parse OVERRIDE_ZERO_MAXSURGE environment variable (defaults to false if not set).
+	// Fleet-wide opt-in: when on, a workload whose maxSurge resolves to 0 (an explicit
+	// maxSurge: 0 or a Recreate strategy) is surged by SURGE_OVERRIDE_MAX_PERCENT of
+	// minReplicas during a drain instead of being unable to surge. When off, such a
+	// workload degrades as today. Strictly validated to "true"/"false"/empty so a typo
+	// (e.g. "yes") fails fast at startup rather than silently disabling the feature.
+	overrideZeroMaxSurge := false
+	switch v := os.Getenv("OVERRIDE_ZERO_MAXSURGE"); v {
 	case "", "false":
-		surgeOverrideEnabled = false
+		overrideZeroMaxSurge = false
 	case "true":
-		surgeOverrideEnabled = true
+		overrideZeroMaxSurge = true
 	default:
-		setupLog.Error(fmt.Errorf("invalid value %q for SURGE_OVERRIDE_ENABLED (must be \"true\" or \"false\")", v),
-			"Failed to parse SURGE_OVERRIDE_ENABLED env variable")
+		setupLog.Error(fmt.Errorf("invalid value %q for OVERRIDE_ZERO_MAXSURGE (must be \"true\" or \"false\")", v),
+			"Failed to parse OVERRIDE_ZERO_MAXSURGE env variable")
 		os.Exit(1)
 	}
-	setupLog.Info("Surge override configuration", "surgeOverrideEnabled", surgeOverrideEnabled)
+	setupLog.Info("Zero-maxSurge override configuration", "overrideZeroMaxSurge", overrideZeroMaxSurge)
 
 	// Parse SURGE_OVERRIDE_MAX_PERCENT environment variable (defaults to 25 if not set).
-	// Bounds the free-form surge-override annotation as a fleet-wide safety net; must be
-	// a positive integer. Operators can raise it to allow larger drain-time surges.
+	// The fleet-wide drain surge, as a percent of minReplicas, applied when
+	// OVERRIDE_ZERO_MAXSURGE is on and a workload's maxSurge resolves to 0. Must be a
+	// positive integer (e.g. set to 10 at install time). The actual surge stays
+	// demand-driven and is capped at this amount, so larger drains proceed in waves.
 	surgeOverrideMaxPercent := int32(25)
 	if v := os.Getenv("SURGE_OVERRIDE_MAX_PERCENT"); v != "" {
 		p, err := strconv.Atoi(v)
@@ -252,7 +255,7 @@ func main() {
 		Client:                  mgr.GetClient(),
 		Scheme:                  mgr.GetScheme(),
 		Filter:                  nsfilter,
-		SurgeOverrideEnabled:    surgeOverrideEnabled,
+		OverrideZeroMaxSurge:    overrideZeroMaxSurge,
 		SurgeOverrideMaxPercent: surgeOverrideMaxPercent,
 	}
 	// Only wire the event recorder when event recording is enabled; otherwise the

--- a/helm/eviction-autoscaler/templates/deployment.yaml
+++ b/helm/eviction-autoscaler/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
             value: {{ .Values.controllerConfig.namespaces.enabledByDefault | quote }}
           - name: ACTIONED_NAMESPACES
             value: {{ join "," .Values.controllerConfig.namespaces.actionedNamespaces | quote }}
+          - name: ZERO_SURGE_OVERRIDE
+            value: {{ .Values.controllerConfig.zeroSurgeOverride | quote }}
         command:
         - /manager
         args:

--- a/helm/eviction-autoscaler/values.yaml
+++ b/helm/eviction-autoscaler/values.yaml
@@ -52,6 +52,18 @@ controllerConfig:
   pdb:
     create: true
 
+  # Zero-maxSurge drain override (fleet-wide, install-time)
+  # When a workload's rollout maxSurge resolves to 0 — an explicit maxSurge: 0, a
+  # Recreate strategy, or an unset RollingUpdate — the controller normally cannot
+  # surge and degrades during a drain. Set this to let it surge such workloads
+  # anyway. The value is an int-or-percentage, mirroring Kubernetes maxSurge:
+  #   "25%" — 25% of the workload's min replicas (rounded up), or
+  #   "10"  — an absolute number of extra pods.
+  # A value that resolves to zero ("0"/"0%") or an empty string leaves the feature
+  # off (default), preserving today's degrade-on-zero behavior. Workloads with a
+  # non-zero maxSurge are never affected.
+  zeroSurgeOverride: ""
+
 
 
 # ServiceAccount annotations (for cloud integrations like IRSA, Workload Identity)

--- a/internal/controller/autoscaler_helpers_test.go
+++ b/internal/controller/autoscaler_helpers_test.go
@@ -163,4 +163,67 @@ var _ = Describe("calculateSurge", func() {
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(3)))
 	})
+
+	// --- surge-override annotation ---
+
+	makeTargetAnn := func(surge intstr.IntOrString, override string) Surger {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{SurgeOverrideAnnotationKey: override},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{MaxSurge: &surge},
+				},
+			},
+		}
+		return &DeploymentWrapper{obj: dep}
+	}
+
+	It("uses an integer surge-override even when maxSurge is 0", func() {
+		target := makeTargetAnn(intstr.FromInt32(0), "2")
+		result, err := calculateSurge(ctx, target, 5)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(7)))
+	})
+
+	It("surge-override wins over a non-zero maxSurge", func() {
+		target := makeTargetAnn(intstr.FromInt32(5), "2")
+		result, err := calculateSurge(ctx, target, 3)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(5))) // 3 + override(2), NOT 3 + maxSurge(5)
+	})
+
+	It("supports a percentage surge-override", func() {
+		target := makeTargetAnn(intstr.FromInt32(0), "10%")
+		// 10 * 10% = 1.0 → ceil = 1 → 10 + 1 = 11
+		result, err := calculateSurge(ctx, target, 10)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(11)))
+	})
+
+	It("applies the override even with no RollingUpdate strategy", func() {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{SurgeOverrideAnnotationKey: "3"},
+			},
+		}
+		target := &DeploymentWrapper{obj: dep}
+		result, err := calculateSurge(ctx, target, 4)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(7)))
+	})
+
+	It("returns errMaxSurgeZero for a zero surge-override", func() {
+		target := makeTargetAnn(intstr.FromInt32(2), "0")
+		result, err := calculateSurge(ctx, target, 3)
+		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
+		Expect(result).To(Equal(int32(3)))
+	})
+
+	It("returns errInvalidPercentage for an unparseable surge-override", func() {
+		target := makeTargetAnn(intstr.FromInt32(2), "abc")
+		_, err := calculateSurge(ctx, target, 3)
+		Expect(errors.Is(err, errInvalidPercentage)).To(BeTrue())
+	})
 })

--- a/internal/controller/autoscaler_helpers_test.go
+++ b/internal/controller/autoscaler_helpers_test.go
@@ -104,18 +104,18 @@ var _ = Describe("calculateSurge", func() {
 		Expect(result).To(Equal(int32(5)))
 	})
 
-	It("returns errSurgeZero when maxSurge is 0", func() {
+	It("returns errMaxSurgeZero when maxSurge is 0", func() {
 		target := makeTarget(intstr.FromInt32(0))
 		result, err := calculateSurge(ctx, target, 5)
-		Expect(errors.Is(err, errSurgeZero)).To(BeTrue())
+		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(5)))
 	})
 
-	It("returns errSurgeZero when no RollingUpdate strategy is set", func() {
+	It("returns errMaxSurgeZero when no RollingUpdate strategy is set", func() {
 		dep := &appsv1.Deployment{}
 		target := &DeploymentWrapper{obj: dep}
 		result, err := calculateSurge(ctx, target, 4)
-		Expect(errors.Is(err, errSurgeZero)).To(BeTrue())
+		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(4)))
 	})
 
@@ -175,10 +175,10 @@ var _ = Describe("calculateSurge", func() {
 		Expect(errors.Is(err, errNegativeSurge)).To(BeTrue())
 	})
 
-	It("returns errSurgeZero for 0% string", func() {
+	It("returns errMaxSurgeZero for 0% string", func() {
 		target := makeTarget(intstr.FromString("0%"))
 		result, err := calculateSurge(ctx, target, 3)
-		Expect(errors.Is(err, errSurgeZero)).To(BeTrue())
+		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(3)))
 	})
 
@@ -232,10 +232,10 @@ var _ = Describe("calculateSurge", func() {
 		Expect(result).To(Equal(int32(7)))
 	})
 
-	It("returns errSurgeZero for a zero surge-override", func() {
+	It("returns errMaxSurgeZero for a zero surge-override", func() {
 		target := makeTargetAnn(intstr.FromInt32(2), "0")
 		result, err := calculateSurge(ctx, target, 3)
-		Expect(errors.Is(err, errSurgeZero)).To(BeTrue())
+		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(3)))
 	})
 

--- a/internal/controller/autoscaler_helpers_test.go
+++ b/internal/controller/autoscaler_helpers_test.go
@@ -104,18 +104,18 @@ var _ = Describe("calculateSurge", func() {
 		Expect(result).To(Equal(int32(5)))
 	})
 
-	It("returns errMaxSurgeZero when maxSurge is 0", func() {
+	It("returns errSurgeZero when maxSurge is 0", func() {
 		target := makeTarget(intstr.FromInt32(0))
 		result, err := calculateSurge(ctx, target, 5)
-		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
+		Expect(errors.Is(err, errSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(5)))
 	})
 
-	It("returns errMaxSurgeZero when no RollingUpdate strategy is set", func() {
+	It("returns errSurgeZero when no RollingUpdate strategy is set", func() {
 		dep := &appsv1.Deployment{}
 		target := &DeploymentWrapper{obj: dep}
 		result, err := calculateSurge(ctx, target, 4)
-		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
+		Expect(errors.Is(err, errSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(4)))
 	})
 
@@ -157,10 +157,28 @@ var _ = Describe("calculateSurge", func() {
 		Expect(errors.Is(err, errInvalidPercentage)).To(BeTrue())
 	})
 
-	It("returns errMaxSurgeZero for 0% string", func() {
+	It("returns errInvalidPercentage for a string without a % suffix", func() {
+		target := makeTarget(intstr.FromString("10"))
+		_, err := calculateSurge(ctx, target, 3)
+		Expect(errors.Is(err, errInvalidPercentage)).To(BeTrue())
+	})
+
+	It("returns errNegativeSurge for a negative int maxSurge", func() {
+		target := makeTarget(intstr.FromInt32(-1))
+		_, err := calculateSurge(ctx, target, 3)
+		Expect(errors.Is(err, errNegativeSurge)).To(BeTrue())
+	})
+
+	It("returns errNegativeSurge for a negative percentage", func() {
+		target := makeTarget(intstr.FromString("-10%"))
+		_, err := calculateSurge(ctx, target, 3)
+		Expect(errors.Is(err, errNegativeSurge)).To(BeTrue())
+	})
+
+	It("returns errSurgeZero for 0% string", func() {
 		target := makeTarget(intstr.FromString("0%"))
 		result, err := calculateSurge(ctx, target, 3)
-		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
+		Expect(errors.Is(err, errSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(3)))
 	})
 
@@ -214,11 +232,17 @@ var _ = Describe("calculateSurge", func() {
 		Expect(result).To(Equal(int32(7)))
 	})
 
-	It("returns errMaxSurgeZero for a zero surge-override", func() {
+	It("returns errSurgeZero for a zero surge-override", func() {
 		target := makeTargetAnn(intstr.FromInt32(2), "0")
 		result, err := calculateSurge(ctx, target, 3)
-		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
+		Expect(errors.Is(err, errSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(3)))
+	})
+
+	It("returns errNegativeSurge for a negative surge-override", func() {
+		target := makeTargetAnn(intstr.FromInt32(2), "-1")
+		_, err := calculateSurge(ctx, target, 3)
+		Expect(errors.Is(err, errNegativeSurge)).To(BeTrue())
 	})
 
 	It("returns errInvalidPercentage for an unparseable surge-override", func() {

--- a/internal/controller/autoscaler_helpers_test.go
+++ b/internal/controller/autoscaler_helpers_test.go
@@ -15,6 +15,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// overridePercent builds a fleet-wide zero-maxSurge override pointer from a
+// percentage string (e.g. "25%") for use in reconciler test fixtures.
+func overridePercent(s string) *intstr.IntOrString {
+	v := intstr.FromString(s)
+	return &v
+}
+
 var _ = Describe("ResolveMinReplicas", func() {
 	It("should return 0 when KEDA ScaledObject has nil minReplicaCount (scale-to-zero)", func() {
 		ctx := context.Background()
@@ -96,17 +103,20 @@ var _ = Describe("calculateSurge", func() {
 		}
 		return &DeploymentWrapper{obj: dep}
 	}
+	// override builds a fleet-wide zero-maxSurge override pointer (int or percent).
+	pct := func(s string) *intstr.IntOrString { v := intstr.FromString(s); return &v }
+	abs := func(i int32) *intstr.IntOrString { v := intstr.FromInt32(i); return &v }
 
 	It("adds an integer maxSurge to minReplicas", func() {
 		target := makeTarget(intstr.FromInt32(2))
-		result, err := calculateSurge(ctx, target, 3, true, 0)
+		result, err := calculateSurge(ctx, target, 3, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(5)))
 	})
 
 	It("returns errMaxSurgeZero when maxSurge is 0", func() {
 		target := makeTarget(intstr.FromInt32(0))
-		result, err := calculateSurge(ctx, target, 5, true, 0)
+		result, err := calculateSurge(ctx, target, 5, nil)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(5)))
 	})
@@ -114,7 +124,7 @@ var _ = Describe("calculateSurge", func() {
 	It("returns errMaxSurgeZero when no RollingUpdate strategy is set", func() {
 		dep := &appsv1.Deployment{}
 		target := &DeploymentWrapper{obj: dep}
-		result, err := calculateSurge(ctx, target, 4, true, 0)
+		result, err := calculateSurge(ctx, target, 4, nil)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(4)))
 	})
@@ -122,7 +132,7 @@ var _ = Describe("calculateSurge", func() {
 	It("computes 25% surge with ceiling (exact)", func() {
 		target := makeTarget(intstr.FromString("25%"))
 		// 4 * 25% = 1.0 → ceil(1.0) = 1 → 4+1 = 5
-		result, err := calculateSurge(ctx, target, 4, true, 0)
+		result, err := calculateSurge(ctx, target, 4, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(5)))
 	})
@@ -130,7 +140,7 @@ var _ = Describe("calculateSurge", func() {
 	It("computes 25% surge with ceiling (fractional)", func() {
 		target := makeTarget(intstr.FromString("25%"))
 		// 3 * 25% = 0.75 → ceil(0.75) = 1 → 3+1 = 4
-		result, err := calculateSurge(ctx, target, 3, true, 0)
+		result, err := calculateSurge(ctx, target, 3, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(4)))
 	})
@@ -138,7 +148,7 @@ var _ = Describe("calculateSurge", func() {
 	It("computes 50% surge with ceiling", func() {
 		target := makeTarget(intstr.FromString("50%"))
 		// 3 * 50% = 1.5 → ceil(1.5) = 2 → 3+2 = 5
-		result, err := calculateSurge(ctx, target, 3, true, 0)
+		result, err := calculateSurge(ctx, target, 3, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(5)))
 	})
@@ -146,90 +156,132 @@ var _ = Describe("calculateSurge", func() {
 	It("computes 100% surge", func() {
 		target := makeTarget(intstr.FromString("100%"))
 		// 5 * 100% = 5 → ceil(5) = 5 → 5+5 = 10
-		result, err := calculateSurge(ctx, target, 5, true, 0)
+		result, err := calculateSurge(ctx, target, 5, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(10)))
 	})
 
 	It("returns errInvalidPercentage for invalid percentage string", func() {
 		target := makeTarget(intstr.FromString("abc%"))
-		_, err := calculateSurge(ctx, target, 3, true, 0)
+		_, err := calculateSurge(ctx, target, 3, nil)
 		Expect(errors.Is(err, errInvalidPercentage)).To(BeTrue())
 	})
 
 	It("returns errInvalidPercentage for a string without a % suffix", func() {
 		target := makeTarget(intstr.FromString("10"))
-		_, err := calculateSurge(ctx, target, 3, true, 0)
+		_, err := calculateSurge(ctx, target, 3, nil)
 		Expect(errors.Is(err, errInvalidPercentage)).To(BeTrue())
 	})
 
 	It("returns errNegativeSurge for a negative int maxSurge", func() {
 		target := makeTarget(intstr.FromInt32(-1))
-		_, err := calculateSurge(ctx, target, 3, true, 0)
+		_, err := calculateSurge(ctx, target, 3, nil)
 		Expect(errors.Is(err, errNegativeSurge)).To(BeTrue())
 	})
 
 	It("returns errNegativeSurge for a negative percentage", func() {
 		target := makeTarget(intstr.FromString("-10%"))
-		_, err := calculateSurge(ctx, target, 3, true, 0)
+		_, err := calculateSurge(ctx, target, 3, nil)
 		Expect(errors.Is(err, errNegativeSurge)).To(BeTrue())
 	})
 
 	It("returns errMaxSurgeZero for 0% string", func() {
 		target := makeTarget(intstr.FromString("0%"))
-		result, err := calculateSurge(ctx, target, 3, true, 0)
+		result, err := calculateSurge(ctx, target, 3, nil)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(3)))
 	})
 
-	// --- fleet-wide zero-maxSurge override (OverrideZeroMaxSurge + SurgeOverrideMaxPercent) ---
+	// --- fleet-wide zero-maxSurge override (ZeroSurgeOverride: int or percent) ---
 
-	It("surges by the fleet percent when maxSurge is 0 and the override is on", func() {
+	It("surges by the override percent when maxSurge is 0 and an override is set", func() {
 		// 10% of 100 = 10 -> 100 + 10 = 110
 		target := makeTarget(intstr.FromInt32(0))
-		result, err := calculateSurge(ctx, target, 100, true, 10)
+		result, err := calculateSurge(ctx, target, 100, pct("10%"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(110)))
 	})
 
-	It("degrades (errMaxSurgeZero) when maxSurge is 0 and the override is off", func() {
+	It("surges by an absolute int override when maxSurge is 0", func() {
+		// absolute 7 -> 100 + 7 = 107 (differentiator: override accepts int, not only percent)
 		target := makeTarget(intstr.FromInt32(0))
-		result, err := calculateSurge(ctx, target, 100, false, 10)
+		result, err := calculateSurge(ctx, target, 100, abs(7))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(107)))
+	})
+
+	It("degrades (errMaxSurgeZero) when maxSurge is 0 and no override is set", func() {
+		target := makeTarget(intstr.FromInt32(0))
+		result, err := calculateSurge(ctx, target, 100, nil)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(100)))
 	})
 
-	It("degrades when maxSurge is 0, override on, but percent is 0 (disabled)", func() {
-		target := makeTarget(intstr.FromInt32(0))
-		_, err := calculateSurge(ctx, target, 100, true, 0)
-		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
-	})
-
-	It("uses maxSurge unchanged when maxSurge is non-zero, even with the override on", func() {
-		// maxSurge 5 -> 3 + 5 = 8; the fleet override does NOT apply
+	It("uses maxSurge unchanged when maxSurge is non-zero, even with an override set", func() {
+		// maxSurge 5 -> 3 + 5 = 8; the override does NOT apply
 		target := makeTarget(intstr.FromInt32(5))
-		result, err := calculateSurge(ctx, target, 3, true, 10)
+		result, err := calculateSurge(ctx, target, 3, pct("10%"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(8)))
 	})
 
-	It("applies the fleet override for a Recreate strategy (no RollingUpdate)", func() {
+	It("applies the override for a Recreate strategy (no RollingUpdate)", func() {
 		dep := &appsv1.Deployment{
 			Spec: appsv1.DeploymentSpec{
 				Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
 			},
 		}
 		target := &DeploymentWrapper{obj: dep}
-		result, err := calculateSurge(ctx, target, 100, true, 10)
+		result, err := calculateSurge(ctx, target, 100, pct("10%"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(110)))
 	})
 
-	It("rounds the fleet percent up (33% of 10 -> 4)", func() {
+	It("rounds the override percent up (33% of 10 -> 4)", func() {
 		// ceil(10 * 33%) = ceil(3.3) = 4 -> 10 + 4 = 14
 		target := makeTarget(intstr.FromInt32(0))
-		result, err := calculateSurge(ctx, target, 10, true, 33)
+		result, err := calculateSurge(ctx, target, 10, pct("33%"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(14)))
+	})
+})
+
+var _ = Describe("ParseZeroSurgeOverride", func() {
+	It("returns nil for an empty string (feature off)", func() {
+		v, err := ParseZeroSurgeOverride("")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v).To(BeNil())
+	})
+
+	It("returns nil for a value that resolves to zero (0 and 0%)", func() {
+		for _, raw := range []string{"0", "0%"} {
+			v, err := ParseZeroSurgeOverride(raw)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v).To(BeNil(), "raw %q should disable the feature", raw)
+		}
+	})
+
+	It("parses a percentage value", func() {
+		v, err := ParseZeroSurgeOverride("25%")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v).NotTo(BeNil())
+		Expect(*v).To(Equal(intstr.FromString("25%")))
+	})
+
+	It("parses an absolute integer value", func() {
+		v, err := ParseZeroSurgeOverride("10")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(v).NotTo(BeNil())
+		Expect(*v).To(Equal(intstr.FromInt32(10)))
+	})
+
+	It("errors on a negative value", func() {
+		_, err := ParseZeroSurgeOverride("-5")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("errors on a malformed percentage", func() {
+		_, err := ParseZeroSurgeOverride("abc%")
+		Expect(err).To(HaveOccurred())
 	})
 })

--- a/internal/controller/autoscaler_helpers_test.go
+++ b/internal/controller/autoscaler_helpers_test.go
@@ -99,14 +99,14 @@ var _ = Describe("calculateSurge", func() {
 
 	It("adds an integer maxSurge to minReplicas", func() {
 		target := makeTarget(intstr.FromInt32(2))
-		result, err := calculateSurge(ctx, target, 3)
+		result, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(5)))
 	})
 
 	It("returns errMaxSurgeZero when maxSurge is 0", func() {
 		target := makeTarget(intstr.FromInt32(0))
-		result, err := calculateSurge(ctx, target, 5)
+		result, err := calculateSurge(ctx, target, 5, true, 0)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(5)))
 	})
@@ -114,7 +114,7 @@ var _ = Describe("calculateSurge", func() {
 	It("returns errMaxSurgeZero when no RollingUpdate strategy is set", func() {
 		dep := &appsv1.Deployment{}
 		target := &DeploymentWrapper{obj: dep}
-		result, err := calculateSurge(ctx, target, 4)
+		result, err := calculateSurge(ctx, target, 4, true, 0)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(4)))
 	})
@@ -122,7 +122,7 @@ var _ = Describe("calculateSurge", func() {
 	It("computes 25% surge with ceiling (exact)", func() {
 		target := makeTarget(intstr.FromString("25%"))
 		// 4 * 25% = 1.0 → ceil(1.0) = 1 → 4+1 = 5
-		result, err := calculateSurge(ctx, target, 4)
+		result, err := calculateSurge(ctx, target, 4, true, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(5)))
 	})
@@ -130,7 +130,7 @@ var _ = Describe("calculateSurge", func() {
 	It("computes 25% surge with ceiling (fractional)", func() {
 		target := makeTarget(intstr.FromString("25%"))
 		// 3 * 25% = 0.75 → ceil(0.75) = 1 → 3+1 = 4
-		result, err := calculateSurge(ctx, target, 3)
+		result, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(4)))
 	})
@@ -138,7 +138,7 @@ var _ = Describe("calculateSurge", func() {
 	It("computes 50% surge with ceiling", func() {
 		target := makeTarget(intstr.FromString("50%"))
 		// 3 * 50% = 1.5 → ceil(1.5) = 2 → 3+2 = 5
-		result, err := calculateSurge(ctx, target, 3)
+		result, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(5)))
 	})
@@ -146,38 +146,38 @@ var _ = Describe("calculateSurge", func() {
 	It("computes 100% surge", func() {
 		target := makeTarget(intstr.FromString("100%"))
 		// 5 * 100% = 5 → ceil(5) = 5 → 5+5 = 10
-		result, err := calculateSurge(ctx, target, 5)
+		result, err := calculateSurge(ctx, target, 5, true, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(10)))
 	})
 
 	It("returns errInvalidPercentage for invalid percentage string", func() {
 		target := makeTarget(intstr.FromString("abc%"))
-		_, err := calculateSurge(ctx, target, 3)
+		_, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(errors.Is(err, errInvalidPercentage)).To(BeTrue())
 	})
 
 	It("returns errInvalidPercentage for a string without a % suffix", func() {
 		target := makeTarget(intstr.FromString("10"))
-		_, err := calculateSurge(ctx, target, 3)
+		_, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(errors.Is(err, errInvalidPercentage)).To(BeTrue())
 	})
 
 	It("returns errNegativeSurge for a negative int maxSurge", func() {
 		target := makeTarget(intstr.FromInt32(-1))
-		_, err := calculateSurge(ctx, target, 3)
+		_, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(errors.Is(err, errNegativeSurge)).To(BeTrue())
 	})
 
 	It("returns errNegativeSurge for a negative percentage", func() {
 		target := makeTarget(intstr.FromString("-10%"))
-		_, err := calculateSurge(ctx, target, 3)
+		_, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(errors.Is(err, errNegativeSurge)).To(BeTrue())
 	})
 
 	It("returns errMaxSurgeZero for 0% string", func() {
 		target := makeTarget(intstr.FromString("0%"))
-		result, err := calculateSurge(ctx, target, 3)
+		result, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(3)))
 	})
@@ -200,14 +200,14 @@ var _ = Describe("calculateSurge", func() {
 
 	It("uses an integer surge-override even when maxSurge is 0", func() {
 		target := makeTargetAnn(intstr.FromInt32(0), "2")
-		result, err := calculateSurge(ctx, target, 5)
+		result, err := calculateSurge(ctx, target, 5, true, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(7)))
 	})
 
 	It("surge-override wins over a non-zero maxSurge", func() {
 		target := makeTargetAnn(intstr.FromInt32(5), "2")
-		result, err := calculateSurge(ctx, target, 3)
+		result, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(5))) // 3 + override(2), NOT 3 + maxSurge(5)
 	})
@@ -215,7 +215,7 @@ var _ = Describe("calculateSurge", func() {
 	It("supports a percentage surge-override", func() {
 		target := makeTargetAnn(intstr.FromInt32(0), "10%")
 		// 10 * 10% = 1.0 → ceil = 1 → 10 + 1 = 11
-		result, err := calculateSurge(ctx, target, 10)
+		result, err := calculateSurge(ctx, target, 10, true, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(11)))
 	})
@@ -227,27 +227,118 @@ var _ = Describe("calculateSurge", func() {
 			},
 		}
 		target := &DeploymentWrapper{obj: dep}
-		result, err := calculateSurge(ctx, target, 4)
+		result, err := calculateSurge(ctx, target, 4, true, 0)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(7)))
 	})
 
 	It("returns errMaxSurgeZero for a zero surge-override", func() {
 		target := makeTargetAnn(intstr.FromInt32(2), "0")
-		result, err := calculateSurge(ctx, target, 3)
+		result, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
 		Expect(result).To(Equal(int32(3)))
 	})
 
 	It("returns errNegativeSurge for a negative surge-override", func() {
 		target := makeTargetAnn(intstr.FromInt32(2), "-1")
-		_, err := calculateSurge(ctx, target, 3)
+		_, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(errors.Is(err, errNegativeSurge)).To(BeTrue())
 	})
 
 	It("returns errInvalidPercentage for an unparseable surge-override", func() {
 		target := makeTargetAnn(intstr.FromInt32(2), "abc")
-		_, err := calculateSurge(ctx, target, 3)
+		_, err := calculateSurge(ctx, target, 3, true, 0)
 		Expect(errors.Is(err, errInvalidPercentage)).To(BeTrue())
+	})
+
+	// --- surge-override cap (SurgeOverrideMaxPercent) ---
+
+	It("caps an int surge-override that exceeds the max-percent bound", func() {
+		// override "100" on minReplicas 10; cap = ceil(10*25%) = 3 → 10+3 = 13
+		target := makeTargetAnn(intstr.FromInt32(0), "100")
+		result, err := calculateSurge(ctx, target, 10, true, 25)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(13)))
+	})
+
+	It("caps a percentage surge-override that exceeds the max-percent bound", func() {
+		// override "100%" on minReplicas 10 → surge 10; cap = ceil(10*25%) = 3 → 13
+		target := makeTargetAnn(intstr.FromInt32(0), "100%")
+		result, err := calculateSurge(ctx, target, 10, true, 25)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(13)))
+	})
+
+	It("does not cap an override within the max-percent bound", func() {
+		// override "2" on minReplicas 10; cap = 3; 2 <= 3 → 10+2 = 12
+		target := makeTargetAnn(intstr.FromInt32(0), "2")
+		result, err := calculateSurge(ctx, target, 10, true, 25)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(12)))
+	})
+
+	It("floors the cap at 1 when minReplicas is small", func() {
+		// minReplicas 1; cap = ceil(1*25%) = ceil(0.25) = 1 (floored) → override "5" capped to 1 → 2
+		target := makeTargetAnn(intstr.FromInt32(0), "5")
+		result, err := calculateSurge(ctx, target, 1, true, 25)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(2)))
+	})
+
+	It("does not cap when max-percent is non-positive (disabled)", func() {
+		// override "100" on minReplicas 10, cap disabled → 10+100 = 110
+		target := makeTargetAnn(intstr.FromInt32(0), "100")
+		result, err := calculateSurge(ctx, target, 10, true, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(110)))
+	})
+
+	It("trims surrounding whitespace on the override value", func() {
+		// "  2  " → parsed as 2; minReplicas 10 → 12
+		target := makeTargetAnn(intstr.FromInt32(0), "  2  ")
+		result, err := calculateSurge(ctx, target, 10, true, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(12)))
+	})
+
+	// --- surge-override feature-gate + rounding/boundary (maxPercent=0 isolates the cap) ---
+
+	It("ignores the surge-override annotation when the feature flag is disabled (maxSurge=0)", func() {
+		// flag off + annotation present → falls through to maxSurge(0) → errMaxSurgeZero
+		target := makeTargetAnn(intstr.FromInt32(0), "2")
+		result, err := calculateSurge(ctx, target, 5, false, 0)
+		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
+		Expect(result).To(Equal(int32(5)))
+	})
+
+	It("falls through to maxSurge when the flag is disabled even with an override present", func() {
+		// flag off + override "10" but maxSurge 3 → uses maxSurge(3), ignores override → 3+3 = 6
+		target := makeTargetAnn(intstr.FromInt32(3), "10")
+		result, err := calculateSurge(ctx, target, 3, false, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(6)))
+	})
+
+	It("rounds a percentage override up (33% of 10 → 4)", func() {
+		// 10 * 33% = 3.3 → ceil = 4 → 10 + 4 = 14 (cap disabled)
+		target := makeTargetAnn(intstr.FromInt32(0), "33%")
+		result, err := calculateSurge(ctx, target, 10, true, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(14)))
+	})
+
+	It("supports a minimal boundary override (1 with minReplicas 1)", func() {
+		target := makeTargetAnn(intstr.FromInt32(0), "1")
+		result, err := calculateSurge(ctx, target, 1, true, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(2)))
+	})
+
+	It("doubles replicas with a 100% override (cap disabled)", func() {
+		// 5 * 100% = 5 → 5 + 5 = 10
+		target := makeTargetAnn(intstr.FromInt32(0), "100%")
+		result, err := calculateSurge(ctx, target, 5, true, 0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(10)))
 	})
 })

--- a/internal/controller/autoscaler_helpers_test.go
+++ b/internal/controller/autoscaler_helpers_test.go
@@ -121,8 +121,22 @@ var _ = Describe("calculateSurge", func() {
 		Expect(result).To(Equal(int32(5)))
 	})
 
-	It("returns errMaxSurgeZero when no RollingUpdate strategy is set", func() {
+	It("uses the Kubernetes default 25% surge when no RollingUpdate strategy is set", func() {
 		dep := &appsv1.Deployment{}
+		target := &DeploymentWrapper{obj: dep}
+		// An unset strategy implies RollingUpdate with 25% maxSurge (k8s default).
+		// 4 * 25% = 1.0 → ceil(1.0) = 1 → 4+1 = 5
+		result, err := calculateSurge(ctx, target, 4, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(5)))
+	})
+
+	It("returns errMaxSurgeZero for a Recreate strategy (no override)", func() {
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
+			},
+		}
 		target := &DeploymentWrapper{obj: dep}
 		result, err := calculateSurge(ctx, target, 4, nil)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
@@ -243,6 +257,32 @@ var _ = Describe("calculateSurge", func() {
 		result, err := calculateSurge(ctx, target, 10, pct("33%"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(14)))
+	})
+
+	It("does NOT apply override for a bare Deployment (unset strategy defaults to 25%)", func() {
+		dep := &appsv1.Deployment{}
+		target := &DeploymentWrapper{obj: dep}
+		// Override is set but should be ignored: unset strategy implies 25% maxSurge.
+		// 100 * 25% = 25 -> 100 + 25 = 125 (using k8s default, not override 10%)
+		result, err := calculateSurge(ctx, target, 100, pct("10%"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(125)))
+	})
+
+	It("does NOT apply override when RollingUpdate type is set but maxSurge is nil", func() {
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+				},
+			},
+		}
+		target := &DeploymentWrapper{obj: dep}
+		// Override is set but should be ignored: nil maxSurge defaults to 25%.
+		// 100 * 25% = 25 -> 100 + 25 = 125
+		result, err := calculateSurge(ctx, target, 100, pct("10%"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(125)))
 	})
 })
 

--- a/internal/controller/autoscaler_helpers_test.go
+++ b/internal/controller/autoscaler_helpers_test.go
@@ -182,163 +182,54 @@ var _ = Describe("calculateSurge", func() {
 		Expect(result).To(Equal(int32(3)))
 	})
 
-	// --- surge-override annotation ---
+	// --- fleet-wide zero-maxSurge override (OverrideZeroMaxSurge + SurgeOverrideMaxPercent) ---
 
-	makeTargetAnn := func(surge intstr.IntOrString, override string) Surger {
-		dep := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{SurgeOverrideAnnotationKey: override},
-			},
-			Spec: appsv1.DeploymentSpec{
-				Strategy: appsv1.DeploymentStrategy{
-					RollingUpdate: &appsv1.RollingUpdateDeployment{MaxSurge: &surge},
-				},
-			},
-		}
-		return &DeploymentWrapper{obj: dep}
-	}
-
-	It("uses an integer surge-override even when maxSurge is 0", func() {
-		target := makeTargetAnn(intstr.FromInt32(0), "2")
-		result, err := calculateSurge(ctx, target, 5, true, 0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(7)))
-	})
-
-	It("surge-override wins over a non-zero maxSurge", func() {
-		target := makeTargetAnn(intstr.FromInt32(5), "2")
-		result, err := calculateSurge(ctx, target, 3, true, 0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(5))) // 3 + override(2), NOT 3 + maxSurge(5)
-	})
-
-	It("supports a percentage surge-override", func() {
-		target := makeTargetAnn(intstr.FromInt32(0), "10%")
-		// 10 * 10% = 1.0 → ceil = 1 → 10 + 1 = 11
-		result, err := calculateSurge(ctx, target, 10, true, 0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(11)))
-	})
-
-	It("applies the override even with no RollingUpdate strategy", func() {
-		dep := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{SurgeOverrideAnnotationKey: "3"},
-			},
-		}
-		target := &DeploymentWrapper{obj: dep}
-		result, err := calculateSurge(ctx, target, 4, true, 0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(7)))
-	})
-
-	It("returns errMaxSurgeZero for a zero surge-override", func() {
-		target := makeTargetAnn(intstr.FromInt32(2), "0")
-		result, err := calculateSurge(ctx, target, 3, true, 0)
-		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
-		Expect(result).To(Equal(int32(3)))
-	})
-
-	It("returns errNegativeSurge for a negative surge-override", func() {
-		target := makeTargetAnn(intstr.FromInt32(2), "-1")
-		_, err := calculateSurge(ctx, target, 3, true, 0)
-		Expect(errors.Is(err, errNegativeSurge)).To(BeTrue())
-	})
-
-	It("returns errInvalidPercentage for an unparseable surge-override", func() {
-		target := makeTargetAnn(intstr.FromInt32(2), "abc")
-		_, err := calculateSurge(ctx, target, 3, true, 0)
-		Expect(errors.Is(err, errInvalidPercentage)).To(BeTrue())
-	})
-
-	// --- surge-override cap (SurgeOverrideMaxPercent) ---
-
-	It("caps an int surge-override that exceeds the max-percent bound", func() {
-		// override "100" on minReplicas 10; cap = ceil(10*25%) = 3 → 10+3 = 13
-		target := makeTargetAnn(intstr.FromInt32(0), "100")
-		result, err := calculateSurge(ctx, target, 10, true, 25)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(13)))
-	})
-
-	It("caps a percentage surge-override that exceeds the max-percent bound", func() {
-		// override "100%" on minReplicas 10 → surge 10; cap = ceil(10*25%) = 3 → 13
-		target := makeTargetAnn(intstr.FromInt32(0), "100%")
-		result, err := calculateSurge(ctx, target, 10, true, 25)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(13)))
-	})
-
-	It("does not cap an override within the max-percent bound", func() {
-		// override "2" on minReplicas 10; cap = 3; 2 <= 3 → 10+2 = 12
-		target := makeTargetAnn(intstr.FromInt32(0), "2")
-		result, err := calculateSurge(ctx, target, 10, true, 25)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(12)))
-	})
-
-	It("floors the cap at 1 when minReplicas is small", func() {
-		// minReplicas 1; cap = ceil(1*25%) = ceil(0.25) = 1 (floored) → override "5" capped to 1 → 2
-		target := makeTargetAnn(intstr.FromInt32(0), "5")
-		result, err := calculateSurge(ctx, target, 1, true, 25)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(2)))
-	})
-
-	It("does not cap when max-percent is non-positive (disabled)", func() {
-		// override "100" on minReplicas 10, cap disabled → 10+100 = 110
-		target := makeTargetAnn(intstr.FromInt32(0), "100")
-		result, err := calculateSurge(ctx, target, 10, true, 0)
+	It("surges by the fleet percent when maxSurge is 0 and the override is on", func() {
+		// 10% of 100 = 10 -> 100 + 10 = 110
+		target := makeTarget(intstr.FromInt32(0))
+		result, err := calculateSurge(ctx, target, 100, true, 10)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(110)))
 	})
 
-	It("trims surrounding whitespace on the override value", func() {
-		// "  2  " → parsed as 2; minReplicas 10 → 12
-		target := makeTargetAnn(intstr.FromInt32(0), "  2  ")
-		result, err := calculateSurge(ctx, target, 10, true, 0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(12)))
-	})
-
-	// --- surge-override feature-gate + rounding/boundary (maxPercent=0 isolates the cap) ---
-
-	It("ignores the surge-override annotation when the feature flag is disabled (maxSurge=0)", func() {
-		// flag off + annotation present → falls through to maxSurge(0) → errMaxSurgeZero
-		target := makeTargetAnn(intstr.FromInt32(0), "2")
-		result, err := calculateSurge(ctx, target, 5, false, 0)
+	It("degrades (errMaxSurgeZero) when maxSurge is 0 and the override is off", func() {
+		target := makeTarget(intstr.FromInt32(0))
+		result, err := calculateSurge(ctx, target, 100, false, 10)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
-		Expect(result).To(Equal(int32(5)))
+		Expect(result).To(Equal(int32(100)))
 	})
 
-	It("falls through to maxSurge when the flag is disabled even with an override present", func() {
-		// flag off + override "10" but maxSurge 3 → uses maxSurge(3), ignores override → 3+3 = 6
-		target := makeTargetAnn(intstr.FromInt32(3), "10")
-		result, err := calculateSurge(ctx, target, 3, false, 0)
+	It("degrades when maxSurge is 0, override on, but percent is 0 (disabled)", func() {
+		target := makeTarget(intstr.FromInt32(0))
+		_, err := calculateSurge(ctx, target, 100, true, 0)
+		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
+	})
+
+	It("uses maxSurge unchanged when maxSurge is non-zero, even with the override on", func() {
+		// maxSurge 5 -> 3 + 5 = 8; the fleet override does NOT apply
+		target := makeTarget(intstr.FromInt32(5))
+		result, err := calculateSurge(ctx, target, 3, true, 10)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(6)))
+		Expect(result).To(Equal(int32(8)))
 	})
 
-	It("rounds a percentage override up (33% of 10 → 4)", func() {
-		// 10 * 33% = 3.3 → ceil = 4 → 10 + 4 = 14 (cap disabled)
-		target := makeTargetAnn(intstr.FromInt32(0), "33%")
-		result, err := calculateSurge(ctx, target, 10, true, 0)
+	It("applies the fleet override for a Recreate strategy (no RollingUpdate)", func() {
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
+			},
+		}
+		target := &DeploymentWrapper{obj: dep}
+		result, err := calculateSurge(ctx, target, 100, true, 10)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(int32(110)))
+	})
+
+	It("rounds the fleet percent up (33% of 10 -> 4)", func() {
+		// ceil(10 * 33%) = ceil(3.3) = 4 -> 10 + 4 = 14
+		target := makeTarget(intstr.FromInt32(0))
+		result, err := calculateSurge(ctx, target, 10, true, 33)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(int32(14)))
-	})
-
-	It("supports a minimal boundary override (1 with minReplicas 1)", func() {
-		target := makeTargetAnn(intstr.FromInt32(0), "1")
-		result, err := calculateSurge(ctx, target, 1, true, 0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(2)))
-	})
-
-	It("doubles replicas with a 100% override (cap disabled)", func() {
-		// 5 * 100% = 5 → 5 + 5 = 10
-		target := makeTargetAnn(intstr.FromInt32(0), "100%")
-		result, err := calculateSurge(ctx, target, 5, true, 0)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal(int32(10)))
 	})
 })

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -14,6 +14,7 @@ import (
 
 	//v1 "k8s.io/api/apps/v1"
 
+	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -32,17 +33,21 @@ import (
 const EvictionSurgeReplicasAnnotationKey = "evictionSurgeReplicas"
 const OriginalMinReplicasAnnotationKey = "eviction-autoscaler.azure.com/original-min-replicas"
 
-// SurgeOverrideAnnotationKey lets an operator override how much the eviction
-// autoscaler surges a target, independently of the target's own
-// spec.strategy.rollingUpdate.maxSurge. When set on the target workload it
-// ALWAYS takes precedence over maxSurge. The value is an int ("2") or a
-// percentage of minReplicas ("10%"), matching maxSurge semantics.
+// SurgeOverrideAnnotationKey sets a drain-time surge cap override on the target
+// workload: how much the eviction autoscaler may surge the target during a drain,
+// independently of the target's own spec.strategy.rollingUpdate.maxSurge (which
+// governs rollouts). When set it ALWAYS takes precedence over maxSurge for
+// drain-time surge. The value is an int ("2") or a percentage of minReplicas
+// ("10%"), matching maxSurge semantics.
 //
-// Motivation: safe-deployment guidance often mandates maxSurge=0 on the rollout
-// strategy (no extra pods created during an app update). But that also disables
-// the eviction autoscaler's drain-time surge for exactly those workloads. This
-// annotation decouples the two: keep maxSurge=0 for rollouts while still allowing
-// a bounded, drain-only surge that the autoscaler reverts when the drain finishes.
+// Motivation: rollout surge and drain surge are different operational events.
+// Safe-deployment guidance often mandates maxSurge=0 on the rollout strategy (no
+// extra pods created during an app update), which also disables the autoscaler's
+// drain-time surge for those workloads. This annotation decouples the two: keep
+// maxSurge=0 for rollouts while still allowing a bounded, workload-tuned surge
+// only during a drain, which the autoscaler reverts when the drain finishes. It
+// is a cap, not the amount: the actual surge stays demand-driven
+// (minReplicas + displaced), so larger drains proceed in waves.
 const SurgeOverrideAnnotationKey = "eviction-autoscaler.azure.com/surge-override"
 
 // EvictionAutoScalerReconciler reconciles a EvictionAutoScaler object
@@ -227,6 +232,20 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name(), "displaced", displaced, "surgeTarget", surgeTarget)
 
+		// Surface when the drain-time surge cap overrides the workload's rollout
+		// maxSurge, since we are deliberately surging a workload whose author set an
+		// explicit (often 0) rollout maxSurge. Emitted only when a surge actually
+		// fires; the Kubernetes event recorder aggregates repeats across reconciles.
+		if override, ok := surgeOverrideValue(target); ok {
+			maxSurge := target.GetMaxSurge()
+			msg := fmt.Sprintf("drain-time surge cap %q overrides rollout maxSurge %q for %s/%s",
+				override, maxSurge.String(), target.Obj().GetNamespace(), target.Obj().GetName())
+			logger.Info(msg, "surgeOverride", override, "rolloutMaxSurge", maxSurge.String(), "surgeTarget", surgeTarget)
+			if r.Recorder != nil {
+				r.Recorder.Event(target.Obj(), corev1.EventTypeNormal, "DrainSurgeOverride", msg)
+			}
+		}
+
 		// Track blocked eviction if the PDB is blocking the eviction
 		metrics.BlockedEvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name).Inc()
 
@@ -347,18 +366,28 @@ var (
 func calculateSurge(_ context.Context, target Surger, minReplicas int32) (int32, error) {
 	// An explicit surge-override annotation on the target always wins over maxSurge,
 	// so a workload can keep maxSurge=0 for its rollout strategy yet still surge on drain.
-	if ann := target.Obj().GetAnnotations(); ann != nil {
-		if override, ok := ann[SurgeOverrideAnnotationKey]; ok {
-			result, err := surgeFromValue(intstr.Parse(override), minReplicas)
-			if err != nil {
-				// Wrap so operators see the value came from the override annotation,
-				// not from the target's maxSurge.
-				return result, fmt.Errorf("surge-override annotation %q: %w", override, err)
-			}
-			return result, nil
+	if override, ok := surgeOverrideValue(target); ok {
+		result, err := surgeFromValue(intstr.Parse(override), minReplicas)
+		if err != nil {
+			// Wrap so operators see the value came from the override annotation,
+			// not from the target's maxSurge.
+			return result, fmt.Errorf("surge-override annotation %q: %w", override, err)
 		}
+		return result, nil
 	}
 	return surgeFromValue(target.GetMaxSurge(), minReplicas)
+}
+
+// surgeOverrideValue returns the SurgeOverrideAnnotationKey value from the target
+// workload if present. Single reader of the annotation, shared by calculateSurge
+// and the surge-path event/log emission.
+func surgeOverrideValue(target Surger) (string, bool) {
+	ann := target.Obj().GetAnnotations()
+	if ann == nil {
+		return "", false
+	}
+	v, ok := ann[SurgeOverrideAnnotationKey]
+	return v, ok
 }
 
 // surgeFromValue resolves an int-or-percentage surge value against minReplicas.

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -194,7 +194,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	maxSurgeTarget, surgeErr := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas)
 	if surgeErr != nil {
 		switch {
-		case errors.Is(surgeErr, errSurgeZero):
+		case errors.Is(surgeErr, errMaxSurgeZero):
 			// Surge resolves to 0 (maxSurge=0/unset or a zero override) — can't surge, degrade.
 			degraded(&EvictionAutoScaler.Status.Conditions, "UnsupportedAutoscalerConfiguration", surgeErr.Error())
 			return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler)
@@ -332,7 +332,7 @@ func (r *EvictionAutoScalerReconciler) SetupWithManager(mgr ctrl.Manager) error 
 }
 
 var (
-	errSurgeZero         = errors.New("surge is 0; eviction autoscaler cannot surge")
+	errMaxSurgeZero      = errors.New("maxSurge is 0; eviction autoscaler cannot surge")
 	errInvalidPercentage = errors.New("invalid surge percentage")
 	errNegativeSurge     = errors.New("surge value is negative")
 )
@@ -340,8 +340,8 @@ var (
 // calculateSurge returns the maximum replica count after surge (minReplicas + surge).
 // The surge amount is taken from the SurgeOverrideAnnotationKey annotation on the
 // target when present (it always wins), otherwise from the target's maxSurge.
-// Returns a sentinel error to distinguish:
-//   - errSurgeZero: the surge amount resolves to 0 (explicitly set or not configured)
+// The underlying error unwraps to a sentinel:
+//   - errMaxSurgeZero: the surge amount resolves to 0 (explicitly set or not configured)
 //   - errInvalidPercentage: percentage string could not be parsed or lacks a "%" suffix
 //   - errNegativeSurge: the surge amount is negative
 func calculateSurge(_ context.Context, target Surger, minReplicas int32) (int32, error) {
@@ -349,7 +349,13 @@ func calculateSurge(_ context.Context, target Surger, minReplicas int32) (int32,
 	// so a workload can keep maxSurge=0 for its rollout strategy yet still surge on drain.
 	if ann := target.Obj().GetAnnotations(); ann != nil {
 		if override, ok := ann[SurgeOverrideAnnotationKey]; ok {
-			return surgeFromValue(intstr.Parse(override), minReplicas)
+			result, err := surgeFromValue(intstr.Parse(override), minReplicas)
+			if err != nil {
+				// Wrap so operators see the value came from the override annotation,
+				// not from the target's maxSurge.
+				return result, fmt.Errorf("surge-override annotation %q: %w", override, err)
+			}
+			return result, nil
 		}
 	}
 	return surgeFromValue(target.GetMaxSurge(), minReplicas)
@@ -357,7 +363,7 @@ func calculateSurge(_ context.Context, target Surger, minReplicas int32) (int32,
 
 // surgeFromValue resolves an int-or-percentage surge value against minReplicas.
 // An int is added directly; a percentage (a string ending in "%") is applied to
-// minReplicas and rounded up. A zero value yields errSurgeZero; a negative value
+// minReplicas and rounded up. A zero value yields errMaxSurgeZero; a negative value
 // yields errNegativeSurge; a string that is not a valid "<n>%" percentage yields
 // errInvalidPercentage.
 func surgeFromValue(surge intstr.IntOrString, minReplicas int32) (int32, error) {
@@ -366,14 +372,15 @@ func surgeFromValue(surge intstr.IntOrString, minReplicas int32) (int32, error) 
 		case surge.IntVal < 0:
 			return minReplicas, fmt.Errorf("%w: %d", errNegativeSurge, surge.IntVal)
 		case surge.IntVal == 0:
-			return minReplicas, errSurgeZero
+			return minReplicas, errMaxSurgeZero
 		}
 		return minReplicas + surge.IntVal, nil
 	}
 
 	if surge.Type == intstr.String {
-		// A string surge value must be a percentage, e.g. "10%". Reject bare numbers
-		// like "10" so they are never silently interpreted as a percentage.
+		// A string surge value must be a percentage, e.g. "10%". Kubernetes stores a
+		// numeric maxSurge as an intstr Int (handled above), so a String type is always
+		// a percentage — reject a bare number like "10" as malformed.
 		if !strings.HasSuffix(surge.StrVal, "%") {
 			return minReplicas, fmt.Errorf("%w: %q is not a percentage (missing %% suffix)", errInvalidPercentage, surge.StrVal)
 		}
@@ -385,11 +392,11 @@ func surgeFromValue(surge intstr.IntOrString, minReplicas int32) (int32, error) 
 		case percentage < 0:
 			return minReplicas, fmt.Errorf("%w: %q", errNegativeSurge, surge.StrVal)
 		case percentage == 0:
-			return minReplicas, errSurgeZero
+			return minReplicas, errMaxSurgeZero
 		}
 		return minReplicas + int32(math.Ceil((float64(minReplicas)*float64(percentage))/100.0)), nil
 	}
 
 	// Unreachable for well-formed intstr values, but handle gracefully
-	return minReplicas, errSurgeZero
+	return minReplicas, errMaxSurgeZero
 }

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -32,6 +32,19 @@ import (
 const EvictionSurgeReplicasAnnotationKey = "evictionSurgeReplicas"
 const OriginalMinReplicasAnnotationKey = "eviction-autoscaler.azure.com/original-min-replicas"
 
+// SurgeOverrideAnnotationKey lets an operator override how much the eviction
+// autoscaler surges a target, independently of the target's own
+// spec.strategy.rollingUpdate.maxSurge. When set on the target workload it
+// ALWAYS takes precedence over maxSurge. The value is an int ("2") or a
+// percentage of minReplicas ("10%"), matching maxSurge semantics.
+//
+// Motivation: safe-deployment guidance often mandates maxSurge=0 on the rollout
+// strategy (no extra pods created during an app update). But that also disables
+// the eviction autoscaler's drain-time surge for exactly those workloads. This
+// annotation decouples the two: keep maxSurge=0 for rollouts while still allowing
+// a bounded, drain-only surge that the autoscaler reverts when the drain finishes.
+const SurgeOverrideAnnotationKey = "eviction-autoscaler.azure.com/surge-override"
+
 // EvictionAutoScalerReconciler reconciles a EvictionAutoScaler object
 type EvictionAutoScalerReconciler struct {
 	client.Client
@@ -323,13 +336,27 @@ var (
 	errInvalidPercentage = errors.New("invalid surge percentage")
 )
 
-// calculateSurge returns the maximum replica count after surge (minReplicas + maxSurge).
+// calculateSurge returns the maximum replica count after surge (minReplicas + surge).
+// The surge amount is taken from the SurgeOverrideAnnotationKey annotation on the
+// target when present (it always wins), otherwise from the target's maxSurge.
 // Returns a sentinel error to distinguish:
-//   - errMaxSurgeZero: maxSurge resolves to 0 (explicitly set or not configured)
+//   - errMaxSurgeZero: the surge amount resolves to 0 (explicitly set or not configured)
 //   - errInvalidPercentage: percentage string could not be parsed
 func calculateSurge(_ context.Context, target Surger, minrepicas int32) (int32, error) {
+	// An explicit surge-override annotation on the target always wins over maxSurge,
+	// so a workload can keep maxSurge=0 for its rollout strategy yet still surge on drain.
+	if ann := target.Obj().GetAnnotations(); ann != nil {
+		if override, ok := ann[SurgeOverrideAnnotationKey]; ok {
+			return surgeFromValue(intstr.Parse(override), minrepicas)
+		}
+	}
+	return surgeFromValue(target.GetMaxSurge(), minrepicas)
+}
 
-	surge := target.GetMaxSurge()
+// surgeFromValue resolves an int-or-percentage surge value against minReplicas.
+// An int is added directly; a percentage is applied to minReplicas and rounded up.
+// A zero value yields errMaxSurgeZero; an unparseable percentage yields errInvalidPercentage.
+func surgeFromValue(surge intstr.IntOrString, minrepicas int32) (int32, error) {
 	if surge.Type == intstr.Int {
 		if surge.IntVal == 0 {
 			return minrepicas, errMaxSurgeZero

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -194,8 +194,8 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	maxSurgeTarget, surgeErr := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas)
 	if surgeErr != nil {
 		switch {
-		case errors.Is(surgeErr, errMaxSurgeZero):
-			// maxSurge is 0 (explicit or not configured) — can't surge, degrade.
+		case errors.Is(surgeErr, errSurgeZero):
+			// Surge resolves to 0 (maxSurge=0/unset or a zero override) — can't surge, degrade.
 			degraded(&EvictionAutoScaler.Status.Conditions, "UnsupportedAutoscalerConfiguration", surgeErr.Error())
 			return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler)
 		default:
@@ -332,50 +332,64 @@ func (r *EvictionAutoScalerReconciler) SetupWithManager(mgr ctrl.Manager) error 
 }
 
 var (
-	errMaxSurgeZero      = errors.New("maxSurge is 0; eviction autoscaler cannot surge")
+	errSurgeZero         = errors.New("surge is 0; eviction autoscaler cannot surge")
 	errInvalidPercentage = errors.New("invalid surge percentage")
+	errNegativeSurge     = errors.New("surge value is negative")
 )
 
 // calculateSurge returns the maximum replica count after surge (minReplicas + surge).
 // The surge amount is taken from the SurgeOverrideAnnotationKey annotation on the
 // target when present (it always wins), otherwise from the target's maxSurge.
 // Returns a sentinel error to distinguish:
-//   - errMaxSurgeZero: the surge amount resolves to 0 (explicitly set or not configured)
-//   - errInvalidPercentage: percentage string could not be parsed
-func calculateSurge(_ context.Context, target Surger, minrepicas int32) (int32, error) {
+//   - errSurgeZero: the surge amount resolves to 0 (explicitly set or not configured)
+//   - errInvalidPercentage: percentage string could not be parsed or lacks a "%" suffix
+//   - errNegativeSurge: the surge amount is negative
+func calculateSurge(_ context.Context, target Surger, minReplicas int32) (int32, error) {
 	// An explicit surge-override annotation on the target always wins over maxSurge,
 	// so a workload can keep maxSurge=0 for its rollout strategy yet still surge on drain.
 	if ann := target.Obj().GetAnnotations(); ann != nil {
 		if override, ok := ann[SurgeOverrideAnnotationKey]; ok {
-			return surgeFromValue(intstr.Parse(override), minrepicas)
+			return surgeFromValue(intstr.Parse(override), minReplicas)
 		}
 	}
-	return surgeFromValue(target.GetMaxSurge(), minrepicas)
+	return surgeFromValue(target.GetMaxSurge(), minReplicas)
 }
 
 // surgeFromValue resolves an int-or-percentage surge value against minReplicas.
-// An int is added directly; a percentage is applied to minReplicas and rounded up.
-// A zero value yields errMaxSurgeZero; an unparseable percentage yields errInvalidPercentage.
-func surgeFromValue(surge intstr.IntOrString, minrepicas int32) (int32, error) {
+// An int is added directly; a percentage (a string ending in "%") is applied to
+// minReplicas and rounded up. A zero value yields errSurgeZero; a negative value
+// yields errNegativeSurge; a string that is not a valid "<n>%" percentage yields
+// errInvalidPercentage.
+func surgeFromValue(surge intstr.IntOrString, minReplicas int32) (int32, error) {
 	if surge.Type == intstr.Int {
-		if surge.IntVal == 0 {
-			return minrepicas, errMaxSurgeZero
+		switch {
+		case surge.IntVal < 0:
+			return minReplicas, fmt.Errorf("%w: %d", errNegativeSurge, surge.IntVal)
+		case surge.IntVal == 0:
+			return minReplicas, errSurgeZero
 		}
-		return minrepicas + surge.IntVal, nil
+		return minReplicas + surge.IntVal, nil
 	}
 
 	if surge.Type == intstr.String {
-		percentageStr := strings.TrimSuffix(surge.StrVal, "%")
-		percentage, err := strconv.Atoi(percentageStr)
+		// A string surge value must be a percentage, e.g. "10%". Reject bare numbers
+		// like "10" so they are never silently interpreted as a percentage.
+		if !strings.HasSuffix(surge.StrVal, "%") {
+			return minReplicas, fmt.Errorf("%w: %q is not a percentage (missing %% suffix)", errInvalidPercentage, surge.StrVal)
+		}
+		percentage, err := strconv.Atoi(strings.TrimSuffix(surge.StrVal, "%"))
 		if err != nil {
-			return minrepicas, fmt.Errorf("%w: %q: %w", errInvalidPercentage, surge.StrVal, err)
+			return minReplicas, fmt.Errorf("%w: %q: %w", errInvalidPercentage, surge.StrVal, err)
 		}
-		if percentage == 0 {
-			return minrepicas, errMaxSurgeZero
+		switch {
+		case percentage < 0:
+			return minReplicas, fmt.Errorf("%w: %q", errNegativeSurge, surge.StrVal)
+		case percentage == 0:
+			return minReplicas, errSurgeZero
 		}
-		return minrepicas + int32(math.Ceil((float64(minrepicas)*float64(percentage))/100.0)), nil
+		return minReplicas + int32(math.Ceil((float64(minReplicas)*float64(percentage))/100.0)), nil
 	}
 
 	// Unreachable for well-formed intstr values, but handle gracefully
-	return minrepicas, errMaxSurgeZero
+	return minReplicas, errSurgeZero
 }

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -33,43 +33,25 @@ import (
 const EvictionSurgeReplicasAnnotationKey = "evictionSurgeReplicas"
 const OriginalMinReplicasAnnotationKey = "eviction-autoscaler.azure.com/original-min-replicas"
 
-// SurgeOverrideAnnotationKey sets a drain-time surge cap override on the target
-// workload: how much the eviction autoscaler may surge the target during a drain,
-// independently of the target's own spec.strategy.rollingUpdate.maxSurge (which
-// governs rollouts). When set it ALWAYS takes precedence over maxSurge for
-// drain-time surge. The value is an int ("2") or a percentage of minReplicas
-// ("10%"), matching maxSurge semantics.
-//
-// Motivation: rollout surge and drain surge are different operational events.
-// Safe-deployment guidance often mandates maxSurge=0 on the rollout strategy (no
-// extra pods created during an app update), which also disables the autoscaler's
-// drain-time surge for those workloads. This annotation decouples the two: keep
-// maxSurge=0 for rollouts while still allowing a bounded, workload-tuned surge
-// only during a drain, which the autoscaler reverts when the drain finishes. It
-// is a cap, not the amount: the actual surge stays demand-driven
-// (minReplicas + displaced), so larger drains proceed in waves.
-const SurgeOverrideAnnotationKey = "eviction-autoscaler.azure.com/surge-override"
-
 // EvictionAutoScalerReconciler reconciles a EvictionAutoScaler object
 type EvictionAutoScalerReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 	Filter   filter
-	// SurgeOverrideEnabled gates the drain-time surge-override annotation
-	// (SurgeOverrideAnnotationKey). When false (the default), the annotation is
-	// ignored and surge sizing falls through to the workload's rollout maxSurge,
-	// preserving today's behavior. It is a fleet-wide opt-in set via the
-	// SURGE_OVERRIDE_ENABLED controller env var, so Cosmic — not individual
-	// workload owners — decides whether drain-time surge overrides are honored.
-	SurgeOverrideEnabled bool
-	// SurgeOverrideMaxPercent bounds the free-form surge-override annotation: the
-	// override-resolved surge amount is capped at this percent of minReplicas
-	// (rounded up, floored at 1). Because the annotation bypasses API-server
-	// admission validation, this is a safety net against a fat-fingered value.
-	// Set via the SURGE_OVERRIDE_MAX_PERCENT env var (default 25); operators can
-	// raise it fleet-wide. A non-positive value disables the cap. The rollout
-	// maxSurge path is already admission-validated and is never capped here.
+	// OverrideZeroMaxSurge lets the controller surge a workload whose maxSurge
+	// resolves to 0 — an explicit maxSurge: 0 (common under safe-deployment
+	// guidance) or a Recreate strategy. When false (the default), such a workload
+	// cannot surge and the autoscaler degrades — today's behavior. It is a
+	// fleet-wide opt-in set via the OVERRIDE_ZERO_MAXSURGE controller env var, so
+	// Cosmic — not individual workload owners — decides whether it applies.
+	OverrideZeroMaxSurge bool
+	// SurgeOverrideMaxPercent is the fleet-wide drain surge, as a percent of
+	// minReplicas (rounded up, floored at 1), applied only when OverrideZeroMaxSurge
+	// is on and the workload's maxSurge resolves to 0. The actual surge stays
+	// demand-driven (minReplicas + displaced) and is capped at this amount, so
+	// larger drains proceed in waves. Set via the SURGE_OVERRIDE_MAX_PERCENT env var
+	// (default 25); a non-positive value disables the override.
 	SurgeOverrideMaxPercent int32
 }
 
@@ -211,7 +193,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// surgeTarget = minReplicas + displaced, capped at minReplicas + maxSurge.
 	// If displaced == 0 the formula yields minReplicas, so no scale-up fires and
 	// we fall through to the cooldown/scale-down path — which is correct.
-	maxSurgeTarget, surgeErr := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas, r.SurgeOverrideEnabled, r.SurgeOverrideMaxPercent)
+	maxSurgeTarget, surgeErr := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas, r.OverrideZeroMaxSurge, r.SurgeOverrideMaxPercent)
 	if surgeErr != nil {
 		switch {
 		case errors.Is(surgeErr, errMaxSurgeZero):
@@ -247,15 +229,15 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name(), "displaced", displaced, "surgeTarget", surgeTarget)
 
-		// Surface when the drain-time surge cap overrides the workload's rollout
-		// maxSurge, since we are deliberately surging a workload whose author set an
-		// explicit (often 0) rollout maxSurge. Emitted only when a surge actually
-		// fires; the Kubernetes event recorder aggregates repeats across reconciles.
-		if override, ok := surgeOverrideValue(target); ok && r.SurgeOverrideEnabled {
-			maxSurge := target.GetMaxSurge()
-			msg := fmt.Sprintf("drain-time surge cap %q overrides rollout maxSurge %q for %s/%s",
-				override, maxSurge.String(), target.Obj().GetNamespace(), target.Obj().GetName())
-			logger.Info(msg, "surgeOverride", override, "rolloutMaxSurge", maxSurge.String(), "surgeTarget", surgeTarget)
+		// Surface when the fleet-wide zero-maxSurge override drives a surge — we are
+		// deliberately surging a workload whose author set an explicit (often 0)
+		// rollout maxSurge. Emitted only when a surge actually fires; the Kubernetes
+		// event recorder aggregates repeats across reconciles.
+		maxSurge := target.GetMaxSurge()
+		if r.OverrideZeroMaxSurge && isZeroSurge(maxSurge) {
+			msg := fmt.Sprintf("zero-maxSurge override surging %s/%s during drain (rollout maxSurge %q)",
+				target.Obj().GetNamespace(), target.Obj().GetName(), maxSurge.String())
+			logger.Info(msg, "surgeTarget", surgeTarget)
 			if r.Recorder != nil {
 				r.Recorder.Event(target.Obj(), corev1.EventTypeNormal, "DrainSurgeOverride", msg)
 			}
@@ -372,65 +354,32 @@ var (
 )
 
 // calculateSurge returns the maximum replica count after surge (minReplicas + surge).
-// The surge amount is taken from the SurgeOverrideAnnotationKey annotation on the
-// target when present (it always wins), otherwise from the target's maxSurge.
+// The surge amount is normally taken from the target's maxSurge. When maxSurge
+// resolves to 0 (an explicit maxSurge: 0 or a Recreate strategy) and the fleet-wide
+// OverrideZeroMaxSurge flag is on, a fleet drain surge of zeroMaxSurgePercent of
+// minReplicas is applied instead of refusing to surge.
 // The underlying error unwraps to a sentinel:
-//   - errMaxSurgeZero: the surge amount resolves to 0 (explicitly set or not configured)
+//   - errMaxSurgeZero: the surge amount resolves to 0 and no override applies
 //   - errInvalidPercentage: percentage string could not be parsed or lacks a "%" suffix
 //   - errNegativeSurge: the surge amount is negative
-func calculateSurge(_ context.Context, target Surger, minReplicas int32, surgeOverrideEnabled bool, surgeOverrideMaxPercent int32) (int32, error) {
-	// An explicit surge-override annotation on the target always wins over maxSurge,
-	// so a workload can keep maxSurge=0 for its rollout strategy yet still surge on drain.
-	// The annotation is only honored when the controller-level flag is enabled
-	// (fleet-wide opt-in); otherwise it is ignored and we fall through to maxSurge,
-	// preserving the controller's default behavior.
-	if surgeOverrideEnabled {
-		if override, ok := surgeOverrideValue(target); ok {
-			result, err := surgeFromValue(intstr.Parse(strings.TrimSpace(override)), minReplicas)
-			if err != nil {
-				// Wrap so operators see the value came from the override annotation,
-				// not from the target's maxSurge.
-				return result, fmt.Errorf("surge-override annotation %q: %w", override, err)
-			}
-			// The override annotation is free-form and bypasses API-server admission
-			// validation, so a fat-fingered value (e.g. "100" on a large deployment)
-			// could request an unbounded surge. Cap the override-resolved surge amount
-			// as a safety bound. The rollout maxSurge path below is already
-			// admission-validated and is left uncapped.
-			return capOverrideSurge(result, minReplicas, surgeOverrideMaxPercent), nil
-		}
+func calculateSurge(_ context.Context, target Surger, minReplicas int32, overrideZeroMaxSurge bool, zeroMaxSurgePercent int32) (int32, error) {
+	result, err := surgeFromValue(target.GetMaxSurge(), minReplicas)
+	// When the workload cannot surge on its own (maxSurge resolves to 0) and the
+	// fleet-wide override is enabled, substitute a fleet drain surge of
+	// zeroMaxSurgePercent of minReplicas. The actual surge stays demand-driven
+	// (minReplicas + displaced) and is capped at this amount, so larger drains
+	// proceed in waves.
+	if errors.Is(err, errMaxSurgeZero) && overrideZeroMaxSurge && zeroMaxSurgePercent > 0 {
+		return surgeFromValue(intstr.FromString(fmt.Sprintf("%d%%", zeroMaxSurgePercent)), minReplicas)
 	}
-	return surgeFromValue(target.GetMaxSurge(), minReplicas)
+	return result, err
 }
 
-// capOverrideSurge bounds the override-resolved surge target so the surge amount
-// (result - minReplicas) does not exceed maxPercent of minReplicas (rounded up,
-// floored at 1). A non-positive maxPercent disables the cap. Only the free-form
-// surge-override path is capped; the API-validated rollout maxSurge is not.
-func capOverrideSurge(result, minReplicas, maxPercent int32) int32 {
-	if maxPercent <= 0 {
-		return result
-	}
-	capAmount := int32(math.Ceil(float64(minReplicas) * float64(maxPercent) / 100.0))
-	if capAmount < 1 {
-		capAmount = 1
-	}
-	if surge := result - minReplicas; surge > capAmount {
-		return minReplicas + capAmount
-	}
-	return result
-}
-
-// surgeOverrideValue returns the SurgeOverrideAnnotationKey value from the target
-// workload if present. Single reader of the annotation, shared by calculateSurge
-// and the surge-path event/log emission.
-func surgeOverrideValue(target Surger) (string, bool) {
-	ann := target.Obj().GetAnnotations()
-	if ann == nil {
-		return "", false
-	}
-	v, ok := ann[SurgeOverrideAnnotationKey]
-	return v, ok
+// isZeroSurge reports whether a maxSurge value resolves to no surge — an int 0 or
+// a 0% (e.g. an explicit maxSurge: 0 or a Recreate strategy).
+func isZeroSurge(maxSurge intstr.IntOrString) bool {
+	_, err := surgeFromValue(maxSurge, 1)
+	return errors.Is(err, errMaxSurgeZero)
 }
 
 // surgeFromValue resolves an int-or-percentage surge value against minReplicas.

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -40,8 +40,10 @@ type EvictionAutoScalerReconciler struct {
 	Filter   filter
 	// ZeroSurgeOverride lets the controller surge a workload whose maxSurge
 	// resolves to 0 — an explicit maxSurge: 0 (common under safe-deployment
-	// guidance) or a Recreate strategy — which otherwise cannot surge and would
-	// degrade. When non-nil, its value is applied as the drain surge for such
+	// guidance) or a Recreate strategy — which otherwise cannot surge and
+	// would degrade. Note: an unset RollingUpdate strategy is NOT treated as
+	// zero — Kubernetes defaults it to 25% at admission time, and GetMaxSurge
+	// returns that default. When non-nil, its value is applied as the drain surge for such
 	// workloads: an int-or-percentage resolved against minReplicas, mirroring
 	// Kubernetes' own maxSurge semantics — e.g. "25%" (rounded up) or an absolute
 	// "10". The actual surge stays demand-driven (minReplicas + displaced) and is
@@ -135,7 +137,8 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// Track whether this workload's rollout maxSurge resolves to 0 (an explicit
-	// maxSurge: 0, a Recreate strategy, or an unset RollingUpdate). Set per reconcile
+	// maxSurge: 0 or a Recreate strategy). An unset RollingUpdate defaults to
+	// 25% (the Kubernetes default) and is NOT counted as zero. Set per reconcile
 	// so the series sum reflects the current count of maxSurge:0 workloads in the cluster.
 	recordZeroMaxSurge(target, EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName)
 
@@ -347,10 +350,13 @@ var (
 )
 
 // calculateSurge returns the maximum replica count after surge (minReplicas + surge).
-// The surge amount is normally taken from the target's maxSurge. When maxSurge
-// resolves to 0 (an explicit maxSurge: 0 or a Recreate strategy) and a fleet-wide
-// zeroSurgeOverride is configured, that override — an int-or-percentage resolved
-// against minReplicas — is applied instead of refusing to surge.
+// The surge amount is normally taken from the target's maxSurge (via GetMaxSurge,
+// which returns the Kubernetes default 25% for an unset RollingUpdate strategy).
+// When maxSurge resolves to 0 (an explicit maxSurge: 0 or a Recreate strategy) and
+// a fleet-wide zeroSurgeOverride is configured, that override — an int-or-percentage
+// resolved against minReplicas — is applied instead of refusing to surge.
+// Note: workloads with an unset strategy (or unset maxSurge within RollingUpdate)
+// get the Kubernetes default 25% and are NOT eligible for the override.
 // The underlying error unwraps to a sentinel:
 //   - errMaxSurgeZero: the surge amount resolves to 0 and no override applies
 //   - errInvalidPercentage: percentage string could not be parsed or lacks a "%" suffix
@@ -391,8 +397,9 @@ func ParseZeroSurgeOverride(raw string) (*intstr.IntOrString, error) {
 }
 
 // recordZeroMaxSurge sets the zero-maxSurge workload gauge for the target: 1 when its
-// rollout maxSurge resolves to 0 (an explicit maxSurge: 0, a Recreate strategy, or an
-// unset RollingUpdate), else 0 — so the series sum is the cluster-wide count.
+// rollout maxSurge resolves to 0 (an explicit maxSurge: 0 or a Recreate strategy),
+// else 0 — so the series sum is the cluster-wide count. Workloads with an unset
+// RollingUpdate strategy are NOT counted as zero (Kubernetes defaults to 25%).
 func recordZeroMaxSurge(target Surger, namespace, name string) {
 	value := 0.0
 	if isZeroSurge(target.GetMaxSurge()) {
@@ -412,7 +419,8 @@ func (r *EvictionAutoScalerReconciler) logZeroSurgeOverride(ctx context.Context,
 }
 
 // isZeroSurge reports whether a maxSurge value resolves to no surge — an int 0 or
-// a 0% (e.g. an explicit maxSurge: 0 or a Recreate strategy).
+// a 0% (e.g. an explicit maxSurge: 0 or a Recreate strategy). An unset RollingUpdate
+// strategy returns 25% (the Kubernetes default) and is NOT considered zero surge.
 func isZeroSurge(maxSurge intstr.IntOrString) bool {
 	_, err := surgeFromValue(maxSurge, 1)
 	return errors.Is(err, errMaxSurgeZero)

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -137,11 +137,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Track whether this workload's rollout maxSurge resolves to 0 (an explicit
 	// maxSurge: 0, a Recreate strategy, or an unset RollingUpdate). Set per reconcile
 	// so the series sum reflects the current count of maxSurge:0 workloads in the cluster.
-	if isZeroSurge(target.GetMaxSurge()) {
-		metrics.ZeroMaxSurgeWorkloadGauge.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName).Set(1)
-	} else {
-		metrics.ZeroMaxSurgeWorkloadGauge.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName).Set(0)
-	}
+	recordZeroMaxSurge(target, EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName)
 
 	// TODO: Move PDB configuration tracking to PDB controller with aggregate labels
 	// Consider tracking: maxUnavailable==0 and minAvailable==replicas as PDBGauge labels
@@ -238,11 +234,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Surface when the fleet-wide zero-maxSurge override drives a surge — we are
 		// deliberately surging a workload whose author set an explicit (often 0)
 		// rollout maxSurge. Logged only when a surge actually fires.
-		maxSurge := target.GetMaxSurge()
-		if r.ZeroSurgeOverride != nil && isZeroSurge(maxSurge) {
-			logger.Info(fmt.Sprintf("zero-maxSurge override surging %s/%s during drain (rollout maxSurge %q)",
-				target.Obj().GetNamespace(), target.Obj().GetName(), maxSurge.String()), "surgeTarget", surgeTarget)
-		}
+		r.logZeroSurgeOverride(ctx, target, surgeTarget)
 
 		// Track blocked eviction if the PDB is blocking the eviction
 		metrics.BlockedEvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name).Inc()
@@ -384,18 +376,39 @@ func calculateSurge(_ context.Context, target Surger, minReplicas int32, zeroSur
 // value returns an error so startup fails fast rather than misbehaving mid-drain.
 func ParseZeroSurgeOverride(raw string) (*intstr.IntOrString, error) {
 	if raw == "" {
-		return nil, nil
+		return nil, nil //nolint:nilnil // a nil pointer signals the override is disabled; not an error
 	}
 	v := intstr.Parse(raw)
 	// Validate against a representative base so a bad percentage/negative surfaces
 	// now rather than on the first drain; the base value itself is irrelevant.
 	switch _, err := surgeFromValue(v, 100); {
 	case errors.Is(err, errMaxSurgeZero):
-		return nil, nil
+		return nil, nil //nolint:nilnil // a value that resolves to zero disables the override; not an error
 	case err != nil:
 		return nil, err
 	}
 	return &v, nil
+}
+
+// recordZeroMaxSurge sets the zero-maxSurge workload gauge for the target: 1 when its
+// rollout maxSurge resolves to 0 (an explicit maxSurge: 0, a Recreate strategy, or an
+// unset RollingUpdate), else 0 — so the series sum is the cluster-wide count.
+func recordZeroMaxSurge(target Surger, namespace, name string) {
+	value := 0.0
+	if isZeroSurge(target.GetMaxSurge()) {
+		value = 1
+	}
+	metrics.ZeroMaxSurgeWorkloadGauge.WithLabelValues(namespace, name).Set(value)
+}
+
+// logZeroSurgeOverride emits a structured log when the fleet-wide zero-maxSurge override
+// drives a surge — i.e. the target's rollout maxSurge resolves to 0 and an override is set.
+func (r *EvictionAutoScalerReconciler) logZeroSurgeOverride(ctx context.Context, target Surger, surgeTarget int32) {
+	maxSurge := target.GetMaxSurge()
+	if r.ZeroSurgeOverride != nil && isZeroSurge(maxSurge) {
+		log.FromContext(ctx).Info(fmt.Sprintf("zero-maxSurge override surging %s/%s during drain (rollout maxSurge %q)",
+			target.Obj().GetNamespace(), target.Obj().GetName(), maxSurge.String()), "surgeTarget", surgeTarget)
+	}
 }
 
 // isZeroSurge reports whether a maxSurge value resolves to no surge — an int 0 or

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -14,7 +14,6 @@ import (
 
 	//v1 "k8s.io/api/apps/v1"
 
-	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -135,6 +134,15 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	// Track whether this workload's rollout maxSurge resolves to 0 (an explicit
+	// maxSurge: 0, a Recreate strategy, or an unset RollingUpdate). Set per reconcile
+	// so the series sum reflects the current count of maxSurge:0 workloads in the cluster.
+	if isZeroSurge(target.GetMaxSurge()) {
+		metrics.ZeroMaxSurgeWorkloadGauge.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName).Set(1)
+	} else {
+		metrics.ZeroMaxSurgeWorkloadGauge.WithLabelValues(EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName).Set(0)
+	}
+
 	// TODO: Move PDB configuration tracking to PDB controller with aggregate labels
 	// Consider tracking: maxUnavailable==0 and minAvailable==replicas as PDBGauge labels
 
@@ -188,14 +196,14 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		"evictionTime", EvictionAutoScaler.Spec.LastEviction.EvictionTime)
 	metrics.EvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace).Inc()
 
-	// surgeTarget = minReplicas + displaced, capped at minReplicas + maxSurge.
-	// If displaced == 0 the formula yields minReplicas, so no scale-up fires and
-	// we fall through to the cooldown/scale-down path — which is correct.
+	// calculateSurge returns the surge ceiling: minReplicas + maxSurge, or — when maxSurge
+	// resolves to 0 and ZeroSurgeOverride is set — minReplicas + the override. surgeTarget
+	// below is demand-driven (minReplicas + displaced), clamped to this ceiling.
 	maxSurgeTarget, surgeErr := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas, r.ZeroSurgeOverride)
 	if surgeErr != nil {
 		switch {
 		case errors.Is(surgeErr, errMaxSurgeZero):
-			// Surge resolves to 0 (maxSurge=0/unset or a zero override) — can't surge, degrade.
+			// maxSurge resolves to 0 and no ZeroSurgeOverride set — nothing to surge, degrade.
 			degraded(&EvictionAutoScaler.Status.Conditions, "UnsupportedAutoscalerConfiguration", surgeErr.Error())
 			return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler)
 		default:
@@ -229,16 +237,11 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		// Surface when the fleet-wide zero-maxSurge override drives a surge — we are
 		// deliberately surging a workload whose author set an explicit (often 0)
-		// rollout maxSurge. Emitted only when a surge actually fires; the Kubernetes
-		// event recorder aggregates repeats across reconciles.
+		// rollout maxSurge. Logged only when a surge actually fires.
 		maxSurge := target.GetMaxSurge()
 		if r.ZeroSurgeOverride != nil && isZeroSurge(maxSurge) {
-			msg := fmt.Sprintf("zero-maxSurge override surging %s/%s during drain (rollout maxSurge %q)",
-				target.Obj().GetNamespace(), target.Obj().GetName(), maxSurge.String())
-			logger.Info(msg, "surgeTarget", surgeTarget)
-			if r.Recorder != nil {
-				r.Recorder.Event(target.Obj(), corev1.EventTypeNormal, "DrainSurgeOverride", msg)
-			}
+			logger.Info(fmt.Sprintf("zero-maxSurge override surging %s/%s during drain (rollout maxSurge %q)",
+				target.Obj().GetNamespace(), target.Obj().GetName(), maxSurge.String()), "surgeTarget", surgeTarget)
 		}
 
 		// Track blocked eviction if the PDB is blocking the eviction

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -39,20 +39,18 @@ type EvictionAutoScalerReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 	Filter   filter
-	// OverrideZeroMaxSurge lets the controller surge a workload whose maxSurge
+	// ZeroSurgeOverride lets the controller surge a workload whose maxSurge
 	// resolves to 0 — an explicit maxSurge: 0 (common under safe-deployment
-	// guidance) or a Recreate strategy. When false (the default), such a workload
-	// cannot surge and the autoscaler degrades — today's behavior. It is a
-	// fleet-wide opt-in set via the OVERRIDE_ZERO_MAXSURGE controller env var, so
-	// Cosmic — not individual workload owners — decides whether it applies.
-	OverrideZeroMaxSurge bool
-	// SurgeOverrideMaxPercent is the fleet-wide drain surge, as a percent of
-	// minReplicas (rounded up, floored at 1), applied only when OverrideZeroMaxSurge
-	// is on and the workload's maxSurge resolves to 0. The actual surge stays
-	// demand-driven (minReplicas + displaced) and is capped at this amount, so
-	// larger drains proceed in waves. Set via the SURGE_OVERRIDE_MAX_PERCENT env var
-	// (default 25); a non-positive value disables the override.
-	SurgeOverrideMaxPercent int32
+	// guidance) or a Recreate strategy — which otherwise cannot surge and would
+	// degrade. When non-nil, its value is applied as the drain surge for such
+	// workloads: an int-or-percentage resolved against minReplicas, mirroring
+	// Kubernetes' own maxSurge semantics — e.g. "25%" (rounded up) or an absolute
+	// "10". The actual surge stays demand-driven (minReplicas + displaced) and is
+	// capped at this amount, so larger drains proceed in waves. It is a fleet-wide,
+	// install-time knob (the ZERO_SURGE_OVERRIDE controller env var); nil (the
+	// default) preserves today's degrade-on-zero behavior, so Cosmic — not
+	// individual workload owners — decides whether it applies.
+	ZeroSurgeOverride *intstr.IntOrString
 }
 
 const cooldown = 1 * time.Minute
@@ -193,7 +191,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// surgeTarget = minReplicas + displaced, capped at minReplicas + maxSurge.
 	// If displaced == 0 the formula yields minReplicas, so no scale-up fires and
 	// we fall through to the cooldown/scale-down path — which is correct.
-	maxSurgeTarget, surgeErr := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas, r.OverrideZeroMaxSurge, r.SurgeOverrideMaxPercent)
+	maxSurgeTarget, surgeErr := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas, r.ZeroSurgeOverride)
 	if surgeErr != nil {
 		switch {
 		case errors.Is(surgeErr, errMaxSurgeZero):
@@ -234,7 +232,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// rollout maxSurge. Emitted only when a surge actually fires; the Kubernetes
 		// event recorder aggregates repeats across reconciles.
 		maxSurge := target.GetMaxSurge()
-		if r.OverrideZeroMaxSurge && isZeroSurge(maxSurge) {
+		if r.ZeroSurgeOverride != nil && isZeroSurge(maxSurge) {
 			msg := fmt.Sprintf("zero-maxSurge override surging %s/%s during drain (rollout maxSurge %q)",
 				target.Obj().GetNamespace(), target.Obj().GetName(), maxSurge.String())
 			logger.Info(msg, "surgeTarget", surgeTarget)
@@ -355,24 +353,46 @@ var (
 
 // calculateSurge returns the maximum replica count after surge (minReplicas + surge).
 // The surge amount is normally taken from the target's maxSurge. When maxSurge
-// resolves to 0 (an explicit maxSurge: 0 or a Recreate strategy) and the fleet-wide
-// OverrideZeroMaxSurge flag is on, a fleet drain surge of zeroMaxSurgePercent of
-// minReplicas is applied instead of refusing to surge.
+// resolves to 0 (an explicit maxSurge: 0 or a Recreate strategy) and a fleet-wide
+// zeroSurgeOverride is configured, that override — an int-or-percentage resolved
+// against minReplicas — is applied instead of refusing to surge.
 // The underlying error unwraps to a sentinel:
 //   - errMaxSurgeZero: the surge amount resolves to 0 and no override applies
 //   - errInvalidPercentage: percentage string could not be parsed or lacks a "%" suffix
 //   - errNegativeSurge: the surge amount is negative
-func calculateSurge(_ context.Context, target Surger, minReplicas int32, overrideZeroMaxSurge bool, zeroMaxSurgePercent int32) (int32, error) {
+func calculateSurge(_ context.Context, target Surger, minReplicas int32, zeroSurgeOverride *intstr.IntOrString) (int32, error) {
 	result, err := surgeFromValue(target.GetMaxSurge(), minReplicas)
-	// When the workload cannot surge on its own (maxSurge resolves to 0) and the
-	// fleet-wide override is enabled, substitute a fleet drain surge of
-	// zeroMaxSurgePercent of minReplicas. The actual surge stays demand-driven
+	// When the workload cannot surge on its own (maxSurge resolves to 0) and a
+	// fleet-wide override is configured, substitute the override surge (an
+	// int-or-percentage of minReplicas). The actual surge stays demand-driven
 	// (minReplicas + displaced) and is capped at this amount, so larger drains
 	// proceed in waves.
-	if errors.Is(err, errMaxSurgeZero) && overrideZeroMaxSurge && zeroMaxSurgePercent > 0 {
-		return surgeFromValue(intstr.FromString(fmt.Sprintf("%d%%", zeroMaxSurgePercent)), minReplicas)
+	if errors.Is(err, errMaxSurgeZero) && zeroSurgeOverride != nil {
+		return surgeFromValue(*zeroSurgeOverride, minReplicas)
 	}
 	return result, err
+}
+
+// ParseZeroSurgeOverride parses the fleet-wide zero-maxSurge override value (the
+// ZERO_SURGE_OVERRIDE controller env var). The value is an int-or-percentage
+// resolved against minReplicas at drain time, mirroring Kubernetes maxSurge — e.g.
+// "25%" or an absolute "10". An empty string, or a value that resolves to zero
+// ("0"/"0%"), returns (nil, nil) so the feature stays off; a negative or malformed
+// value returns an error so startup fails fast rather than misbehaving mid-drain.
+func ParseZeroSurgeOverride(raw string) (*intstr.IntOrString, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	v := intstr.Parse(raw)
+	// Validate against a representative base so a bad percentage/negative surfaces
+	// now rather than on the first drain; the base value itself is irrelevant.
+	switch _, err := surgeFromValue(v, 100); {
+	case errors.Is(err, errMaxSurgeZero):
+		return nil, nil
+	case err != nil:
+		return nil, err
+	}
+	return &v, nil
 }
 
 // isZeroSurge reports whether a maxSurge value resolves to no surge — an int 0 or

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -56,6 +56,21 @@ type EvictionAutoScalerReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 	Filter   filter
+	// SurgeOverrideEnabled gates the drain-time surge-override annotation
+	// (SurgeOverrideAnnotationKey). When false (the default), the annotation is
+	// ignored and surge sizing falls through to the workload's rollout maxSurge,
+	// preserving today's behavior. It is a fleet-wide opt-in set via the
+	// SURGE_OVERRIDE_ENABLED controller env var, so Cosmic — not individual
+	// workload owners — decides whether drain-time surge overrides are honored.
+	SurgeOverrideEnabled bool
+	// SurgeOverrideMaxPercent bounds the free-form surge-override annotation: the
+	// override-resolved surge amount is capped at this percent of minReplicas
+	// (rounded up, floored at 1). Because the annotation bypasses API-server
+	// admission validation, this is a safety net against a fat-fingered value.
+	// Set via the SURGE_OVERRIDE_MAX_PERCENT env var (default 25); operators can
+	// raise it fleet-wide. A non-positive value disables the cap. The rollout
+	// maxSurge path is already admission-validated and is never capped here.
+	SurgeOverrideMaxPercent int32
 }
 
 const cooldown = 1 * time.Minute
@@ -196,7 +211,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// surgeTarget = minReplicas + displaced, capped at minReplicas + maxSurge.
 	// If displaced == 0 the formula yields minReplicas, so no scale-up fires and
 	// we fall through to the cooldown/scale-down path — which is correct.
-	maxSurgeTarget, surgeErr := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas)
+	maxSurgeTarget, surgeErr := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas, r.SurgeOverrideEnabled, r.SurgeOverrideMaxPercent)
 	if surgeErr != nil {
 		switch {
 		case errors.Is(surgeErr, errMaxSurgeZero):
@@ -236,7 +251,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// maxSurge, since we are deliberately surging a workload whose author set an
 		// explicit (often 0) rollout maxSurge. Emitted only when a surge actually
 		// fires; the Kubernetes event recorder aggregates repeats across reconciles.
-		if override, ok := surgeOverrideValue(target); ok {
+		if override, ok := surgeOverrideValue(target); ok && r.SurgeOverrideEnabled {
 			maxSurge := target.GetMaxSurge()
 			msg := fmt.Sprintf("drain-time surge cap %q overrides rollout maxSurge %q for %s/%s",
 				override, maxSurge.String(), target.Obj().GetNamespace(), target.Obj().GetName())
@@ -363,19 +378,47 @@ var (
 //   - errMaxSurgeZero: the surge amount resolves to 0 (explicitly set or not configured)
 //   - errInvalidPercentage: percentage string could not be parsed or lacks a "%" suffix
 //   - errNegativeSurge: the surge amount is negative
-func calculateSurge(_ context.Context, target Surger, minReplicas int32) (int32, error) {
+func calculateSurge(_ context.Context, target Surger, minReplicas int32, surgeOverrideEnabled bool, surgeOverrideMaxPercent int32) (int32, error) {
 	// An explicit surge-override annotation on the target always wins over maxSurge,
 	// so a workload can keep maxSurge=0 for its rollout strategy yet still surge on drain.
-	if override, ok := surgeOverrideValue(target); ok {
-		result, err := surgeFromValue(intstr.Parse(override), minReplicas)
-		if err != nil {
-			// Wrap so operators see the value came from the override annotation,
-			// not from the target's maxSurge.
-			return result, fmt.Errorf("surge-override annotation %q: %w", override, err)
+	// The annotation is only honored when the controller-level flag is enabled
+	// (fleet-wide opt-in); otherwise it is ignored and we fall through to maxSurge,
+	// preserving the controller's default behavior.
+	if surgeOverrideEnabled {
+		if override, ok := surgeOverrideValue(target); ok {
+			result, err := surgeFromValue(intstr.Parse(strings.TrimSpace(override)), minReplicas)
+			if err != nil {
+				// Wrap so operators see the value came from the override annotation,
+				// not from the target's maxSurge.
+				return result, fmt.Errorf("surge-override annotation %q: %w", override, err)
+			}
+			// The override annotation is free-form and bypasses API-server admission
+			// validation, so a fat-fingered value (e.g. "100" on a large deployment)
+			// could request an unbounded surge. Cap the override-resolved surge amount
+			// as a safety bound. The rollout maxSurge path below is already
+			// admission-validated and is left uncapped.
+			return capOverrideSurge(result, minReplicas, surgeOverrideMaxPercent), nil
 		}
-		return result, nil
 	}
 	return surgeFromValue(target.GetMaxSurge(), minReplicas)
+}
+
+// capOverrideSurge bounds the override-resolved surge target so the surge amount
+// (result - minReplicas) does not exceed maxPercent of minReplicas (rounded up,
+// floored at 1). A non-positive maxPercent disables the cap. Only the free-form
+// surge-override path is capped; the API-validated rollout maxSurge is not.
+func capOverrideSurge(result, minReplicas, maxPercent int32) int32 {
+	if maxPercent <= 0 {
+		return result
+	}
+	capAmount := int32(math.Ceil(float64(minReplicas) * float64(maxPercent) / 100.0))
+	if capAmount < 1 {
+		capAmount = 1
+	}
+	if surge := result - minReplicas; surge > capAmount {
+		return minReplicas + capAmount
+	}
+	return result
 }
 
 // surgeOverrideValue returns the SurgeOverrideAnnotationKey value from the target

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -338,6 +339,57 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			dep := &appsv1.Deployment{}
 			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
 			Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
+		})
+
+		It("should emit a DrainSurgeOverride event when the surge-override annotation drives the surge", func() {
+			By("setting maxSurge=0 and a surge-override annotation on the deployment")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			zeroSurge := intstr.FromInt32(0)
+			dep.Spec.Strategy.RollingUpdate.MaxSurge = &zeroSurge
+			if dep.Annotations == nil {
+				dep.Annotations = map[string]string{}
+			}
+			dep.Annotations[SurgeOverrideAnnotationKey] = "2"
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			recorder := record.NewFakeRecorder(10)
+			controllerReconciler := &EvictionAutoScalerReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Filter:   &evictionTestFilter{},
+				Recorder: recorder,
+			}
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "override-event-node-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "override-pod-", Namespace: namespace, Labels: map[string]string{"app": "example"}},
+				Spec:       corev1.PodSpec{NodeName: node.Name, Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}}},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+
+			// Populate TargetGeneration, then log an eviction to enter the surge path.
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			ea := &v1.EvictionAutoScaler{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction = v1.Eviction{PodName: "override-pod", EvictionTime: metav1.Now()}
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Surge fired (maxSurge=0 would otherwise degrade), so an override event was recorded.
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
+			var got string
+			Eventually(recorder.Events).Should(Receive(&got))
+			Expect(got).To(ContainSubstring("DrainSurgeOverride"))
+			Expect(got).To(ContainSubstring("overrides rollout maxSurge"))
 		})
 
 		It("should surge by exactly displaced pod count when displaced is less than maxSurge", func() {

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -355,10 +355,11 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 
 			recorder := record.NewFakeRecorder(10)
 			controllerReconciler := &EvictionAutoScalerReconciler{
-				Client:   k8sClient,
-				Scheme:   k8sClient.Scheme(),
-				Filter:   &evictionTestFilter{},
-				Recorder: recorder,
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				Filter:               &evictionTestFilter{},
+				Recorder:             recorder,
+				SurgeOverrideEnabled: true,
 			}
 
 			node := &corev1.Node{
@@ -390,6 +391,169 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			Eventually(recorder.Events).Should(Receive(&got))
 			Expect(got).To(ContainSubstring("DrainSurgeOverride"))
 			Expect(got).To(ContainSubstring("overrides rollout maxSurge"))
+		})
+
+		It("surges via the override without emitting an event when the recorder is disabled", func() {
+			By("setting maxSurge=0 and a surge-override annotation, with NO recorder wired")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			zeroSurge := intstr.FromInt32(0)
+			dep.Spec.Strategy.RollingUpdate.MaxSurge = &zeroSurge
+			if dep.Annotations == nil {
+				dep.Annotations = map[string]string{}
+			}
+			dep.Annotations[SurgeOverrideAnnotationKey] = "2"
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			// Recorder is nil (ENABLE_EVENT_RECORDING=false), but the feature flag is on.
+			controllerReconciler := &EvictionAutoScalerReconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				Filter:               &evictionTestFilter{},
+				SurgeOverrideEnabled: true,
+			}
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "override-norec-node-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "override-norec-pod-", Namespace: namespace, Labels: map[string]string{"app": "example"}},
+				Spec:       corev1.PodSpec{NodeName: node.Name, Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}}},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			ea := &v1.EvictionAutoScaler{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction = v1.Eviction{PodName: "override-norec-pod", EvictionTime: metav1.Now()}
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			// Nil recorder must not panic and surge must still fire.
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
+		})
+
+		It("ignores the surge-override annotation when the feature flag is disabled", func() {
+			By("setting maxSurge=0 and a surge-override annotation, with the feature flag OFF")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			zeroSurge := intstr.FromInt32(0)
+			dep.Spec.Strategy.RollingUpdate.MaxSurge = &zeroSurge
+			if dep.Annotations == nil {
+				dep.Annotations = map[string]string{}
+			}
+			dep.Annotations[SurgeOverrideAnnotationKey] = "2"
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			recorder := record.NewFakeRecorder(10)
+			controllerReconciler := &EvictionAutoScalerReconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				Filter:               &evictionTestFilter{},
+				Recorder:             recorder,
+				SurgeOverrideEnabled: false, // gate OFF: the annotation must be a no-op
+			}
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "override-off-node-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "override-off-pod-", Namespace: namespace, Labels: map[string]string{"app": "example"}},
+				Spec:       corev1.PodSpec{NodeName: node.Name, Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}}},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			ea := &v1.EvictionAutoScaler{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction = v1.Eviction{PodName: "override-off-pod", EvictionTime: metav1.Now()}
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("falling through to maxSurge=0: Degraded set, no scale-up, no override event")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			found := false
+			for _, c := range ea.Status.Conditions {
+				if c.Reason == "UnsupportedAutoscalerConfiguration" {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "expected Degraded condition since the override is ignored and maxSurge=0")
+
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(1)))
+			Expect(recorder.Events).ToNot(Receive(), "no DrainSurgeOverride event should fire when the flag is off")
+		})
+
+		It("reverts an override-driven surge once the drain completes (flag enabled)", func() {
+			By("setting maxSurge=0 and a surge-override annotation with the feature flag ON")
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			zeroSurge := intstr.FromInt32(0)
+			dep.Spec.Strategy.RollingUpdate.MaxSurge = &zeroSurge
+			if dep.Annotations == nil {
+				dep.Annotations = map[string]string{}
+			}
+			dep.Annotations[SurgeOverrideAnnotationKey] = "2"
+			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
+
+			controllerReconciler := &EvictionAutoScalerReconciler{
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				Filter:               &evictionTestFilter{},
+				SurgeOverrideEnabled: true,
+			}
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "override-revert-node-" + namespace},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{GenerateName: "override-revert-pod-", Namespace: namespace, Labels: map[string]string{"app": "example"}},
+				Spec:       corev1.PodSpec{NodeName: node.Name, Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}}},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			ea := &v1.EvictionAutoScaler{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction = v1.Eviction{PodName: "override-revert-pod", EvictionTime: metav1.Now()}
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			By("surging up while the PDB blocks disruptions")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
+
+			By("completing the drain: PDB allows disruptions, surge reverts to original replicas")
+			pdb := &policyv1.PodDisruptionBudget{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, pdb)).To(Succeed())
+			pdb.Status.DisruptionsAllowed = 1
+			Expect(k8sClient.Status().Update(ctx, pdb)).To(Succeed())
+
+			// Age the eviction beyond the cooldown so the revert (scale-down) gate is open.
+			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
+			ea.Spec.LastEviction.EvictionTime = metav1.NewTime(time.Now().Add(-2 * cooldown))
+			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
+			Expect(*dep.Spec.Replicas).To(Equal(int32(1)))
 		})
 
 		It("should surge by exactly displaced pod count when displaced is less than maxSurge", func() {

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -341,25 +341,22 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
 		})
 
-		It("should emit a DrainSurgeOverride event when the surge-override annotation drives the surge", func() {
-			By("setting maxSurge=0 and a surge-override annotation on the deployment")
+		It("should emit a DrainSurgeOverride event when the fleet zero-maxSurge override drives the surge", func() {
+			By("setting maxSurge=0 with the fleet zero-maxSurge override on")
 			dep := &appsv1.Deployment{}
 			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
 			zeroSurge := intstr.FromInt32(0)
 			dep.Spec.Strategy.RollingUpdate.MaxSurge = &zeroSurge
-			if dep.Annotations == nil {
-				dep.Annotations = map[string]string{}
-			}
-			dep.Annotations[SurgeOverrideAnnotationKey] = "2"
 			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
 
 			recorder := record.NewFakeRecorder(10)
 			controllerReconciler := &EvictionAutoScalerReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				Filter:               &evictionTestFilter{},
-				Recorder:             recorder,
-				SurgeOverrideEnabled: true,
+				Client:                  k8sClient,
+				Scheme:                  k8sClient.Scheme(),
+				Filter:                  &evictionTestFilter{},
+				Recorder:                recorder,
+				OverrideZeroMaxSurge:    true,
+				SurgeOverrideMaxPercent: 25,
 			}
 
 			node := &corev1.Node{
@@ -390,27 +387,24 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			var got string
 			Eventually(recorder.Events).Should(Receive(&got))
 			Expect(got).To(ContainSubstring("DrainSurgeOverride"))
-			Expect(got).To(ContainSubstring("overrides rollout maxSurge"))
+			Expect(got).To(ContainSubstring("rollout maxSurge"))
 		})
 
 		It("surges via the override without emitting an event when the recorder is disabled", func() {
-			By("setting maxSurge=0 and a surge-override annotation, with NO recorder wired")
+			By("setting maxSurge=0 with the override on and NO recorder wired")
 			dep := &appsv1.Deployment{}
 			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
 			zeroSurge := intstr.FromInt32(0)
 			dep.Spec.Strategy.RollingUpdate.MaxSurge = &zeroSurge
-			if dep.Annotations == nil {
-				dep.Annotations = map[string]string{}
-			}
-			dep.Annotations[SurgeOverrideAnnotationKey] = "2"
 			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
 
 			// Recorder is nil (ENABLE_EVENT_RECORDING=false), but the feature flag is on.
 			controllerReconciler := &EvictionAutoScalerReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				Filter:               &evictionTestFilter{},
-				SurgeOverrideEnabled: true,
+				Client:                  k8sClient,
+				Scheme:                  k8sClient.Scheme(),
+				Filter:                  &evictionTestFilter{},
+				OverrideZeroMaxSurge:    true,
+				SurgeOverrideMaxPercent: 25,
 			}
 
 			node := &corev1.Node{
@@ -438,16 +432,12 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
 		})
 
-		It("ignores the surge-override annotation when the feature flag is disabled", func() {
-			By("setting maxSurge=0 and a surge-override annotation, with the feature flag OFF")
+		It("does not surge a maxSurge=0 workload when the override is disabled", func() {
+			By("setting maxSurge=0 with the zero-maxSurge override OFF")
 			dep := &appsv1.Deployment{}
 			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
 			zeroSurge := intstr.FromInt32(0)
 			dep.Spec.Strategy.RollingUpdate.MaxSurge = &zeroSurge
-			if dep.Annotations == nil {
-				dep.Annotations = map[string]string{}
-			}
-			dep.Annotations[SurgeOverrideAnnotationKey] = "2"
 			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
 
 			recorder := record.NewFakeRecorder(10)
@@ -456,7 +446,7 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 				Scheme:               k8sClient.Scheme(),
 				Filter:               &evictionTestFilter{},
 				Recorder:             recorder,
-				SurgeOverrideEnabled: false, // gate OFF: the annotation must be a no-op
+				OverrideZeroMaxSurge: false, // gate OFF: the annotation must be a no-op
 			}
 
 			node := &corev1.Node{
@@ -496,23 +486,20 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			Expect(recorder.Events).ToNot(Receive(), "no DrainSurgeOverride event should fire when the flag is off")
 		})
 
-		It("reverts an override-driven surge once the drain completes (flag enabled)", func() {
-			By("setting maxSurge=0 and a surge-override annotation with the feature flag ON")
+		It("reverts a zero-maxSurge override surge once the drain completes", func() {
+			By("setting maxSurge=0 with the zero-maxSurge override ON")
 			dep := &appsv1.Deployment{}
 			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
 			zeroSurge := intstr.FromInt32(0)
 			dep.Spec.Strategy.RollingUpdate.MaxSurge = &zeroSurge
-			if dep.Annotations == nil {
-				dep.Annotations = map[string]string{}
-			}
-			dep.Annotations[SurgeOverrideAnnotationKey] = "2"
 			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
 
 			controllerReconciler := &EvictionAutoScalerReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				Filter:               &evictionTestFilter{},
-				SurgeOverrideEnabled: true,
+				Client:                  k8sClient,
+				Scheme:                  k8sClient.Scheme(),
+				Filter:                  &evictionTestFilter{},
+				OverrideZeroMaxSurge:    true,
+				SurgeOverrideMaxPercent: 25,
 			}
 
 			node := &corev1.Node{

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -341,68 +340,19 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
 		})
 
-		It("should emit a DrainSurgeOverride event when the fleet zero-maxSurge override drives the surge", func() {
-			By("setting maxSurge=0 with the fleet zero-maxSurge override on")
+		It("surges a maxSurge=0 workload via the zero-maxSurge override", func() {
+			By("setting maxSurge=0 with the override on")
 			dep := &appsv1.Deployment{}
 			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
 			zeroSurge := intstr.FromInt32(0)
 			dep.Spec.Strategy.RollingUpdate.MaxSurge = &zeroSurge
 			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
 
-			recorder := record.NewFakeRecorder(10)
 			controllerReconciler := &EvictionAutoScalerReconciler{
-				Client:                  k8sClient,
-				Scheme:                  k8sClient.Scheme(),
-				Filter:                  &evictionTestFilter{},
-				Recorder:                recorder,
-				ZeroSurgeOverride:       overridePercent("25%"),
-			}
-
-			node := &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: "override-event-node-" + namespace},
-				Spec:       corev1.NodeSpec{Unschedulable: true},
-			}
-			Expect(k8sClient.Create(ctx, node)).To(Succeed())
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{GenerateName: "override-pod-", Namespace: namespace, Labels: map[string]string{"app": "example"}},
-				Spec:       corev1.PodSpec{NodeName: node.Name, Containers: []corev1.Container{{Name: "nginx", Image: "nginx:latest"}}},
-			}
-			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
-
-			// Populate TargetGeneration, then log an eviction to enter the surge path.
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
-			Expect(err).NotTo(HaveOccurred())
-			ea := &v1.EvictionAutoScaler{}
-			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
-			ea.Spec.LastEviction = v1.Eviction{PodName: "override-pod", EvictionTime: metav1.Now()}
-			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
-
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
-			Expect(err).NotTo(HaveOccurred())
-
-			// Surge fired (maxSurge=0 would otherwise degrade), so an override event was recorded.
-			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
-			Expect(*dep.Spec.Replicas).To(Equal(int32(2)))
-			var got string
-			Eventually(recorder.Events).Should(Receive(&got))
-			Expect(got).To(ContainSubstring("DrainSurgeOverride"))
-			Expect(got).To(ContainSubstring("rollout maxSurge"))
-		})
-
-		It("surges via the override without emitting an event when the recorder is disabled", func() {
-			By("setting maxSurge=0 with the override on and NO recorder wired")
-			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
-			zeroSurge := intstr.FromInt32(0)
-			dep.Spec.Strategy.RollingUpdate.MaxSurge = &zeroSurge
-			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
-
-			// Recorder is nil (ENABLE_EVENT_RECORDING=false), but the feature flag is on.
-			controllerReconciler := &EvictionAutoScalerReconciler{
-				Client:                  k8sClient,
-				Scheme:                  k8sClient.Scheme(),
-				Filter:                  &evictionTestFilter{},
-				ZeroSurgeOverride:       overridePercent("25%"),
+				Client:            k8sClient,
+				Scheme:            k8sClient.Scheme(),
+				Filter:            &evictionTestFilter{},
+				ZeroSurgeOverride: overridePercent("25%"),
 			}
 
 			node := &corev1.Node{
@@ -423,7 +373,7 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			ea.Spec.LastEviction = v1.Eviction{PodName: "override-norec-pod", EvictionTime: metav1.Now()}
 			Expect(k8sClient.Update(ctx, ea)).To(Succeed())
 
-			// Nil recorder must not panic and surge must still fire.
+			// maxSurge=0 would otherwise degrade; the override drives the surge instead.
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
@@ -438,13 +388,11 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			dep.Spec.Strategy.RollingUpdate.MaxSurge = &zeroSurge
 			Expect(k8sClient.Update(ctx, dep)).To(Succeed())
 
-			recorder := record.NewFakeRecorder(10)
 			controllerReconciler := &EvictionAutoScalerReconciler{
-				Client:               k8sClient,
-				Scheme:               k8sClient.Scheme(),
-				Filter:               &evictionTestFilter{},
-				Recorder:             recorder,
-				ZeroSurgeOverride:    nil, // no override configured: must be a no-op
+				Client:            k8sClient,
+				Scheme:            k8sClient.Scheme(),
+				Filter:            &evictionTestFilter{},
+				ZeroSurgeOverride: nil, // no override configured: must be a no-op
 			}
 
 			node := &corev1.Node{
@@ -468,7 +416,7 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("falling through to maxSurge=0: Degraded set, no scale-up, no override event")
+			By("falling through to maxSurge=0: Degraded set, no scale-up")
 			Expect(k8sClient.Get(ctx, typeNamespacedName, ea)).To(Succeed())
 			found := false
 			for _, c := range ea.Status.Conditions {
@@ -481,7 +429,6 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 
 			Expect(k8sClient.Get(ctx, deploymentNamespacedName, dep)).To(Succeed())
 			Expect(*dep.Spec.Replicas).To(Equal(int32(1)))
-			Expect(recorder.Events).ToNot(Receive(), "no DrainSurgeOverride event should fire when the flag is off")
 		})
 
 		It("reverts a zero-maxSurge override surge once the drain completes", func() {

--- a/internal/controller/evictionautoscaler_controller_test.go
+++ b/internal/controller/evictionautoscaler_controller_test.go
@@ -355,8 +355,7 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 				Scheme:                  k8sClient.Scheme(),
 				Filter:                  &evictionTestFilter{},
 				Recorder:                recorder,
-				OverrideZeroMaxSurge:    true,
-				SurgeOverrideMaxPercent: 25,
+				ZeroSurgeOverride:       overridePercent("25%"),
 			}
 
 			node := &corev1.Node{
@@ -403,8 +402,7 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 				Client:                  k8sClient,
 				Scheme:                  k8sClient.Scheme(),
 				Filter:                  &evictionTestFilter{},
-				OverrideZeroMaxSurge:    true,
-				SurgeOverrideMaxPercent: 25,
+				ZeroSurgeOverride:       overridePercent("25%"),
 			}
 
 			node := &corev1.Node{
@@ -446,7 +444,7 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 				Scheme:               k8sClient.Scheme(),
 				Filter:               &evictionTestFilter{},
 				Recorder:             recorder,
-				OverrideZeroMaxSurge: false, // gate OFF: the annotation must be a no-op
+				ZeroSurgeOverride:    nil, // no override configured: must be a no-op
 			}
 
 			node := &corev1.Node{
@@ -498,8 +496,7 @@ var _ = Describe("EvictionAutoScaler Controller", func() {
 				Client:                  k8sClient,
 				Scheme:                  k8sClient.Scheme(),
 				Filter:                  &evictionTestFilter{},
-				OverrideZeroMaxSurge:    true,
-				SurgeOverrideMaxPercent: 25,
+				ZeroSurgeOverride:       overridePercent("25%"),
 			}
 
 			node := &corev1.Node{

--- a/internal/controller/wrappers.go
+++ b/internal/controller/wrappers.go
@@ -51,7 +51,17 @@ func (d *DeploymentWrapper) GetMaxSurge() intstr.IntOrString {
 	if d.obj.Spec.Strategy.RollingUpdate != nil && d.obj.Spec.Strategy.RollingUpdate.MaxSurge != nil {
 		return *d.obj.Spec.Strategy.RollingUpdate.MaxSurge
 	}
-	return intstr.FromInt(0)
+	// Recreate strategy has no rolling-update concept — return 0 so the
+	// zero-surge override can apply if configured.
+	if d.obj.Spec.Strategy.Type == v1.RecreateDeploymentStrategyType {
+		return intstr.FromInt(0)
+	}
+	// When the strategy is RollingUpdate (or unset, which implies RollingUpdate)
+	// and maxSurge is not explicitly specified, Kubernetes defaults to 25% at
+	// admission time. Return that default so we don't incorrectly trigger the
+	// fleet-wide zero-surge override for workloads that actually get 25% surge
+	// during rollouts.
+	return intstr.FromString("25%")
 }
 
 // AddAnnotation  add new status annotation

--- a/internal/controller/wrappers_test.go
+++ b/internal/controller/wrappers_test.go
@@ -1,0 +1,112 @@
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var _ = Describe("DeploymentWrapper.GetMaxSurge", func() {
+	It("returns the explicit maxSurge when RollingUpdate strategy is fully specified", func() {
+		surge := intstr.FromInt32(5)
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxSurge: &surge,
+					},
+				},
+			},
+		}
+		w := &DeploymentWrapper{obj: dep}
+		Expect(w.GetMaxSurge()).To(Equal(intstr.FromInt32(5)))
+	})
+
+	It("returns the explicit percentage maxSurge", func() {
+		surge := intstr.FromString("50%")
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxSurge: &surge,
+					},
+				},
+			},
+		}
+		w := &DeploymentWrapper{obj: dep}
+		Expect(w.GetMaxSurge()).To(Equal(intstr.FromString("50%")))
+	})
+
+	It("returns explicit maxSurge 0 when set to 0", func() {
+		surge := intstr.FromInt32(0)
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxSurge: &surge,
+					},
+				},
+			},
+		}
+		w := &DeploymentWrapper{obj: dep}
+		Expect(w.GetMaxSurge()).To(Equal(intstr.FromInt32(0)))
+	})
+
+	It("returns 0 for a Recreate strategy", func() {
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					Type: appsv1.RecreateDeploymentStrategyType,
+				},
+			},
+		}
+		w := &DeploymentWrapper{obj: dep}
+		Expect(w.GetMaxSurge()).To(Equal(intstr.FromInt(0)))
+	})
+
+	It("returns the Kubernetes default 25% when RollingUpdate is set but maxSurge is nil", func() {
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						// MaxSurge intentionally nil
+					},
+				},
+			},
+		}
+		w := &DeploymentWrapper{obj: dep}
+		Expect(w.GetMaxSurge()).To(Equal(intstr.FromString("25%")))
+	})
+
+	It("returns the Kubernetes default 25% when RollingUpdate type is set but rollingUpdate field is nil", func() {
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+					// RollingUpdate field nil
+				},
+			},
+		}
+		w := &DeploymentWrapper{obj: dep}
+		Expect(w.GetMaxSurge()).To(Equal(intstr.FromString("25%")))
+	})
+
+	It("returns the Kubernetes default 25% for a bare Deployment (completely unset strategy)", func() {
+		dep := &appsv1.Deployment{}
+		w := &DeploymentWrapper{obj: dep}
+		Expect(w.GetMaxSurge()).To(Equal(intstr.FromString("25%")))
+	})
+})
+
+var _ = Describe("StatefulSetWrapper.GetMaxSurge", func() {
+	It("always returns 10%", func() {
+		ss := &appsv1.StatefulSet{}
+		w := &StatefulSetWrapper{obj: ss}
+		Expect(w.GetMaxSurge()).To(Equal(intstr.FromString("10%")))
+	})
+})

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -33,6 +33,19 @@ var (
 		[]string{"namespace", "can_create_pdb"},
 	)
 
+	// ZeroMaxSurgeWorkloadGauge tracks workloads whose rollout maxSurge resolves to 0
+	// (an explicit maxSurge: 0, a Recreate strategy, or an unset RollingUpdate), set to
+	// 1 per such workload and 0 otherwise, so the series sum is the count of maxSurge:0
+	// workloads currently seen in the cluster.
+	// Labels: namespace, name
+	ZeroMaxSurgeWorkloadGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "eviction_autoscaler_zero_maxsurge_workloads",
+			Help: "Workloads whose rollout maxSurge resolves to 0, seen by the eviction autoscaler",
+		},
+		[]string{"namespace", "name"},
+	)
+
 	// PDBGauge tracks the number of PDBs seen by the controller
 	// Labels: namespace, created_by_us (true/false)
 	PDBGauge = prometheus.NewGaugeVec(
@@ -191,6 +204,7 @@ func init() {
 	// Register metrics with controller-runtime's registry
 	ctrlmetrics.Registry.MustRegister(
 		DeploymentGauge,
+		ZeroMaxSurgeWorkloadGauge,
 		PDBGauge,
 		EvictionCounter,
 		BlockedEvictionCounter,


### PR DESCRIPTION
## What / why

The eviction autoscaler derives its drain-time surge budget from the target's rolling-update `maxSurge`. Workloads that pin `maxSurge: 0` — a common safe-deployment requirement so app rollouts never create extra pods — get **no** drain-time surge at all, so `calculateSurge` returns an error and the controller cannot add replicas to relieve a PDB-blocked drain. This disables the autoscaler for exactly the workloads that most need disruption headroom.

## Change

Add an annotation `eviction-autoscaler.azure.com/surge-override` on the target workload (Deployment/StatefulSet). When present it **always wins** over `maxSurge`, using the same int-or-percentage semantics. A workload can keep `maxSurge: 0` for rollouts while still allowing a bounded, drain-only surge that the controller reverts when the drain finishes.

- Add `SurgeOverrideAnnotationKey` constant.
- `calculateSurge` reads the override first, falling back to `maxSurge`.
- Extract `surgeFromValue` helper for the int/percentage math.
- Unit tests: int override with `maxSurge=0`, override wins over non-zero `maxSurge`, percentage, no-RollingUpdate, zero (→ `errMaxSurgeZero`), invalid (→ `errInvalidPercentage`).
- Document the annotation in the README under "How Surge Sizing Works".

## Testing

- `go build ./...` clean.
- Full controller suite (`go test ./internal/controller/...`, envtest) passes, including the new override tests.