### PR TITLE
e2e Test: verify controller survives Deployment Safeguards blocking a surge in AKS-owned namespaces

### DIFF
--- a/test/e2e/e2e_helpers.go
+++ b/test/e2e/e2e_helpers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/azure/eviction-autoscaler/test/utils"
 	. "github.com/onsi/gomega"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -567,4 +568,73 @@ func dumpClusterState() {
 		_ = os.WriteFile(e2eLogsDir+"/"+d.file, out, 0600)
 	}
 	fmt.Printf("cluster state dumped to %s\n", e2eLogsDir)
+}
+
+// applyDSBlockPolicy installs a ValidatingAdmissionPolicy that denies UPDATE
+// writes to Deployments in namespaces labeled ds-block=true, simulating
+// Deployment Safeguards flat-rejecting writes in AKS-owned namespaces.
+func applyDSBlockPolicy() error {
+	policyYaml := `apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: ds-block-deployment-writes
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["apps"]
+        apiVersions: ["v1"]
+        operations:  ["UPDATE"]
+        resources:   ["deployments"]
+  validations:
+    - expression: "false"
+      message: "Deployment Safeguards: writes to Deployments are blocked in this namespace"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: ds-block-deployment-writes-binding
+spec:
+  policyName: ds-block-deployment-writes
+  validationActions: ["Deny"]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        ds-block: "true"
+`
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(policyYaml)
+	_, err := utils.Run(cmd)
+	return err
+}
+
+func deleteDSBlockPolicy() {
+	cmd := exec.Command("kubectl", "delete", "validatingadmissionpolicybinding",
+		"ds-block-deployment-writes-binding", "--ignore-not-found")
+	_, _ = utils.Run(cmd)
+	cmd = exec.Command("kubectl", "delete", "validatingadmissionpolicy",
+		"ds-block-deployment-writes", "--ignore-not-found")
+	_, _ = utils.Run(cmd)
+}
+
+// controllerPodStatus returns the controller-manager pod name and total
+// container restart count, erroring if the pod is missing or not Running.
+func controllerPodStatus(ctx context.Context, c client.Client) (string, int32, error) {
+	var pods corev1.PodList
+	if err := c.List(ctx, &pods, client.InNamespace(namespace),
+		client.MatchingLabels{"app.kubernetes.io/name": "eviction-autoscaler"}); err != nil {
+		return "", 0, err
+	}
+	if len(pods.Items) == 0 {
+		return "", 0, fmt.Errorf("no controller-manager pod found")
+	}
+	pod := pods.Items[0]
+	if pod.Status.Phase != corev1.PodRunning {
+		return pod.Name, 0, fmt.Errorf("controller pod %s in %s phase", pod.Name, pod.Status.Phase)
+	}
+	var restarts int32
+	for _, cs := range pod.Status.ContainerStatuses {
+		restarts += cs.RestartCount
+	}
+	return pod.Name, restarts, nil
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1161,6 +1161,132 @@ var _ = Describe("controller", Ordered, func() {
 			_, _ = utils.Run(cmd)
 		})
 
+		It("should not crash when Deployment Safeguards blocks the surge write in an AKS-owned namespace", func() {
+			ctx := context.Background()
+			testNs := "test-ds-block"
+
+			By("uncordoning all nodes to ensure clean state from prior tests")
+			cmd := exec.Command("kubectl", "get", "nodes", "-o", "jsonpath={.items[*].metadata.name}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			for _, nodeName := range strings.Fields(string(output)) {
+				cmd = exec.Command("kubectl", "uncordon", nodeName)
+				_, _ = utils.Run(cmd)
+			}
+
+			By("creating test namespace with enable annotation and ds-block label")
+			cmd = exec.Command("kubectl", "create", "namespace", testNs)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("kubectl", "annotate", "namespace", testNs,
+				"eviction-autoscaler.azure.com/enable=true")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd = exec.Command("kubectl", "label", "namespace", testNs, "ds-block=true")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating a deployment with 1 replica and maxUnavailable=0")
+			err = createDeployment(deploymentConfig{
+				Name:           "nginx-ds",
+				Namespace:      testNs,
+				Replicas:       1,
+				MaxUnavailable: 0,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for deployment to be ready")
+			err = waitForDeployment("nginx-ds", testNs)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("building a client")
+			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+			Expect(err).NotTo(HaveOccurred())
+			clientset, err := client.New(config, client.Options{Scheme: scheme})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying PDB and EvictionAutoScaler are created")
+			EventuallyWithOffset(1, func() error {
+				return verifyPdbCreated(ctx, clientset, testNs, "nginx-ds")
+			}, time.Minute, time.Second).Should(Succeed())
+			EventuallyWithOffset(1, func() error {
+				return verifyEvictionAutoScalerCreated(ctx, clientset, testNs, "nginx-ds")
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("installing a ValidatingAdmissionPolicy that blocks Deployment writes (simulating DS)")
+			err = applyDSBlockPolicy()
+			Expect(err).NotTo(HaveOccurred())
+			defer deleteDSBlockPolicy()
+
+			By("waiting for the DS policy to become enforced")
+			EventuallyWithOffset(1, func() error {
+				probe := exec.Command("kubectl", "-n", testNs, "annotate", "deployment", "nginx-ds",
+					"ds-probe=1", "--overwrite")
+				if _, perr := utils.Run(probe); perr == nil {
+					return fmt.Errorf("expected DS policy to block the deployment write, but it succeeded")
+				}
+				return nil
+			}, time.Minute, 2*time.Second).Should(Succeed())
+
+			By("recording the controller-manager pod baseline before the surge")
+			baselineName, baselineRestarts, err := controllerPodStatus(ctx, clientset)
+			Expect(err).NotTo(HaveOccurred())
+			fmt.Printf("controller pod %s baseline restarts=%d\n", baselineName, baselineRestarts)
+
+			By("finding the node the pod runs on")
+			var pods corev1.PodList
+			err = clientset.List(ctx, &pods, client.InNamespace(testNs))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pods.Items).NotTo(BeEmpty())
+			nodeName := pods.Items[0].Spec.NodeName
+			fmt.Printf("nginx-ds pod running on node %s\n", nodeName)
+
+			By("cordoning the node to trigger an eviction surge (which DS will block)")
+			var node corev1.Node
+			err = clientset.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+			Expect(err).NotTo(HaveOccurred())
+			node.Spec.Unschedulable = true
+			err = clientset.Update(ctx, &node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the deployment never surges because the write is blocked")
+			ConsistentlyWithOffset(1, func() (int32, error) {
+				var dep appsv1.Deployment
+				if err := clientset.Get(ctx, client.ObjectKey{Namespace: testNs, Name: "nginx-ds"}, &dep); err != nil {
+					return 0, err
+				}
+				if dep.Spec.Replicas == nil {
+					return 0, fmt.Errorf("deployment replicas is nil")
+				}
+				return *dep.Spec.Replicas, nil
+			}, time.Minute, 5*time.Second).Should(Equal(int32(1)))
+
+			By("verifying the controller-manager pod stays healthy (no crash, panic, or restart)")
+			ConsistentlyWithOffset(1, func() error {
+				name, restarts, err := controllerPodStatus(ctx, clientset)
+				if err != nil {
+					return err
+				}
+				if restarts > baselineRestarts {
+					return fmt.Errorf("controller pod %s restarted (%d -> %d)", name, baselineRestarts, restarts)
+				}
+				return nil
+			}, time.Minute, 5*time.Second).Should(Succeed())
+
+			By("cleaning up: removing DS policy, uncordoning, deleting resources")
+			deleteDSBlockPolicy()
+			err = clientset.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+			Expect(err).NotTo(HaveOccurred())
+			node.Spec.Unschedulable = false
+			err = clientset.Update(ctx, &node)
+			Expect(err).NotTo(HaveOccurred())
+			deleteDeployment("nginx-ds", testNs)
+			cmd = exec.Command("kubectl", "delete", "namespace", testNs)
+			_, _ = utils.Run(cmd)
+		})
+
 		// Test 3b: PDB minAvailable should use HPA minReplicas, not deployment replicas
 		It("should create PDB with minAvailable from HPA minReplicas when HPA targets the deployment", func() {
 			ctx := context.Background()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1224,8 +1224,12 @@ var _ = Describe("controller", Ordered, func() {
 			EventuallyWithOffset(1, func() error {
 				probe := exec.Command("kubectl", "-n", testNs, "annotate", "deployment", "nginx-ds",
 					"ds-probe=1", "--overwrite")
-				if _, perr := utils.Run(probe); perr == nil {
+				out, perr := utils.Run(probe)
+				if perr == nil {
 					return fmt.Errorf("expected DS policy to block the deployment write, but it succeeded")
+				}
+				if !strings.Contains(string(out), "Deployment Safeguards: writes to Deployments are blocked") {
+					return fmt.Errorf("expected DS policy denial, got: %v", perr)
 				}
 				return nil
 			}, time.Minute, 2*time.Second).Should(Succeed())


### PR DESCRIPTION
#### Impact
Adds an end-to-end test proving the eviction-autoscaler controller degrades gracefully (no crash, panic, or CrashLoopBackOff) when Deployment Safeguards (DS) rejects its surge write in an AKS-owned namespace. Complements the controller-level unit test in #151 by exercising the real deployed controller against a real admission webhook on a live kind cluster.

#### Background / why
On Automatic clusters, DS is a ValidatingAdmissionPolicy (VAP) + SAR restrictions that flat-out rejects writes to protected/AKS-owned namespaces regardless of resource type. When EA tries to surge a workload there, the write is rejected. We need to prove EA treats that rejection as a normal error (requeue with backoff) and never panics or crash-loops. The unit test (#151) proves the logic; this proves the real deployed system.

#### What the test does
- Creates an EA-enabled namespace labeled ds-block=true, with a deployment (1 replica, maxUnavailable=0).
- Waits for the PDB + EvictionAutoScaler CR to be created.
- Installs a VAP + binding that denies UPDATE on Deployments in ds-block=true namespaces — the DS simulation (kind runs k8s v1.30.2, where VAP is GA).
- Gates until the VAP is actually enforcing (a probe write must fail) to avoid admission-registration races.
- Records the controller-manager pod's baseline restart count.
- Cordons the node to trigger a surge (which DS blocks).
- Asserts over a 60s window: (a) the deployment never scales past 1 (surge write blocked), and (b) the controller pod stays Running with no restart increase.
- Cleans up: removes the VAP, uncordons, deletes resources.

#### Testing
- gofmt + go vet ./test/e2e/... — clean.
- make test-e2e (full ordered kind suite, k8s v1.30.2):

  Ran 6 of 6 Specs in 713.805 seconds
  SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
  --- PASS: TestE2E (713.81s)
  PASS
  ok  github.com/azure/eviction-autoscaler/test/e2e  713.828s

New DS-block spec (130.199s), evidence from the run:
- DS policy enforcement gate held (probe write rejected before cordon).
- controller pod eviction-autoscaler-74d4d57f84-l9xwg baseline restarts=0.
- Deployment stayed at 1 replica for the full 60s window (surge write blocked).
- Controller pod stayed Running with 0 restarts for the 60s health window — no crash/panic.

#### Notes
- Separate PR from #151 (the controller-level unit test).
- Scoped to Deployment writes (the surge path) for a deterministic e2e; the #151 unit test blocks all namespace writes.
