### PR TITLE
Auto-merge Dependabot minor updates in addition to patch

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,7 +2,10 @@ name: Dependabot auto-merge
 
 # Requires branch protection with required status checks on the default branch;
 # gh pr merge --auto waits on those checks before merging.
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,9 +21,11 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # Auto-merge patch updates only; minor and major are left for human review.
-      - name: Enable auto-merge for patch updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+      # Auto-merge patch and minor updates only; major are left for human review.
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## What

Extends the existing Dependabot auto-merge workflow to also auto-merge minor version updates, not just patch. Major updates are still left for manual review.

## Why

Minor updates are low-risk and gated by CI, so requiring a human to click merge just adds delay.
