### PR TITLE
Add panic metric with namespace and target labels

### DIFF
--- a/internal/controller/autoscaler_to_pdb_controller.go
+++ b/internal/controller/autoscaler_to_pdb_controller.go
@@ -42,6 +42,7 @@ type AutoscalerToPDBReconciler struct {
 // Reconcile is triggered when an HPA or ScaledObject changes. The request key is the
 // autoscaler's namespace/name. We resolve the target deployment from its scaleTargetRef.
 func (r *AutoscalerToPDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	defer recordPanic("autoscalertopdb", req.Namespace, &req.Name)
 	logger := log.FromContext(ctx)
 
 	// Gate: only act in namespaces where the eviction autoscaler is enabled.

--- a/internal/controller/deployment_to_pdb_controller.go
+++ b/internal/controller/deployment_to_pdb_controller.go
@@ -46,6 +46,7 @@ type DeploymentToPDBReconciler struct {
 // Reconcile watches for Deployment changes (created, updated, deleted) and creates or deletes the associated PDB.
 // creates pdb with minAvailable to be same as replicas for any deployment
 func (r *DeploymentToPDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	defer recordPanic("deploymenttopdb", req.Namespace, &req.Name)
 	// Fetch the Deployment instance
 	var deployment v1.Deployment
 	if err := r.Get(ctx, req.NamespacedName, &deployment); err != nil {

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -107,12 +107,12 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	panicTarget = EvictionAutoScaler.Spec.TargetName
 	if EvictionAutoScaler.Spec.TargetName == "" {
 		degraded(&EvictionAutoScaler.Status.Conditions, "EmptyTarget", "no specified target")
 		logger.Error(err, "no specified target name", "targetname", EvictionAutoScaler.Spec.TargetName)
 		return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler)
 	}
+	panicTarget = EvictionAutoScaler.Spec.TargetName
 
 	// StatefulSets are intentionally skipped — their ordered pod management
 	// semantics conflict with the eviction surge strategy.

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -51,7 +51,24 @@ const cooldown = 1 * time.Minute
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;update
 
+// recordPanic counts a recovered reconcile panic against the namespace and target that caused
+// it, then re-panics so controller-runtime still handles it as before.
+func recordPanic(controller, namespace string, target *string) {
+	rec := recover()
+	if rec == nil {
+		return
+	}
+	targetName := ""
+	if target != nil {
+		targetName = *target
+	}
+	metrics.PanicCounter.WithLabelValues(namespace, targetName, controller).Inc()
+	panic(rec)
+}
+
 func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var panicTarget string
+	defer recordPanic("evictionautoscaler", req.Namespace, &panicTarget)
 	logger := log.FromContext(ctx)
 
 	// Fetch the EvictionAutoScaler instance
@@ -90,6 +107,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	panicTarget = EvictionAutoScaler.Spec.TargetName
 	if EvictionAutoScaler.Spec.TargetName == "" {
 		degraded(&EvictionAutoScaler.Status.Conditions, "EmptyTarget", "no specified target")
 		logger.Error(err, "no specified target name", "targetname", EvictionAutoScaler.Spec.TargetName)

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -67,7 +67,7 @@ func recordPanic(controller, namespace string, target *string) {
 }
 
 func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	var panicTarget string
+	panicTarget := req.Name
 	defer recordPanic("evictionautoscaler", req.Namespace, &panicTarget)
 	logger := log.FromContext(ctx)
 

--- a/internal/controller/node_reconciler.go
+++ b/internal/controller/node_reconciler.go
@@ -36,6 +36,7 @@ const NodeNameIndex = "spec.nodeName"
 
 // Reconcile is the main loop of the controller. It will look for unschedulded nodes and for every pod on the node
 func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	defer recordPanic("node", req.Namespace, &req.Name)
 	logger := log.FromContext(ctx)
 
 	// Fetch the EvictionAutoScaler instance

--- a/internal/controller/node_reconciler.go
+++ b/internal/controller/node_reconciler.go
@@ -36,7 +36,11 @@ const NodeNameIndex = "spec.nodeName"
 
 // Reconcile is the main loop of the controller. It will look for unschedulded nodes and for every pod on the node
 func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	defer recordPanic("node", req.Namespace, &req.Name)
+	namespace := req.Namespace
+	if namespace == "" {
+		namespace = "_cluster"
+	}
+	defer recordPanic("node", namespace, &req.Name)
 	logger := log.FromContext(ctx)
 
 	// Fetch the EvictionAutoScaler instance

--- a/internal/controller/panic_test.go
+++ b/internal/controller/panic_test.go
@@ -1,0 +1,71 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/azure/eviction-autoscaler/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func panicCountFor(t *testing.T, namespace, target string) float64 {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(metrics.PanicCounter); err != nil {
+		t.Fatalf("register panic counter: %v", err)
+	}
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() != "eviction_autoscaler_panics_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			var gotNamespace, gotTarget string
+			for _, label := range metric.GetLabel() {
+				switch label.GetName() {
+				case "namespace":
+					gotNamespace = label.GetValue()
+				case "target_name":
+					gotTarget = label.GetValue()
+				}
+			}
+			if gotNamespace == namespace && gotTarget == target {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func TestRecordPanicCountsWorkloadAndRepanics(t *testing.T) {
+	metrics.PanicCounter.Reset()
+	target := "nginx"
+
+	func() {
+		defer func() {
+			if rec := recover(); rec == nil {
+				t.Fatal("expected recordPanic to re-panic so controller-runtime still handles it")
+			}
+		}()
+		defer recordPanic("evictionautoscaler", "team-a", &target)
+		panic("boom")
+	}()
+
+	if got := panicCountFor(t, "team-a", target); got != 1 {
+		t.Fatalf("expected 1 panic recorded for team-a/nginx, got %v", got)
+	}
+}
+
+func TestRecordPanicIgnoresNormalReturn(t *testing.T) {
+	metrics.PanicCounter.Reset()
+
+	func() {
+		defer recordPanic("evictionautoscaler", "team-a", nil)
+	}()
+
+	if got := panicCountFor(t, "team-a", ""); got != 0 {
+		t.Fatalf("expected no panic recorded when nothing panicked, got %v", got)
+	}
+}

--- a/internal/controller/panic_test.go
+++ b/internal/controller/panic_test.go
@@ -22,16 +22,18 @@ func panicCountFor(t *testing.T, namespace, target string) float64 {
 			continue
 		}
 		for _, metric := range family.GetMetric() {
-			var gotNamespace, gotTarget string
+			var gotNamespace, gotTarget, gotController string
 			for _, label := range metric.GetLabel() {
 				switch label.GetName() {
 				case "namespace":
 					gotNamespace = label.GetValue()
 				case "target_name":
 					gotTarget = label.GetValue()
+				case "controller":
+					gotController = label.GetValue()
 				}
 			}
-			if gotNamespace == namespace && gotTarget == target {
+			if gotNamespace == namespace && gotTarget == target && gotController == "evictionautoscaler" {
 				return metric.GetCounter().GetValue()
 			}
 		}

--- a/internal/controller/pdb_to_evictionautoscaler_controller.go
+++ b/internal/controller/pdb_to_evictionautoscaler_controller.go
@@ -40,6 +40,7 @@ type PDBToEvictionAutoScalerReconciler struct {
 
 // Reconcile reads the state of the cluster for a PDB and creates/deletes EvictionAutoScalers accordingly.
 func (r *PDBToEvictionAutoScalerReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	defer recordPanic("pdbtoevictionautoscaler", req.Namespace, &req.Name)
 	logger := log.FromContext(ctx)
 	logger.WithValues("pdb", req.Name, "namespace", req.Namespace)
 	ctx = log.IntoContext(ctx, logger)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -123,6 +123,16 @@ var (
 		[]string{"namespace", "pdb_name", "target_name", "metric_type"},
 	)
 
+	// PanicCounter tracks recovered reconcile panics
+	// Labels: namespace, target_name, controller
+	PanicCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eviction_autoscaler_panics_total",
+			Help: "Total number of panics recovered in the eviction autoscaler reconcile loop",
+		},
+		[]string{"namespace", "target_name", "controller"},
+	)
+
 	// PDBCounter tracks the number of PDBs with an increment interface
 	// Labels: namespace, created_by_us (true/false)
 	PDBCounter = prometheus.NewCounterVec(
@@ -201,5 +211,6 @@ func init() {
 		NodeCordoningCounter,
 		PDBInfoGauge,
 		PDBCounter,
+		PanicCounter,
 	)
 }


### PR DESCRIPTION
#### Impact
Adds a panic counter so we can alert when the eviction autoscaler panics while reconciling. Today a reconcile panic is invisible in production: controller-runtime recovers it, so the pod never crashes or restarts and nothing pages, while that controller's work silently stops for the affected object.

#### Why not the built-in metric
controller-runtime emits `controller_runtime_reconcile_panics_total`, but it doesn't work here. Its only label is `controller`, so it can't say which workload panicked. More importantly, I checked the AKSCCPMetrics Kusto database: there is no `ControllerRuntimeReconcilePanicsTotal` table, and eviction-autoscaler doesn't appear in the controller-runtime tables at all (only gpu_provisioner and kaito_workspace do). Our own `eviction_autoscaler_*` metrics are already ingested as 9 tables, so emitting our own panic metric uses an ingestion path that already works.

#### What changed
- `eviction_autoscaler_panics_total` labeled by `namespace`, `target_name`, and `controller`.
- A small `recordPanic` helper that records the panic and re-panics, so controller-runtime's recovery still applies and runtime behavior is unchanged.
- One deferred call in each of the five reconcilers. The eviction autoscaler reconciler passes the spec target so panics on the surge path name the workload being surged.

#### Testing
- gofmt, go vet, and go build clean; full unit suite passes.
- Two new tests: one asserts the counter increments with the correct namespace/target and that the panic is re-raised; one asserts nothing is recorded on a normal return.
- Anti-vacuous proofs: recording the wrong namespace fails the test, and swallowing the panic fails the test. Restored, both pass.
- No dependency changes (go.mod and go.sum untouched).

#### Follow-up
A companion alert in aks-rp-alerts queries `EvictionAutoscalerPanicsTotal1mIncrease`. It can only fire once this ships, since the table won't exist until the metric is emitted in production.
