### PR TITLE
feat: UnitedDeployment (OpenKruise) surge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Networking](#networking)
 - [Usage](#usage)
   - [Surge Annotations](#surge-annotations)
+  - [UnitedDeployment Surge](#uniteddeployment-surge)
   - [How Surge Sizing Works](#how-surge-sizing-works)
 
 ## Introduction
@@ -32,6 +33,7 @@ Your app might also experience issues for unrelated reasons, and a maintenance e
 - **Eviction-autoscaler Controller**: Watches eviction-autoscale resources. If there a recent eviction singals and the PDB's AllowedDisruotions is zero, it triggers a surge in the corresponding deployment. Once evitions have stopped for some cooldown period and allowed diruptions has rised above zero it scales down.
 - **HPA-aware surge**: When an HPA targets the deployment, the controller surges by temporarily raising the HPA's `minReplicas` instead of mutating deployment replicas directly. This prevents the HPA from immediately scaling the deployment back down during a surge. On revert, the original `minReplicas` floor is restored.
 - **KEDA-aware surge**: When a KEDA ScaledObject targets the deployment, the controller surges by temporarily raising the ScaledObject's `minReplicaCount`. The same pattern applies — annotations on the ScaledObject track the surge state and original value for safe revert.
+- **UnitedDeployment-aware surge**: When the PDB-protected pods belong to an OpenKruise [UnitedDeployment](https://openkruise.io/docs/user-manuals/uniteddeployment/), the controller surges the UnitedDeployment's own `spec.replicas` and routes the extra replicas to a chosen subset (pinning the other subsets to absolute counts). Scaling the subset's child Deployment directly does not work — the UnitedDeployment controller reverts it — so the surge goes through the owner the platform controls. By default the surge lands on the subset the drain is displacing; set the `eviction-autoscaler.azure.com/surge-subset` annotation on the UnitedDeployment to force a specific subset (e.g. route surge onto spot capacity for cost). The original per-subset topology is snapshotted for exact restore on revert.
 - **PDB Controller** (Optional): Automatically creates eviction-autoscalers Custom Resources for existing PDBs. When an HPA or KEDA ScaledObject targets the deployment, PDB `minAvailable` is set from the autoscaler's min replicas floor rather than `deployment.spec.replicas`.
 - **Autoscaler-to-PDB Controller** (Optional): Watches HPA and KEDA ScaledObject changes and updates PDB `minAvailable` to track the autoscaler's min replicas floor, even when deployment replicas don't change.
 - **Deployment Controller** (Optional): Creates PDBs for deployments that don't already have them and keeps min available matching the deployments replicas (not counting any surged in by eviction autoscaler). Defers to the Autoscaler-to-PDB controller when an HPA or KEDA ScaledObject is present.
@@ -524,6 +526,9 @@ During a surge, the eviction autoscaler places annotations on the **autoscaler o
 | `evictionSurgeReplicas` | HPA or ScaledObject | Surged replica count (e.g., `"3"`) | Marks that a surge is active |
 | `eviction-autoscaler.azure.com/original-min-replicas` | HPA or ScaledObject | Pre-surge min replicas (e.g., `"1"`) | Stores the original value for safe revert |
 | `evictionSurgeReplicas` | Deployment | Surged replica count | Only used when **no** HPA/KEDA is present |
+| `evictionSurgeReplicas` | UnitedDeployment | Surged replica count | Marks that a UnitedDeployment surge is active |
+| `eviction-autoscaler.azure.com/ud-surge-snapshot` | UnitedDeployment | JSON topology snapshot | Stores the pre-surge per-subset config + total for exact revert |
+| `eviction-autoscaler.azure.com/surge-subset` | UnitedDeployment | Subset name (e.g. `"spot"`) | **User-set** (optional): forces which subset absorbs the surge; overrides the displaced-subset default |
 
 These annotations are managed automatically by the controller. They are set atomically with the `minReplicas`/`minReplicaCount` change during surge and removed during revert. You should not modify them manually.
 
@@ -539,6 +544,30 @@ kubectl get scaledobject <name> -n <namespace> -o jsonpath='{.metadata.annotatio
 # Check the original minReplicas that will be restored on revert
 kubectl get hpa <name> -n <namespace> -o jsonpath='{.metadata.annotations.eviction-autoscaler\.azure\.com/original-min-replicas}'
 ```
+
+### UnitedDeployment Surge
+
+When the PDB-protected pods belong to an OpenKruise UnitedDeployment, the controller resolves the target through the pod → ReplicaSet → child Deployment → UnitedDeployment owner chain and surges the UnitedDeployment's own `spec.replicas`, routing the delta to a single subset while pinning the others to absolute counts.
+
+**Where the surge lands (subset selection):**
+
+1. If the `eviction-autoscaler.azure.com/surge-subset` annotation is set on the UnitedDeployment to a valid subset name, that subset absorbs the surge (operator override — e.g. always surge onto `spot` for cost).
+2. Otherwise, the surge lands on the subset the current drain is displacing (the subset with the most pods on cordoned nodes).
+3. If neither can be determined, it falls back to the subset with the most replicas.
+
+The `surge-subset` annotation is the only surge annotation you may set yourself; `evictionSurgeReplicas` and `ud-surge-snapshot` are managed by the controller and restored/removed on revert.
+
+```yaml
+apiVersion: apps.kruise.io/v1alpha1
+kind: UnitedDeployment
+metadata:
+  name: my-app
+  annotations:
+    # Optional: force drain-time surge onto the "spot" subset.
+    eviction-autoscaler.azure.com/surge-subset: "spot"
+```
+
+**Prerequisite:** OpenKruise must be installed in the cluster (the UnitedDeployment CRD must exist). The controller's RBAC includes `get;list;watch;update;patch` on `uniteddeployments` in the `apps.kruise.io` group.
 
 ### How Surge Sizing Works
 

--- a/README.md
+++ b/README.md
@@ -569,6 +569,10 @@ metadata:
 
 **Prerequisite:** OpenKruise must be installed in the cluster (the UnitedDeployment CRD must exist). The controller's RBAC includes `get;list;watch;update;patch` on `uniteddeployments` in the `apps.kruise.io` group.
 
+**Enabling:** UnitedDeployment surge is **off by default** and gated by the `ENABLE_UNITEDDEPLOYMENT_SURGE` environment variable on the controller (`true`/`false`, strictly validated at startup). When disabled, the controller neither redirects the surge target to the UnitedDeployment nor uses the UnitedDeployment surge strategy, preserving prior behavior for clusters that also run OpenKruise.
+
+**Observability:** UnitedDeployment surge/revert failures that are handled without a hard error (status not yet converged, a lost topology snapshot, or a best-effort scale-down on revert) increment the `eviction_autoscaler_uniteddeployment_surge_failures_total{namespace,reason}` counter.
+
 ### How Surge Sizing Works
 
 Eviction-autoscaler scales **to** a specific target rather than scaling **by** a fixed amount. The target is computed per reconcile:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	kruiseappsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -53,6 +54,7 @@ func init() {
 
 	utilruntime.Must(appsv1.AddToScheme(scheme))
 	utilruntime.Must(kedav1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kruiseappsv1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -197,10 +197,27 @@ func main() {
 	}
 	setupLog.Info("PDB creation configuration", "pdbCreate", pdbCreate)
 
+	// Parse ENABLE_UNITEDDEPLOYMENT_SURGE (defaults to false if not set).
+	// When false, the controller ignores OpenKruise UnitedDeployment ownership:
+	// it neither redirects the surge target to the UD nor uses the UD surge
+	// strategy, preserving the pre-UD-support behavior for operators who opt out.
+	udSurgeStr := os.Getenv("ENABLE_UNITEDDEPLOYMENT_SURGE")
+	enableUnitedDeploymentSurge := false
+	if udSurgeStr != "" {
+		var err error
+		enableUnitedDeploymentSurge, err = strconv.ParseBool(strings.TrimSpace(udSurgeStr))
+		if err != nil {
+			setupLog.Error(err, "Failed to parse ENABLE_UNITEDDEPLOYMENT_SURGE env variable")
+			os.Exit(1)
+		}
+	}
+	setupLog.Info("UnitedDeployment surge configuration", "enableUnitedDeploymentSurge", enableUnitedDeploymentSurge)
+
 	if err = (&controllers.EvictionAutoScalerReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Filter: nsfilter,
+		Client:                      mgr.GetClient(),
+		Scheme:                      mgr.GetScheme(),
+		Filter:                      nsfilter,
+		EnableUnitedDeploymentSurge: enableUnitedDeploymentSurge,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EvictionAutoScaler")
 		os.Exit(1)
@@ -232,9 +249,10 @@ func main() {
 	}
 
 	if err = (&controllers.PDBToEvictionAutoScalerReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Filter: nsfilter,
+		Client:                      mgr.GetClient(),
+		Scheme:                      mgr.GetScheme(),
+		Filter:                      nsfilter,
+		EnableUnitedDeploymentSurge: enableUnitedDeploymentSurge,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PDBToEvictionAutoScalerReconciler")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -32,6 +32,24 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps.kruise.io
+  resources:
+  - uniteddeployments
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - uniteddeployments/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 
 require (
 	github.com/go-logr/logr v1.4.3
+	github.com/openkruise/kruise-api v1.8.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/samber/lo v1.52.0
 	go.uber.org/zap v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
 github.com/onsi/gomega v1.39.1/go.mod h1:hL6yVALoTOxeWudERyfppUcZXjMwIMLnuSfruD2lcfg=
+github.com/openkruise/kruise-api v1.8.0 h1:DoUb873uuf2Bhoajim+9tb/X0eFpwIxRydc4Awfeeiw=
+github.com/openkruise/kruise-api v1.8.0/go.mod h1:XRpoTk7VFgh9r5HRUZurwhiC3cpCf5BX8X4beZLcIfA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -205,6 +205,18 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			surgeTarget = maxSurgeTarget
 		}
 
+		// For a UnitedDeployment target, default the surge to land on the subset
+		// the drain is displacing (overridable via the surge-subset annotation).
+		if udWrapper, isUD := target.(*UnitedDeploymentWrapper); isUD {
+			subset, subsetErr := displacedSubsetOnCordoned(ctx, r.Client, pdb)
+			if subsetErr != nil {
+				logger.Error(subsetErr, "failed to determine displaced UnitedDeployment subset; falling back to dominant subset")
+			} else if subset != "" {
+				logger.Info("Routing UnitedDeployment surge to displaced subset", "pdb", pdb.Name, "subset", subset)
+				udWrapper.SetPreferredSurgeSubset(subset)
+			}
+		}
+
 		if target.GetReplicas() >= surgeTarget {
 			//we've scaled up but pdb is still blockign may just be waiting for new pods to become ready
 			logger.Info("Have already scaled up to handle evictions, waiting for PDB to allow disruptions before reverting",

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -38,6 +38,8 @@ type EvictionAutoScalerReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 	Filter   filter
+	// EnableUnitedDeploymentSurge gates OpenKruise UnitedDeployment surge support.
+	EnableUnitedDeploymentSurge bool
 }
 
 const cooldown = 1 * time.Minute
@@ -127,6 +129,14 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// TODO: Move PDB configuration tracking to PDB controller with aggregate labels
 	// Consider tracking: maxUnavailable==0 and minAvailable==replicas as PDBGauge labels
 
+	// If the target resolves to a UnitedDeployment but the feature is disabled,
+	// treat it as unsupported rather than silently surging the wrong resource.
+	if strings.EqualFold(EvictionAutoScaler.Spec.TargetKind, unitedDeploymentKind) && !r.EnableUnitedDeploymentSurge {
+		logger.Info("UnitedDeployment surge is disabled; not surging", "targetname", EvictionAutoScaler.Spec.TargetName)
+		degraded(&EvictionAutoScaler.Status.Conditions, "UnitedDeploymentSurgeDisabled", "UnitedDeployment surge is disabled (set ENABLE_UNITEDDEPLOYMENT_SURGE=true to enable)")
+		return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler)
+	}
+
 	// Detect surge strategy based on KEDA, HPA, or plain deployment
 	surgeApplier, err := detectSurgeApplier(ctx, r.Client, EvictionAutoScaler.Namespace, EvictionAutoScaler.Spec.TargetName, EvictionAutoScaler.Spec.TargetKind, target)
 	if err != nil {
@@ -193,11 +203,12 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler)
 		}
 	} else if pdb.Status.DisruptionsAllowed == 0 {
-		displaced, countErr := countPodsOnCordoned(ctx, r.Client, pdb)
+		drain, countErr := computeCordonedDrainStats(ctx, r.Client, pdb)
 		if countErr != nil {
-			logger.Error(countErr, "failed to count displaced pods on cordoned nodes")
+			logger.Error(countErr, "failed to inspect displaced pods on cordoned nodes")
 			return ctrl.Result{}, countErr
 		}
+		displaced := drain.count
 
 		surgeTarget := EvictionAutoScaler.Status.MinReplicas + displaced
 		if surgeTarget > maxSurgeTarget {
@@ -207,14 +218,9 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		// For a UnitedDeployment target, default the surge to land on the subset
 		// the drain is displacing (overridable via the surge-subset annotation).
-		if udWrapper, isUD := target.(*UnitedDeploymentWrapper); isUD {
-			subset, subsetErr := displacedSubsetOnCordoned(ctx, r.Client, pdb)
-			if subsetErr != nil {
-				logger.Error(subsetErr, "failed to determine displaced UnitedDeployment subset; falling back to dominant subset")
-			} else if subset != "" {
-				logger.Info("Routing UnitedDeployment surge to displaced subset", "pdb", pdb.Name, "subset", subset)
-				udWrapper.SetPreferredSurgeSubset(subset)
-			}
+		if udWrapper, isUD := target.(*UnitedDeploymentWrapper); isUD && drain.displacedSubset != "" {
+			logger.Info("Routing UnitedDeployment surge to displaced subset", "pdb", pdb.Name, "subset", drain.displacedSubset)
+			udWrapper.SetPreferredSurgeSubset(drain.displacedSubset)
 		}
 
 		if target.GetReplicas() >= surgeTarget {

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -46,6 +46,8 @@ const cooldown = 1 * time.Minute
 // +kubebuilder:rbac:groups=eviction-autoscaler.azure.com,resources=evictionautoscalers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=eviction-autoscaler.azure.com,resources=evictionautoscalers/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=watch;get;list;update
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=uniteddeployments,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=apps.kruise.io,resources=uniteddeployments/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=watch;get;list
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=update
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch

--- a/internal/controller/pdb_helpers.go
+++ b/internal/controller/pdb_helpers.go
@@ -236,3 +236,49 @@ func countPodsOnCordoned(ctx context.Context, c client.Client, pdb *policyv1.Pod
 	}
 	return count, nil
 }
+
+// kruiseSubsetLabel is the label OpenKruise sets on UnitedDeployment subset pods.
+const kruiseSubsetLabel = "apps.kruise.io/subset-name"
+
+// displacedSubsetOnCordoned returns the UnitedDeployment subset name with the
+// most PDB-selected pods sitting on cordoned nodes, i.e. the subset the drain is
+// displacing. Returns "" when no such pod carries a subset label (e.g. the
+// target is not a UnitedDeployment or no pods are on cordoned nodes).
+func displacedSubsetOnCordoned(ctx context.Context, c client.Client, pdb *policyv1.PodDisruptionBudget) (string, error) {
+	selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+	if err != nil {
+		return "", fmt.Errorf("invalid PDB selector: %w", err)
+	}
+
+	var podList corev1.PodList
+	if err := c.List(ctx, &podList, client.InNamespace(pdb.Namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		return "", fmt.Errorf("failed to list pods for PDB %s: %w", pdb.Name, err)
+	}
+
+	var nodeList corev1.NodeList
+	if err := c.List(ctx, &nodeList); err != nil {
+		return "", fmt.Errorf("failed to list nodes: %w", err)
+	}
+	cordoned := make(map[string]bool, len(nodeList.Items))
+	for _, node := range nodeList.Items {
+		cordoned[node.Name] = node.Spec.Unschedulable
+	}
+
+	counts := map[string]int32{}
+	for _, pod := range podList.Items {
+		if !cordoned[pod.Spec.NodeName] {
+			continue
+		}
+		if subset := pod.Labels[kruiseSubsetLabel]; subset != "" {
+			counts[subset]++
+		}
+	}
+
+	best, bestN := "", int32(0)
+	for name, n := range counts {
+		if n > bestN {
+			best, bestN = name, n
+		}
+	}
+	return best, nil
+}

--- a/internal/controller/pdb_helpers.go
+++ b/internal/controller/pdb_helpers.go
@@ -200,18 +200,32 @@ func triggerOnPDBAnnotationChange(e event.UpdateEvent, logger logr.Logger) bool 
 	return false
 }
 
-// countPodsOnCordoned counts pods matching the PDB selector that are currently on cordoned
-// (Unschedulable) nodes. It aggregates across all cordoned nodes, so simultaneous drains
-// are counted correctly.
-func countPodsOnCordoned(ctx context.Context, c client.Client, pdb *policyv1.PodDisruptionBudget) (int32, error) {
+// kruiseSubsetLabel is the label OpenKruise sets on UnitedDeployment subset pods.
+const kruiseSubsetLabel = "apps.kruise.io/subset-name"
+
+// cordonedDrainStats describes the pods a drain is displacing for a given PDB.
+type cordonedDrainStats struct {
+	// count is the number of PDB-selected pods on cordoned nodes.
+	count int32
+	// displacedSubset is the OpenKruise UnitedDeployment subset (by the
+	// apps.kruise.io/subset-name label) with the most displaced pods, or "" when
+	// no displaced pod carries a subset label (non-UD target, or nothing draining).
+	displacedSubset string
+}
+
+// computeCordonedDrainStats does a single pass over the PDB-selected pods and the
+// node list, returning both the displaced pod count and the dominant displaced
+// UnitedDeployment subset. Combining these avoids listing pods+nodes twice in the
+// reconcile hot path while a PDB is blocking evictions.
+func computeCordonedDrainStats(ctx context.Context, c client.Client, pdb *policyv1.PodDisruptionBudget) (cordonedDrainStats, error) {
 	selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
 	if err != nil {
-		return 0, fmt.Errorf("invalid PDB selector: %w", err)
+		return cordonedDrainStats{}, fmt.Errorf("invalid PDB selector: %w", err)
 	}
 
 	var podList corev1.PodList
 	if err := c.List(ctx, &podList, client.InNamespace(pdb.Namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
-		return 0, fmt.Errorf("failed to list pods for PDB %s: %w", pdb.Name, err)
+		return cordonedDrainStats{}, fmt.Errorf("failed to list pods for PDB %s: %w", pdb.Name, err)
 	}
 
 	// We use node cordon (Spec.Unschedulable) as the signal for "pods need to move".
@@ -221,64 +235,41 @@ func countPodsOnCordoned(ctx context.Context, c client.Client, pdb *policyv1.Pod
 	// without needing to inspect nodes at all.
 	var nodeList corev1.NodeList
 	if err := c.List(ctx, &nodeList); err != nil {
-		return 0, fmt.Errorf("failed to list nodes: %w", err)
+		return cordonedDrainStats{}, fmt.Errorf("failed to list nodes: %w", err)
 	}
 	cordoned := make(map[string]bool, len(nodeList.Items))
 	for _, node := range nodeList.Items {
 		cordoned[node.Name] = node.Spec.Unschedulable
 	}
 
-	var count int32
-	for _, pod := range podList.Items {
-		if cordoned[pod.Spec.NodeName] {
-			count++
-		}
-	}
-	return count, nil
-}
-
-// kruiseSubsetLabel is the label OpenKruise sets on UnitedDeployment subset pods.
-const kruiseSubsetLabel = "apps.kruise.io/subset-name"
-
-// displacedSubsetOnCordoned returns the UnitedDeployment subset name with the
-// most PDB-selected pods sitting on cordoned nodes, i.e. the subset the drain is
-// displacing. Returns "" when no such pod carries a subset label (e.g. the
-// target is not a UnitedDeployment or no pods are on cordoned nodes).
-func displacedSubsetOnCordoned(ctx context.Context, c client.Client, pdb *policyv1.PodDisruptionBudget) (string, error) {
-	selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
-	if err != nil {
-		return "", fmt.Errorf("invalid PDB selector: %w", err)
-	}
-
-	var podList corev1.PodList
-	if err := c.List(ctx, &podList, client.InNamespace(pdb.Namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
-		return "", fmt.Errorf("failed to list pods for PDB %s: %w", pdb.Name, err)
-	}
-
-	var nodeList corev1.NodeList
-	if err := c.List(ctx, &nodeList); err != nil {
-		return "", fmt.Errorf("failed to list nodes: %w", err)
-	}
-	cordoned := make(map[string]bool, len(nodeList.Items))
-	for _, node := range nodeList.Items {
-		cordoned[node.Name] = node.Spec.Unschedulable
-	}
-
-	counts := map[string]int32{}
+	var stats cordonedDrainStats
+	subsetCounts := map[string]int32{}
 	for _, pod := range podList.Items {
 		if !cordoned[pod.Spec.NodeName] {
 			continue
 		}
+		stats.count++
 		if subset := pod.Labels[kruiseSubsetLabel]; subset != "" {
-			counts[subset]++
+			subsetCounts[subset]++
 		}
 	}
 
-	best, bestN := "", int32(0)
-	for name, n := range counts {
+	var bestN int32
+	for name, n := range subsetCounts {
 		if n > bestN {
-			best, bestN = name, n
+			stats.displacedSubset, bestN = name, n
 		}
 	}
-	return best, nil
+	return stats, nil
+}
+
+// countPodsOnCordoned counts pods matching the PDB selector that are currently on cordoned
+// (Unschedulable) nodes. It aggregates across all cordoned nodes, so simultaneous drains
+// are counted correctly.
+func countPodsOnCordoned(ctx context.Context, c client.Client, pdb *policyv1.PodDisruptionBudget) (int32, error) {
+	stats, err := computeCordonedDrainStats(ctx, c, pdb)
+	if err != nil {
+		return 0, err
+	}
+	return stats.count, nil
 }

--- a/internal/controller/pdb_to_evictionautoscaler_controller.go
+++ b/internal/controller/pdb_to_evictionautoscaler_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	types "github.com/azure/eviction-autoscaler/api/v1"
 	"github.com/azure/eviction-autoscaler/internal/metrics"
@@ -93,7 +94,7 @@ func (r *PDBToEvictionAutoScalerReconciler) Reconcile(ctx context.Context, req r
 			return ctrl.Result{}, err
 		}
 
-		deploymentName, _, e := r.discoverDeployment(ctx, &pdb)
+		deploymentName, targetKind, _, e := r.discoverDeployment(ctx, &pdb)
 		if e != nil {
 			return reconcile.Result{}, e
 		}
@@ -129,7 +130,7 @@ func (r *PDBToEvictionAutoScalerReconciler) Reconcile(ctx context.Context, req r
 			},
 			Spec: types.EvictionAutoScalerSpec{
 				TargetName: deploymentName,
-				TargetKind: deploymentKind,
+				TargetKind: targetKind,
 			},
 		}
 
@@ -192,7 +193,7 @@ func (r *PDBToEvictionAutoScalerReconciler) handleOwnershipTransfer(ctx context.
 		logger.Info("Adding owner reference to PDB - controller taking control back",
 			"namespace", pdb.Namespace, "name", pdb.Name)
 
-		deploymentName, deploymentUID, err := r.discoverDeployment(ctx, pdb)
+		deploymentName, targetKind, deploymentUID, err := r.discoverDeployment(ctx, pdb)
 		if err != nil {
 			logger.Error(err, "Failed to get deployment",
 				"namespace", pdb.Namespace, "name", deploymentName)
@@ -202,9 +203,16 @@ func (r *PDBToEvictionAutoScalerReconciler) handleOwnershipTransfer(ctx context.
 		controller := true
 		blockOwnerDeletion := true
 
+		ownerAPIVersion := "apps/v1"
+		ownerKind := ResourceTypeDeployment
+		if strings.EqualFold(targetKind, unitedDeploymentKind) {
+			ownerAPIVersion = "apps.kruise.io/v1alpha1"
+			ownerKind = "UnitedDeployment"
+		}
+
 		pdb.OwnerReferences = append(pdb.OwnerReferences, metav1.OwnerReference{
-			APIVersion:         "apps/v1",
-			Kind:               ResourceTypeDeployment,
+			APIVersion:         ownerAPIVersion,
+			Kind:               ownerKind,
 			Name:               deploymentName,
 			UID:                deploymentUID,
 			Controller:         &controller,
@@ -249,26 +257,26 @@ func (r *PDBToEvictionAutoScalerReconciler) SetupWithManager(mgr ctrl.Manager) e
 		Complete(r)
 }
 
-func (r *PDBToEvictionAutoScalerReconciler) discoverDeployment(ctx context.Context, pdb *policyv1.PodDisruptionBudget) (string, k8s_types.UID, error) {
+func (r *PDBToEvictionAutoScalerReconciler) discoverDeployment(ctx context.Context, pdb *policyv1.PodDisruptionBudget) (string, string, k8s_types.UID, error) {
 	logger := log.FromContext(ctx)
 
 	// Convert PDB label selector to Kubernetes selector
 	selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
 	if err != nil {
-		return "", "", fmt.Errorf("error converting label selector: %v", err)
+		return "", "", "", fmt.Errorf("error converting label selector: %v", err)
 	}
 	logger.Info("PDB Selector", "selector", pdb.Spec.Selector)
 
 	podList := &corev1.PodList{}
 	err = r.List(ctx, podList, &client.ListOptions{Namespace: pdb.Namespace, LabelSelector: selector})
 	if err != nil {
-		return "", "", fmt.Errorf("error listing pods: %v", err)
+		return "", "", "", fmt.Errorf("error listing pods: %v", err)
 	}
 	logger.Info("Number of pods found", "count", len(podList.Items))
 
 	if len(podList.Items) == 0 {
 		// TODO instead of an error which leads to a backoff retry quietly for a while then error?
-		return "", "", fmt.Errorf("no pods found matching the PDB selector %s; leaky pdb(?!)", pdb.Name)
+		return "", "", "", fmt.Errorf("no pods found matching the PDB selector %s; leaky pdb(?!)", pdb.Name)
 	}
 
 	// Iterate through each pod
@@ -279,7 +287,7 @@ func (r *PDBToEvictionAutoScalerReconciler) discoverDeployment(ctx context.Conte
 				replicaSet := &appsv1.ReplicaSet{}
 				err = r.Get(ctx, k8s_types.NamespacedName{Name: ownerRef.Name, Namespace: pdb.Namespace}, replicaSet)
 				if apierrors.IsNotFound(err) {
-					return "", "", fmt.Errorf("error fetching ReplicaSet: %v", err)
+					return "", "", "", fmt.Errorf("error fetching ReplicaSet: %v", err)
 				}
 
 				// Log ReplicaSet details
@@ -289,7 +297,18 @@ func (r *PDBToEvictionAutoScalerReconciler) discoverDeployment(ctx context.Conte
 				for _, rsOwnerRef := range replicaSet.OwnerReferences {
 					if rsOwnerRef.Kind == "Deployment" {
 						logger.Info("Found Deployment owner", "deployment", rsOwnerRef.Name)
-						return rsOwnerRef.Name, rsOwnerRef.UID, nil
+						// The Deployment may itself be a subset child of an OpenKruise
+						// UnitedDeployment. If so, target the UD — scaling the child
+						// Deployment directly is reverted by the UD controller.
+						udName, udUID, isUD, e := r.unitedDeploymentOwner(ctx, pdb.Namespace, rsOwnerRef.Name)
+						if e != nil {
+							return "", "", "", e
+						}
+						if isUD {
+							logger.Info("Deployment is a UnitedDeployment subset; targeting the UnitedDeployment", "uniteddeployment", udName)
+							return udName, unitedDeploymentKind, udUID, nil
+						}
+						return rsOwnerRef.Name, deploymentKind, rsOwnerRef.UID, nil
 					}
 				}
 				// no replicaset owner just move on and see if any other pods have have something.
@@ -308,5 +327,23 @@ func (r *PDBToEvictionAutoScalerReconciler) discoverDeployment(ctx context.Conte
 		}
 	}
 	logger.Info("No Deployment owner found")
-	return "", "", errOwnerNotFound
+	return "", "", "", errOwnerNotFound
+}
+
+// unitedDeploymentOwner reports whether the named Deployment is a subset child of
+// an OpenKruise UnitedDeployment and, if so, returns the UD's name and UID.
+func (r *PDBToEvictionAutoScalerReconciler) unitedDeploymentOwner(ctx context.Context, namespace, deploymentName string) (string, k8s_types.UID, bool, error) {
+	dep := &appsv1.Deployment{}
+	if err := r.Get(ctx, k8s_types.NamespacedName{Name: deploymentName, Namespace: namespace}, dep); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", "", false, nil
+		}
+		return "", "", false, fmt.Errorf("error fetching Deployment %s: %v", deploymentName, err)
+	}
+	for _, ref := range dep.OwnerReferences {
+		if ref.Kind == "UnitedDeployment" {
+			return ref.Name, ref.UID, true, nil
+		}
+	}
+	return "", "", false, nil
 }

--- a/internal/controller/pdb_to_evictionautoscaler_controller.go
+++ b/internal/controller/pdb_to_evictionautoscaler_controller.go
@@ -32,6 +32,9 @@ type PDBToEvictionAutoScalerReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 	Filter   filter
+	// EnableUnitedDeploymentSurge gates redirecting the surge target from a child
+	// Deployment to its owning OpenKruise UnitedDeployment.
+	EnableUnitedDeploymentSurge bool
 }
 
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;create;watch;update
@@ -298,15 +301,18 @@ func (r *PDBToEvictionAutoScalerReconciler) discoverDeployment(ctx context.Conte
 					if rsOwnerRef.Kind == "Deployment" {
 						logger.Info("Found Deployment owner", "deployment", rsOwnerRef.Name)
 						// The Deployment may itself be a subset child of an OpenKruise
-						// UnitedDeployment. If so, target the UD — scaling the child
-						// Deployment directly is reverted by the UD controller.
-						udName, udUID, isUD, e := r.unitedDeploymentOwner(ctx, pdb.Namespace, rsOwnerRef.Name)
-						if e != nil {
-							return "", "", "", e
-						}
-						if isUD {
-							logger.Info("Deployment is a UnitedDeployment subset; targeting the UnitedDeployment", "uniteddeployment", udName)
-							return udName, unitedDeploymentKind, udUID, nil
+						// UnitedDeployment. If so (and the feature is enabled), target
+						// the UD — scaling the child Deployment directly is reverted by
+						// the UD controller.
+						if r.EnableUnitedDeploymentSurge {
+							udName, udUID, isUD, e := r.unitedDeploymentOwner(ctx, pdb.Namespace, rsOwnerRef.Name)
+							if e != nil {
+								return "", "", "", e
+							}
+							if isUD {
+								logger.Info("Deployment is a UnitedDeployment subset; targeting the UnitedDeployment", "uniteddeployment", udName)
+								return udName, unitedDeploymentKind, udUID, nil
+							}
 						}
 						return rsOwnerRef.Name, deploymentKind, rsOwnerRef.UID, nil
 					}

--- a/internal/controller/surge_strategy.go
+++ b/internal/controller/surge_strategy.go
@@ -57,6 +57,14 @@ var errUnsupportedAutoscalerConfig = errors.New("unsupported autoscaler configur
 func detectSurgeApplier(ctx context.Context, c client.Client, namespace, targetName, targetKind string, target Surger) (SurgeApplier, error) {
 	logger := log.FromContext(ctx)
 
+	// UnitedDeployment: surge through the UD's own spec. Scaling a child Deployment
+	// directly is reverted by the UD controller, so we use a dedicated applier that
+	// clamps the UD topology. HPA/KEDA never target UnitedDeployments.
+	if strings.EqualFold(targetKind, unitedDeploymentKind) {
+		logger.Info("Target is a UnitedDeployment, using UnitedDeployment surge strategy", "target", targetName)
+		return &UnitedDeploymentSurgeApplier{client: c, target: target}, nil
+	}
+
 	// HPA and KEDA only target Deployments; skip autoscaler detection for other kinds.
 	if strings.EqualFold(targetKind, ResourceTypeDeployment) {
 		// Check for KEDA ScaledObject targeting this workload

--- a/internal/controller/ud_surge_applier.go
+++ b/internal/controller/ud_surge_applier.go
@@ -2,9 +2,11 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
+	"github.com/azure/eviction-autoscaler/internal/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -21,12 +23,35 @@ type UnitedDeploymentSurgeApplier struct {
 var _ SurgeApplier = &UnitedDeploymentSurgeApplier{}
 
 func (u *UnitedDeploymentSurgeApplier) ApplySurge(ctx context.Context, surgeReplicas int32) error {
-	u.target.SetReplicas(surgeReplicas)
-	u.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, strconv.FormatInt(int64(surgeReplicas), 10))
-	return u.client.Update(ctx, u.target.Obj())
+	wrapper, ok := u.target.(*UnitedDeploymentWrapper)
+	if !ok {
+		return fmt.Errorf("UnitedDeploymentSurgeApplier: unexpected target type %T", u.target)
+	}
+	// Capture the pre-surge snapshot with safety guards (status convergence,
+	// lost-snapshot detection) before mutating replicas.
+	if err := wrapper.PrepareSurge(); err != nil {
+		metrics.UnitedDeploymentSurgeFailureCounter.WithLabelValues(
+			wrapper.Obj().GetNamespace(), surgeFailureReason(err)).Inc()
+		return err
+	}
+	wrapper.SetReplicas(surgeReplicas)
+	wrapper.AddAnnotation(EvictionSurgeReplicasAnnotationKey, strconv.FormatInt(int64(surgeReplicas), 10))
+	return u.client.Update(ctx, wrapper.Obj())
 }
 
-func (u *UnitedDeploymentSurgeApplier) RevertSurge(ctx context.Context, _ int32) error {
+// surgeFailureReason maps a PrepareSurge error to a bounded metric label.
+func surgeFailureReason(err error) string {
+	switch {
+	case errors.Is(err, errStatusNotConverged):
+		return "status_not_converged"
+	case errors.Is(err, errSnapshotLostDuringSurge):
+		return "snapshot_lost"
+	default:
+		return "snapshot_write_failed"
+	}
+}
+
+func (u *UnitedDeploymentSurgeApplier) RevertSurge(ctx context.Context, originalMinReplicas int32) error {
 	// Restore the pre-surge topology from the snapshot (original per-subset
 	// config + total), not just a flat replica count, so percentage/remainder
 	// subsets are returned exactly as the author set them.
@@ -34,9 +59,18 @@ func (u *UnitedDeploymentSurgeApplier) RevertSurge(ctx context.Context, _ int32)
 	if !ok {
 		return fmt.Errorf("UnitedDeploymentSurgeApplier: unexpected target type %T", u.target)
 	}
-	wrapper.RestoreOriginal()
-	u.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
-	return u.client.Update(ctx, u.target.Obj())
+	if _, hasSnapshot := wrapper.readSnapshot(); hasSnapshot {
+		wrapper.RestoreOriginal()
+	} else {
+		// Snapshot lost: we can't restore the exact topology, but we must still
+		// scale the UnitedDeployment back down to the floor so it isn't left
+		// stuck at the surged replica count.
+		metrics.UnitedDeploymentSurgeFailureCounter.WithLabelValues(
+			wrapper.Obj().GetNamespace(), "revert_without_snapshot").Inc()
+		wrapper.ForceScaleDown(originalMinReplicas)
+	}
+	wrapper.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
+	return u.client.Update(ctx, wrapper.Obj())
 }
 
 func (u *UnitedDeploymentSurgeApplier) IsSurgeActive() bool {

--- a/internal/controller/ud_surge_applier.go
+++ b/internal/controller/ud_surge_applier.go
@@ -1,0 +1,48 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// UnitedDeploymentSurgeApplier surges an OpenKruise UnitedDeployment by clamping
+// the UD's own spec (via UnitedDeploymentWrapper) instead of scaling a child
+// Deployment directly — which the UD controller would revert. It mirrors the
+// autoscaler-floor pattern (HPA/KEDA): mutate the owner the platform controls so
+// it cooperates rather than fights.
+type UnitedDeploymentSurgeApplier struct {
+	client client.Client
+	target Surger
+}
+
+var _ SurgeApplier = &UnitedDeploymentSurgeApplier{}
+
+func (u *UnitedDeploymentSurgeApplier) ApplySurge(ctx context.Context, surgeReplicas int32) error {
+	u.target.SetReplicas(surgeReplicas)
+	u.target.AddAnnotation(EvictionSurgeReplicasAnnotationKey, strconv.FormatInt(int64(surgeReplicas), 10))
+	return u.client.Update(ctx, u.target.Obj())
+}
+
+func (u *UnitedDeploymentSurgeApplier) RevertSurge(ctx context.Context, _ int32) error {
+	// Restore the pre-surge topology from the snapshot (original per-subset
+	// config + total), not just a flat replica count, so percentage/remainder
+	// subsets are returned exactly as the author set them.
+	wrapper, ok := u.target.(*UnitedDeploymentWrapper)
+	if !ok {
+		return fmt.Errorf("UnitedDeploymentSurgeApplier: unexpected target type %T", u.target)
+	}
+	wrapper.RestoreOriginal()
+	u.target.RemoveAnnotation(EvictionSurgeReplicasAnnotationKey)
+	return u.client.Update(ctx, u.target.Obj())
+}
+
+func (u *UnitedDeploymentSurgeApplier) IsSurgeActive() bool {
+	return hasTargetAnnotation(u.target)
+}
+
+func (u *UnitedDeploymentSurgeApplier) Name() string {
+	return "uniteddeployment"
+}

--- a/internal/controller/ud_surge_applier_test.go
+++ b/internal/controller/ud_surge_applier_test.go
@@ -1,0 +1,165 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	kruiseappsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func udScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := kruiseappsv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add kruise scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := policyv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add policy scheme: %v", err)
+	}
+	return scheme
+}
+
+func TestUDSurgeApplier_ApplyThenRevertRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	ud := makeTestUD()
+	fc := fake.NewClientBuilder().WithScheme(udScheme(t)).WithObjects(ud).Build()
+
+	// Apply surge.
+	applier := &UnitedDeploymentSurgeApplier{client: fc, target: &UnitedDeploymentWrapper{obj: ud.DeepCopy()}}
+	if err := applier.ApplySurge(ctx, 118); err != nil {
+		t.Fatalf("ApplySurge: %v", err)
+	}
+	key := k8stypes.NamespacedName{Name: ud.Name, Namespace: ud.Namespace}
+	got := &kruiseappsv1alpha1.UnitedDeployment{}
+	if err := fc.Get(ctx, key, got); err != nil {
+		t.Fatalf("get after surge: %v", err)
+	}
+	if got.Spec.Replicas == nil || *got.Spec.Replicas != 118 {
+		t.Fatalf("surged spec.replicas = %v, want 118", got.Spec.Replicas)
+	}
+	if _, ok := got.Annotations[udSurgeSnapshotAnnotationKey]; !ok {
+		t.Fatalf("snapshot annotation missing after surge")
+	}
+	if _, ok := got.Annotations[EvictionSurgeReplicasAnnotationKey]; !ok {
+		t.Fatalf("surge marker annotation missing after surge")
+	}
+
+	// Revert from the surged state read back from the client.
+	revApplier := &UnitedDeploymentSurgeApplier{client: fc, target: &UnitedDeploymentWrapper{obj: got.DeepCopy()}}
+	if err := revApplier.RevertSurge(ctx, 100); err != nil {
+		t.Fatalf("RevertSurge: %v", err)
+	}
+	reverted := &kruiseappsv1alpha1.UnitedDeployment{}
+	if err := fc.Get(ctx, key, reverted); err != nil {
+		t.Fatalf("get after revert: %v", err)
+	}
+	if reverted.Spec.Replicas == nil || *reverted.Spec.Replicas != 112 {
+		t.Fatalf("reverted spec.replicas = %v, want 112", reverted.Spec.Replicas)
+	}
+	if _, ok := reverted.Annotations[udSurgeSnapshotAnnotationKey]; ok {
+		t.Fatalf("snapshot annotation should be cleared after revert")
+	}
+	if _, ok := reverted.Annotations[EvictionSurgeReplicasAnnotationKey]; ok {
+		t.Fatalf("surge marker should be cleared after revert")
+	}
+}
+
+// When the snapshot is lost while a surge is active, RevertSurge must still scale
+// the UD back down to the floor (best-effort) rather than leaving it surged.
+func TestUDSurgeApplier_RevertWithoutSnapshotForcesScaleDown(t *testing.T) {
+	ctx := context.Background()
+	ud := makeTestUD()
+	surged := int32(118)
+	ud.Spec.Replicas = &surged
+	ud.Annotations = map[string]string{EvictionSurgeReplicasAnnotationKey: "118"} // marker, no snapshot
+	fc := fake.NewClientBuilder().WithScheme(udScheme(t)).WithObjects(ud).Build()
+
+	applier := &UnitedDeploymentSurgeApplier{client: fc, target: &UnitedDeploymentWrapper{obj: ud.DeepCopy()}}
+	if err := applier.RevertSurge(ctx, 100); err != nil {
+		t.Fatalf("RevertSurge: %v", err)
+	}
+	got := &kruiseappsv1alpha1.UnitedDeployment{}
+	if err := fc.Get(ctx, k8stypes.NamespacedName{Name: ud.Name, Namespace: ud.Namespace}, got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Spec.Replicas == nil || *got.Spec.Replicas != 100 {
+		t.Fatalf("spec.replicas = %v, want 100 (forced scale-down)", got.Spec.Replicas)
+	}
+	if _, ok := got.Annotations[EvictionSurgeReplicasAnnotationKey]; ok {
+		t.Fatalf("surge marker should be cleared after revert")
+	}
+}
+
+// discoverDeployment must redirect a Deployment that is a UnitedDeployment subset
+// child to the owning UnitedDeployment when the feature is enabled, and NOT
+// redirect when it is disabled.
+func TestDiscoverDeployment_UnitedDeploymentRedirect(t *testing.T) {
+	ctx := context.Background()
+	ns := "ns"
+	labels := map[string]string{"app": "x"}
+
+	ud := &kruiseappsv1alpha1.UnitedDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "myud", Namespace: ns, UID: k8stypes.UID("ud-uid")},
+	}
+	ctrl := true
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myud-regular", Namespace: ns, UID: k8stypes.UID("dep-uid"),
+			OwnerReferences: []metav1.OwnerReference{{Kind: "UnitedDeployment", Name: "myud", UID: "ud-uid", Controller: &ctrl}},
+		},
+	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "myud-regular-abc", Namespace: ns, UID: k8stypes.UID("rs-uid"),
+			OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: "myud-regular", UID: "dep-uid", Controller: &ctrl}},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1", Namespace: ns, Labels: labels,
+			OwnerReferences: []metav1.OwnerReference{{Kind: "ReplicaSet", Name: "myud-regular-abc", UID: "rs-uid", Controller: &ctrl}},
+		},
+	}
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: "mypdb", Namespace: ns},
+		Spec:       policyv1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: labels}},
+	}
+
+	build := func() client.Client {
+		return fake.NewClientBuilder().WithScheme(udScheme(t)).WithObjects(ud, deploy, rs, pod, pdb).Build()
+	}
+
+	// Enabled -> redirect to the UnitedDeployment.
+	rOn := &PDBToEvictionAutoScalerReconciler{Client: build(), EnableUnitedDeploymentSurge: true}
+	name, kind, uid, err := rOn.discoverDeployment(ctx, pdb)
+	if err != nil {
+		t.Fatalf("discoverDeployment (enabled): %v", err)
+	}
+	if name != "myud" || kind != unitedDeploymentKind || uid != k8stypes.UID("ud-uid") {
+		t.Fatalf("enabled: got (%q,%q,%q), want (myud,%s,ud-uid)", name, kind, uid, unitedDeploymentKind)
+	}
+
+	// Disabled -> stay on the child Deployment.
+	rOff := &PDBToEvictionAutoScalerReconciler{Client: build(), EnableUnitedDeploymentSurge: false}
+	name, kind, uid, err = rOff.discoverDeployment(ctx, pdb)
+	if err != nil {
+		t.Fatalf("discoverDeployment (disabled): %v", err)
+	}
+	if name != "myud-regular" || kind != deploymentKind || uid != k8stypes.UID("dep-uid") {
+		t.Fatalf("disabled: got (%q,%q,%q), want (myud-regular,%s,dep-uid)", name, kind, uid, deploymentKind)
+	}
+}

--- a/internal/controller/ud_wrapper.go
+++ b/internal/controller/ud_wrapper.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 
 	kruiseappsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -9,6 +11,17 @@ import (
 )
 
 const unitedDeploymentKind = "uniteddeployment"
+
+// Surge-guard sentinels. Both are transient/recoverable: the reconciler should
+// requeue (and record a failure metric) rather than degrade permanently.
+var (
+	// errStatusNotConverged means status.subsetReplicas has not caught up to
+	// spec.replicas, so we cannot safely snapshot per-subset baselines yet.
+	errStatusNotConverged = errors.New("uniteddeployment status not converged with spec")
+	// errSnapshotLostDuringSurge means a surge is active but the topology
+	// snapshot is missing; re-capturing would baseline off the surged state.
+	errSnapshotLostDuringSurge = errors.New("uniteddeployment surge snapshot lost during active surge")
+)
 
 // SurgeSubsetAnnotationKey lets a workload owner choose which UnitedDeployment
 // subset absorbs the drain-time surge, i.e. WHERE the surge lands. Value is a
@@ -51,12 +64,37 @@ func (u *UnitedDeploymentWrapper) Obj() client.Object {
 	return u.obj
 }
 
-// GetReplicas returns the UD's total desired replicas (spec.replicas).
+// GetReplicas returns the UD's total desired replicas. When spec.replicas is
+// nil (Kruise allows this — the UnitedDeployment controller fills it from the
+// subset allocation), the true total is the sum of the live per-subset counts,
+// NOT 1; defaulting to 1 would make the surge delta massively over-provision.
 func (u *UnitedDeploymentWrapper) GetReplicas() int32 {
 	if u.obj.Spec.Replicas == nil {
-		return 1
+		return u.statusReplicaSum()
 	}
 	return *u.obj.Spec.Replicas
+}
+
+// statusReplicaSum totals the live per-subset replica counts from status.
+func (u *UnitedDeploymentWrapper) statusReplicaSum() int32 {
+	var sum int32
+	for _, n := range u.obj.Status.SubsetReplicas {
+		sum += n
+	}
+	return sum
+}
+
+// isStatusConverged reports whether status.subsetReplicas has caught up to
+// spec.replicas. We surge by pinning every subset to an absolute count taken
+// from status; if status has not converged (mid-rollout, just created, transient
+// lag) a healthy subset could be understated and get scaled DOWN. Callers must
+// refuse to snapshot/surge until this returns true.
+func (u *UnitedDeploymentWrapper) isStatusConverged() bool {
+	if u.obj.Spec.Replicas == nil {
+		// Total is derived from status itself, so it is converged by definition.
+		return true
+	}
+	return u.statusReplicaSum() == *u.obj.Spec.Replicas
 }
 
 // GetMaxSurge reads the maxSurge from the UD's deploymentTemplate rolling-update
@@ -70,17 +108,18 @@ func (u *UnitedDeploymentWrapper) GetMaxSurge() intstr.IntOrString {
 }
 
 // SetReplicas surges the UD to a new total by routing the delta onto the chosen
-// surge subset. It snapshots the original topology on first call (so revert can
-// restore it) and is idempotent: the surge amount is always derived from the
-// snapshot baseline, so re-applying the same total yields the same spec.
+// surge subset. A snapshot MUST already exist (see PrepareSurge) — the surge
+// amount is always derived from the snapshot baseline, so re-applying the same
+// total yields the same spec (idempotent). Without a snapshot this is a no-op,
+// so a lost snapshot can never cause a re-baseline off an already-surged state.
 func (u *UnitedDeploymentWrapper) SetReplicas(newTotal int32) {
-	u.obj = u.obj.DeepCopy() // don't mutate the cache
-
 	snap, ok := u.readSnapshot()
 	if !ok {
-		snap = u.captureSnapshot()
-		u.writeSnapshot(snap)
+		// PrepareSurge must run first. Refuse to surge without a baseline rather
+		// than capturing one from a possibly-already-surged object.
+		return
 	}
+	u.obj = u.obj.DeepCopy() // don't mutate the cache
 
 	delta := newTotal - snap.Total
 	total := newTotal
@@ -104,14 +143,36 @@ func (u *UnitedDeploymentWrapper) SetReplicas(newTotal int32) {
 	}
 }
 
+// PrepareSurge captures the pre-surge topology snapshot on first surge, applying
+// the safety guards that make the surge correct and reversible. It must be called
+// before SetReplicas. Returns:
+//   - errStatusNotConverged when status.subsetReplicas has not caught up to
+//     spec.replicas (surging now could scale a healthy subset down);
+//   - errSnapshotLostDuringSurge when a surge is already active but the snapshot
+//     annotation is gone (re-capturing would baseline off the surged state).
+func (u *UnitedDeploymentWrapper) PrepareSurge() error {
+	u.obj = u.obj.DeepCopy()
+	if _, ok := u.readSnapshot(); ok {
+		return nil // snapshot already present — surge in flight, keep it
+	}
+	if u.hasAnnotation(EvictionSurgeReplicasAnnotationKey) {
+		return errSnapshotLostDuringSurge
+	}
+	if !u.isStatusConverged() {
+		return errStatusNotConverged
+	}
+	snap := u.captureSnapshot()
+	return u.writeSnapshot(snap)
+}
+
 // RestoreOriginal reverts the UD to its pre-surge topology using the snapshot,
 // then clears the snapshot annotation. No-op when nothing was snapshotted.
 func (u *UnitedDeploymentWrapper) RestoreOriginal() {
+	u.obj = u.obj.DeepCopy()
 	snap, ok := u.readSnapshot()
 	if !ok {
 		return
 	}
-	u.obj = u.obj.DeepCopy()
 
 	total := snap.Total
 	u.obj.Spec.Replicas = &total
@@ -129,6 +190,19 @@ func (u *UnitedDeploymentWrapper) RestoreOriginal() {
 		s.Replicas = &v
 	}
 	u.RemoveAnnotation(udSurgeSnapshotAnnotationKey)
+}
+
+// ForceScaleDown is a best-effort recovery when the topology snapshot is lost
+// while a surge is active: it lowers spec.replicas to the floor and drops the
+// absolute per-subset pins (nil) so the UnitedDeployment controller redistributes
+// — ensuring the UD is not left stuck at the surged replica count.
+func (u *UnitedDeploymentWrapper) ForceScaleDown(replicas int32) {
+	u.obj = u.obj.DeepCopy()
+	r := replicas
+	u.obj.Spec.Replicas = &r
+	for i := range u.obj.Spec.Topology.Subsets {
+		u.obj.Spec.Topology.Subsets[i].Replicas = nil
+	}
 }
 
 // captureSnapshot records the current topology + live per-subset counts.
@@ -216,12 +290,23 @@ func (u *UnitedDeploymentWrapper) readSnapshot() (udSurgeSnapshot, bool) {
 	return snap, true
 }
 
-func (u *UnitedDeploymentWrapper) writeSnapshot(snap udSurgeSnapshot) {
+func (u *UnitedDeploymentWrapper) writeSnapshot(snap udSurgeSnapshot) error {
 	b, err := json.Marshal(snap)
 	if err != nil {
-		return
+		// Do not swallow: a lost snapshot would silently disable revert.
+		return fmt.Errorf("marshalling UnitedDeployment surge snapshot: %w", err)
 	}
 	u.AddAnnotation(udSurgeSnapshotAnnotationKey, string(b))
+	return nil
+}
+
+func (u *UnitedDeploymentWrapper) hasAnnotation(key string) bool {
+	ann := u.obj.GetAnnotations()
+	if ann == nil {
+		return false
+	}
+	_, ok := ann[key]
+	return ok
 }
 
 func (u *UnitedDeploymentWrapper) AddAnnotation(key, value string) {

--- a/internal/controller/ud_wrapper.go
+++ b/internal/controller/ud_wrapper.go
@@ -1,0 +1,214 @@
+package controllers
+
+import (
+	"encoding/json"
+
+	kruiseappsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const unitedDeploymentKind = "uniteddeployment"
+
+// SurgeSubsetAnnotationKey lets a workload owner choose which UnitedDeployment
+// subset absorbs the drain-time surge, i.e. WHERE the surge lands. Value is a
+// subset name (e.g. "regular" for on-demand, "spot" for spot capacity). When
+// absent, the wrapper defaults to the subset with the most current replicas.
+const SurgeSubsetAnnotationKey = "eviction-autoscaler.azure.com/surge-subset"
+
+// udSurgeSnapshotAnnotationKey stores the pre-surge UnitedDeployment topology so
+// the exact original per-subset config (nil/remainder or "15%") and total can be
+// restored on revert. Single source of truth for restore; also makes ApplySurge
+// idempotent (surge amounts are always computed from the snapshot baseline).
+const udSurgeSnapshotAnnotationKey = "eviction-autoscaler.azure.com/ud-surge-snapshot"
+
+// udSurgeSnapshot is the JSON captured on the UD at first surge.
+type udSurgeSnapshot struct {
+	Total       int32            `json:"total"`          // original spec.replicas
+	Original    map[string]string `json:"original"`      // subset name -> original .Replicas ("" == nil/remainder)
+	Baseline    map[string]int32 `json:"baseline"`       // subset name -> live replicas at snapshot (from status)
+	SurgeSubset string           `json:"surgeSubset"`    // subset chosen to absorb the surge
+}
+
+// UnitedDeploymentWrapper adapts an OpenKruise UnitedDeployment to the Surger
+// interface. Surging a UD by scaling its child Deployment directly does not work
+// — the UD controller reverts it — so we surge through the UD's own spec: raise
+// spec.replicas and route the delta to a chosen subset (pinning the others to
+// absolute counts so percentage subsets don't grow with the new total). The UD
+// controller then propagates the surge and does not fight it.
+type UnitedDeploymentWrapper struct {
+	obj *kruiseappsv1alpha1.UnitedDeployment
+}
+
+var _ Surger = &UnitedDeploymentWrapper{}
+
+func (u *UnitedDeploymentWrapper) Obj() client.Object {
+	return u.obj
+}
+
+// GetReplicas returns the UD's total desired replicas (spec.replicas).
+func (u *UnitedDeploymentWrapper) GetReplicas() int32 {
+	if u.obj.Spec.Replicas == nil {
+		return 1
+	}
+	return *u.obj.Spec.Replicas
+}
+
+// GetMaxSurge reads the maxSurge from the UD's deploymentTemplate rolling-update
+// strategy (the same knob a plain Deployment uses). Defaults to 0 when unset.
+func (u *UnitedDeploymentWrapper) GetMaxSurge() intstr.IntOrString {
+	dt := u.obj.Spec.Template.DeploymentTemplate
+	if dt != nil && dt.Spec.Strategy.RollingUpdate != nil && dt.Spec.Strategy.RollingUpdate.MaxSurge != nil {
+		return *dt.Spec.Strategy.RollingUpdate.MaxSurge
+	}
+	return intstr.FromInt(0)
+}
+
+// SetReplicas surges the UD to a new total by routing the delta onto the chosen
+// surge subset. It snapshots the original topology on first call (so revert can
+// restore it) and is idempotent: the surge amount is always derived from the
+// snapshot baseline, so re-applying the same total yields the same spec.
+func (u *UnitedDeploymentWrapper) SetReplicas(newTotal int32) {
+	u.obj = u.obj.DeepCopy() // don't mutate the cache
+
+	snap, ok := u.readSnapshot()
+	if !ok {
+		snap = u.captureSnapshot()
+		u.writeSnapshot(snap)
+	}
+
+	delta := newTotal - snap.Total
+	total := newTotal
+	u.obj.Spec.Replicas = &total
+
+	// Pin every subset to an absolute count; the surge subset additionally
+	// carries the delta. Absolute values make the totals reconcile exactly and
+	// stop percentage/remainder subsets from drifting with the new total.
+	for i := range u.obj.Spec.Topology.Subsets {
+		s := &u.obj.Spec.Topology.Subsets[i]
+		base, hasBase := snap.Baseline[s.Name]
+		if !hasBase {
+			continue
+		}
+		want := base
+		if s.Name == snap.SurgeSubset {
+			want = base + delta
+		}
+		v := intstr.FromInt(int(want))
+		s.Replicas = &v
+	}
+}
+
+// RestoreOriginal reverts the UD to its pre-surge topology using the snapshot,
+// then clears the snapshot annotation. No-op when nothing was snapshotted.
+func (u *UnitedDeploymentWrapper) RestoreOriginal() {
+	snap, ok := u.readSnapshot()
+	if !ok {
+		return
+	}
+	u.obj = u.obj.DeepCopy()
+
+	total := snap.Total
+	u.obj.Spec.Replicas = &total
+	for i := range u.obj.Spec.Topology.Subsets {
+		s := &u.obj.Spec.Topology.Subsets[i]
+		orig, hasOrig := snap.Original[s.Name]
+		if !hasOrig {
+			continue
+		}
+		if orig == "" {
+			s.Replicas = nil // controller-managed remainder
+			continue
+		}
+		v := intstr.Parse(orig)
+		s.Replicas = &v
+	}
+	u.RemoveAnnotation(udSurgeSnapshotAnnotationKey)
+}
+
+// captureSnapshot records the current topology + live per-subset counts.
+func (u *UnitedDeploymentWrapper) captureSnapshot() udSurgeSnapshot {
+	snap := udSurgeSnapshot{
+		Total:    u.GetReplicas(),
+		Original: map[string]string{},
+		Baseline: map[string]int32{},
+	}
+	for _, s := range u.obj.Spec.Topology.Subsets {
+		if s.Replicas == nil {
+			snap.Original[s.Name] = ""
+		} else {
+			snap.Original[s.Name] = s.Replicas.String()
+		}
+	}
+	// Live per-subset counts come from status.subsetReplicas.
+	for name, n := range u.obj.Status.SubsetReplicas {
+		snap.Baseline[name] = n
+	}
+	// Fallback: any subset missing from status baselines gets 0 so it is still pinned.
+	for _, s := range u.obj.Spec.Topology.Subsets {
+		if _, ok := snap.Baseline[s.Name]; !ok {
+			snap.Baseline[s.Name] = 0
+		}
+	}
+	snap.SurgeSubset = u.resolveSurgeSubset(snap.Baseline)
+	return snap
+}
+
+// resolveSurgeSubset picks the subset that absorbs the surge: an explicit
+// surge-subset annotation if valid, otherwise the subset with the most current
+// replicas (the dominant, typically on-demand, subset).
+func (u *UnitedDeploymentWrapper) resolveSurgeSubset(baseline map[string]int32) string {
+	if ann := u.obj.GetAnnotations(); ann != nil {
+		if want := ann[SurgeSubsetAnnotationKey]; want != "" {
+			for _, s := range u.obj.Spec.Topology.Subsets {
+				if s.Name == want {
+					return want
+				}
+			}
+		}
+	}
+	best, bestN := "", int32(-1)
+	for _, s := range u.obj.Spec.Topology.Subsets {
+		if n := baseline[s.Name]; n > bestN {
+			best, bestN = s.Name, n
+		}
+	}
+	return best
+}
+
+func (u *UnitedDeploymentWrapper) readSnapshot() (udSurgeSnapshot, bool) {
+	ann := u.obj.GetAnnotations()
+	if ann == nil {
+		return udSurgeSnapshot{}, false
+	}
+	raw, ok := ann[udSurgeSnapshotAnnotationKey]
+	if !ok || raw == "" {
+		return udSurgeSnapshot{}, false
+	}
+	var snap udSurgeSnapshot
+	if err := json.Unmarshal([]byte(raw), &snap); err != nil {
+		return udSurgeSnapshot{}, false
+	}
+	return snap, true
+}
+
+func (u *UnitedDeploymentWrapper) writeSnapshot(snap udSurgeSnapshot) {
+	b, err := json.Marshal(snap)
+	if err != nil {
+		return
+	}
+	u.AddAnnotation(udSurgeSnapshotAnnotationKey, string(b))
+}
+
+func (u *UnitedDeploymentWrapper) AddAnnotation(key, value string) {
+	if u.obj.Annotations == nil {
+		u.obj.Annotations = make(map[string]string)
+	}
+	u.obj.Annotations[key] = value
+}
+
+func (u *UnitedDeploymentWrapper) RemoveAnnotation(key string) {
+	if u.obj.Annotations != nil {
+		delete(u.obj.Annotations, key)
+	}
+}

--- a/internal/controller/ud_wrapper.go
+++ b/internal/controller/ud_wrapper.go
@@ -38,6 +38,11 @@ type udSurgeSnapshot struct {
 // controller then propagates the surge and does not fight it.
 type UnitedDeploymentWrapper struct {
 	obj *kruiseappsv1alpha1.UnitedDeployment
+	// preferredSurgeSubset is the subset whose pods are being displaced by the
+	// current drain (the subset the reconciler computed from pods on cordoned
+	// nodes). It is the default landing subset unless overridden by the
+	// surge-subset annotation. Empty when the reconciler could not determine it.
+	preferredSurgeSubset string
 }
 
 var _ Surger = &UnitedDeploymentWrapper{}
@@ -154,18 +159,28 @@ func (u *UnitedDeploymentWrapper) captureSnapshot() udSurgeSnapshot {
 	return snap
 }
 
-// resolveSurgeSubset picks the subset that absorbs the surge: an explicit
-// surge-subset annotation if valid, otherwise the subset with the most current
-// replicas (the dominant, typically on-demand, subset).
+// SetPreferredSurgeSubset records the drain-displaced subset so it becomes the
+// default landing subset for the surge (still overridable by the surge-subset
+// annotation). Ignored once a snapshot already exists, so an in-flight surge
+// keeps its originally chosen subset.
+func (u *UnitedDeploymentWrapper) SetPreferredSurgeSubset(name string) {
+	u.preferredSurgeSubset = name
+}
+
+// resolveSurgeSubset picks the subset that absorbs the surge, in priority order:
+// (1) an explicit, valid surge-subset annotation (operator override, e.g. route
+// to spot for cost); (2) the drain-displaced subset the reconciler detected;
+// (3) fallback to the subset with the most current replicas (dominant).
 func (u *UnitedDeploymentWrapper) resolveSurgeSubset(baseline map[string]int32) string {
 	if ann := u.obj.GetAnnotations(); ann != nil {
 		if want := ann[SurgeSubsetAnnotationKey]; want != "" {
-			for _, s := range u.obj.Spec.Topology.Subsets {
-				if s.Name == want {
-					return want
-				}
+			if u.hasSubset(want) {
+				return want
 			}
 		}
+	}
+	if u.preferredSurgeSubset != "" && u.hasSubset(u.preferredSurgeSubset) {
+		return u.preferredSurgeSubset
 	}
 	best, bestN := "", int32(-1)
 	for _, s := range u.obj.Spec.Topology.Subsets {
@@ -174,6 +189,15 @@ func (u *UnitedDeploymentWrapper) resolveSurgeSubset(baseline map[string]int32) 
 		}
 	}
 	return best
+}
+
+func (u *UnitedDeploymentWrapper) hasSubset(name string) bool {
+	for _, s := range u.obj.Spec.Topology.Subsets {
+		if s.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (u *UnitedDeploymentWrapper) readSnapshot() (udSurgeSnapshot, bool) {

--- a/internal/controller/ud_wrapper_test.go
+++ b/internal/controller/ud_wrapper_test.go
@@ -1,0 +1,132 @@
+package controllers
+
+import (
+	"testing"
+
+	kruiseappsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// makeTestUD builds a UD matching the spot experiment: total 112, regular subset
+// with implicit remainder (nil replicas -> 95), spot subset "15%" (-> 17), a
+// deploymentTemplate maxSurge of 10%, and live per-subset counts in status.
+func makeTestUD() *kruiseappsv1alpha1.UnitedDeployment {
+	total := int32(112)
+	spotPct := intstr.FromString("15%")
+	maxSurge := intstr.FromString("10%")
+	return &kruiseappsv1alpha1.UnitedDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "spot-app", Namespace: "spot-exp"},
+		Spec: kruiseappsv1alpha1.UnitedDeploymentSpec{
+			Replicas: &total,
+			Topology: kruiseappsv1alpha1.Topology{
+				Subsets: []kruiseappsv1alpha1.Subset{
+					{Name: "regular"}, // nil replicas -> remainder
+					{Name: "spot", Replicas: &spotPct},
+				},
+			},
+			Template: kruiseappsv1alpha1.SubsetTemplate{
+				DeploymentTemplate: &kruiseappsv1alpha1.DeploymentTemplateSpec{
+					Spec: appsv1.DeploymentSpec{
+						Strategy: appsv1.DeploymentStrategy{
+							RollingUpdate: &appsv1.RollingUpdateDeployment{MaxSurge: &maxSurge},
+						},
+					},
+				},
+			},
+		},
+		Status: kruiseappsv1alpha1.UnitedDeploymentStatus{
+			SubsetReplicas: map[string]int32{"regular": 95, "spot": 17},
+		},
+	}
+}
+
+func subsetRepl(ud *kruiseappsv1alpha1.UnitedDeployment, name string) *intstr.IntOrString {
+	for i := range ud.Spec.Topology.Subsets {
+		if ud.Spec.Topology.Subsets[i].Name == name {
+			return ud.Spec.Topology.Subsets[i].Replicas
+		}
+	}
+	return nil
+}
+
+func TestUDWrapper_SurgeDefaultSubsetIsDominant(t *testing.T) {
+	w := &UnitedDeploymentWrapper{obj: makeTestUD()}
+	w.SetReplicas(118) // surge total by 6
+
+	ud := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
+	if *ud.Spec.Replicas != 118 {
+		t.Fatalf("spec.replicas = %d, want 118", *ud.Spec.Replicas)
+	}
+	// Default surge subset is the dominant one (regular, 95 baseline).
+	if r := subsetRepl(ud, "regular"); r == nil || r.IntValue() != 101 {
+		t.Fatalf("regular replicas = %v, want 101", r)
+	}
+	// Other subsets pinned to their absolute baseline.
+	if s := subsetRepl(ud, "spot"); s == nil || s.IntValue() != 17 {
+		t.Fatalf("spot replicas = %v, want 17", s)
+	}
+}
+
+func TestUDWrapper_SurgeSubsetAnnotationRoutesToSpot(t *testing.T) {
+	ud := makeTestUD()
+	ud.Annotations = map[string]string{SurgeSubsetAnnotationKey: "spot"}
+	w := &UnitedDeploymentWrapper{obj: ud}
+	w.SetReplicas(118) // surge by 6, onto spot
+
+	got := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
+	if *got.Spec.Replicas != 118 {
+		t.Fatalf("spec.replicas = %d, want 118", *got.Spec.Replicas)
+	}
+	if s := subsetRepl(got, "spot"); s == nil || s.IntValue() != 23 {
+		t.Fatalf("spot replicas = %v, want 23", s)
+	}
+	if r := subsetRepl(got, "regular"); r == nil || r.IntValue() != 95 {
+		t.Fatalf("regular replicas = %v, want 95", r)
+	}
+}
+
+func TestUDWrapper_RestoreOriginalTopology(t *testing.T) {
+	w := &UnitedDeploymentWrapper{obj: makeTestUD()}
+	w.SetReplicas(118)
+	w.RestoreOriginal()
+
+	ud := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
+	if *ud.Spec.Replicas != 112 {
+		t.Fatalf("restored spec.replicas = %d, want 112", *ud.Spec.Replicas)
+	}
+	// regular returns to nil (controller-managed remainder).
+	if r := subsetRepl(ud, "regular"); r != nil {
+		t.Fatalf("regular replicas = %v, want nil (remainder)", r)
+	}
+	// spot returns to the original "15%".
+	if s := subsetRepl(ud, "spot"); s == nil || s.String() != "15%" {
+		t.Fatalf("spot replicas = %v, want \"15%%\"", s)
+	}
+	// Snapshot annotation cleared.
+	if _, ok := ud.Annotations[udSurgeSnapshotAnnotationKey]; ok {
+		t.Fatalf("snapshot annotation should be removed after restore")
+	}
+}
+
+func TestUDWrapper_SurgeIsIdempotent(t *testing.T) {
+	w := &UnitedDeploymentWrapper{obj: makeTestUD()}
+	w.SetReplicas(118)
+	w.SetReplicas(118) // re-apply same surge
+
+	ud := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
+	if *ud.Spec.Replicas != 118 {
+		t.Fatalf("spec.replicas = %d, want 118", *ud.Spec.Replicas)
+	}
+	if r := subsetRepl(ud, "regular"); r == nil || r.IntValue() != 101 {
+		t.Fatalf("regular replicas after re-apply = %v, want 101", r)
+	}
+}
+
+func TestUDWrapper_GetMaxSurgeFromDeploymentTemplate(t *testing.T) {
+	w := &UnitedDeploymentWrapper{obj: makeTestUD()}
+	if ms := w.GetMaxSurge(); ms.String() != "10%" {
+		t.Fatalf("GetMaxSurge = %v, want \"10%%\"", ms)
+	}
+}

--- a/internal/controller/ud_wrapper_test.go
+++ b/internal/controller/ud_wrapper_test.go
@@ -51,9 +51,19 @@ func subsetRepl(ud *kruiseappsv1alpha1.UnitedDeployment, name string) *intstr.In
 	return nil
 }
 
+// mustSurge runs the PrepareSurge -> SetReplicas contract, failing the test if
+// the snapshot guard rejects the surge.
+func mustSurge(t *testing.T, w *UnitedDeploymentWrapper, newTotal int32) {
+	t.Helper()
+	if err := w.PrepareSurge(); err != nil {
+		t.Fatalf("PrepareSurge failed: %v", err)
+	}
+	w.SetReplicas(newTotal)
+}
+
 func TestUDWrapper_SurgeDefaultSubsetIsDominant(t *testing.T) {
 	w := &UnitedDeploymentWrapper{obj: makeTestUD()}
-	w.SetReplicas(118) // surge total by 6
+	mustSurge(t, w, 118) // surge total by 6
 
 	ud := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
 	if *ud.Spec.Replicas != 118 {
@@ -73,7 +83,7 @@ func TestUDWrapper_SurgeSubsetAnnotationRoutesToSpot(t *testing.T) {
 	ud := makeTestUD()
 	ud.Annotations = map[string]string{SurgeSubsetAnnotationKey: "spot"}
 	w := &UnitedDeploymentWrapper{obj: ud}
-	w.SetReplicas(118) // surge by 6, onto spot
+	mustSurge(t, w, 118) // surge by 6, onto spot
 
 	got := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
 	if *got.Spec.Replicas != 118 {
@@ -89,7 +99,7 @@ func TestUDWrapper_SurgeSubsetAnnotationRoutesToSpot(t *testing.T) {
 
 func TestUDWrapper_RestoreOriginalTopology(t *testing.T) {
 	w := &UnitedDeploymentWrapper{obj: makeTestUD()}
-	w.SetReplicas(118)
+	mustSurge(t, w, 118)
 	w.RestoreOriginal()
 
 	ud := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
@@ -112,8 +122,8 @@ func TestUDWrapper_RestoreOriginalTopology(t *testing.T) {
 
 func TestUDWrapper_SurgeIsIdempotent(t *testing.T) {
 	w := &UnitedDeploymentWrapper{obj: makeTestUD()}
-	w.SetReplicas(118)
-	w.SetReplicas(118) // re-apply same surge
+	mustSurge(t, w, 118)
+	w.SetReplicas(118) // re-apply same surge (snapshot already present)
 
 	ud := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
 	if *ud.Spec.Replicas != 118 {
@@ -134,7 +144,7 @@ func TestUDWrapper_GetMaxSurgeFromDeploymentTemplate(t *testing.T) {
 func TestUDWrapper_SurgeDefaultsToPreferredDisplacedSubset(t *testing.T) {
 	w := &UnitedDeploymentWrapper{obj: makeTestUD()}
 	w.SetPreferredSurgeSubset("spot") // drain is displacing spot pods
-	w.SetReplicas(118)                // surge by 6
+	mustSurge(t, w, 118)              // surge by 6
 
 	ud := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
 	// Surge lands on the displaced (spot) subset, not the dominant (regular) one.
@@ -151,7 +161,7 @@ func TestUDWrapper_AnnotationOverridesPreferredSubset(t *testing.T) {
 	ud.Annotations = map[string]string{SurgeSubsetAnnotationKey: "regular"}
 	w := &UnitedDeploymentWrapper{obj: ud}
 	w.SetPreferredSurgeSubset("spot") // displaced subset is spot...
-	w.SetReplicas(118)                // ...but annotation forces regular
+	mustSurge(t, w, 118)              // ...but annotation forces regular
 
 	got := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
 	if r := subsetRepl(got, "regular"); r == nil || r.IntValue() != 101 {
@@ -159,5 +169,80 @@ func TestUDWrapper_AnnotationOverridesPreferredSubset(t *testing.T) {
 	}
 	if s := subsetRepl(got, "spot"); s == nil || s.IntValue() != 17 {
 		t.Fatalf("spot replicas = %v, want 17", s)
+	}
+}
+
+// A surge-subset annotation naming a nonexistent subset is ignored; selection
+// falls back to the preferred/dominant subset.
+func TestUDWrapper_InvalidAnnotationFallsBack(t *testing.T) {
+	ud := makeTestUD()
+	ud.Annotations = map[string]string{SurgeSubsetAnnotationKey: "does-not-exist"}
+	w := &UnitedDeploymentWrapper{obj: ud}
+	mustSurge(t, w, 118)
+
+	got := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
+	// Falls back to dominant (regular).
+	if r := subsetRepl(got, "regular"); r == nil || r.IntValue() != 101 {
+		t.Fatalf("regular replicas = %v, want 101 (dominant fallback)", r)
+	}
+}
+
+// GetReplicas must derive the total from status when spec.replicas is nil, not
+// default to 1 (which would massively over-provision the surge subset).
+func TestUDWrapper_GetReplicasNilSpecUsesStatusSum(t *testing.T) {
+	ud := makeTestUD()
+	ud.Spec.Replicas = nil // Kruise allows nil; total lives in status
+	w := &UnitedDeploymentWrapper{obj: ud}
+	if got := w.GetReplicas(); got != 112 {
+		t.Fatalf("GetReplicas() with nil spec.replicas = %d, want 112 (status sum)", got)
+	}
+}
+
+// PrepareSurge must refuse to snapshot when status has not converged with spec,
+// so a lagging subset is never pinned below its true count.
+func TestUDWrapper_PrepareSurgeRefusesWhenStatusNotConverged(t *testing.T) {
+	ud := makeTestUD()
+	ud.Status.SubsetReplicas = map[string]int32{"regular": 40, "spot": 17} // sum 57 != 112
+	w := &UnitedDeploymentWrapper{obj: ud}
+	if err := w.PrepareSurge(); err != errStatusNotConverged {
+		t.Fatalf("PrepareSurge err = %v, want errStatusNotConverged", err)
+	}
+}
+
+// PrepareSurge must refuse to re-capture a snapshot when a surge is already
+// active but the snapshot was lost (else it would baseline off the surged state).
+func TestUDWrapper_PrepareSurgeRefusesWhenSnapshotLost(t *testing.T) {
+	ud := makeTestUD()
+	ud.Annotations = map[string]string{EvictionSurgeReplicasAnnotationKey: "118"} // surge marker, no snapshot
+	w := &UnitedDeploymentWrapper{obj: ud}
+	if err := w.PrepareSurge(); err != errSnapshotLostDuringSurge {
+		t.Fatalf("PrepareSurge err = %v, want errSnapshotLostDuringSurge", err)
+	}
+}
+
+// SetReplicas without a prior snapshot is a no-op (guards against re-baseline).
+func TestUDWrapper_SetReplicasNoopWithoutSnapshot(t *testing.T) {
+	w := &UnitedDeploymentWrapper{obj: makeTestUD()}
+	w.SetReplicas(118) // no PrepareSurge
+
+	ud := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
+	if *ud.Spec.Replicas != 112 {
+		t.Fatalf("spec.replicas = %d, want 112 (unchanged)", *ud.Spec.Replicas)
+	}
+}
+
+// ForceScaleDown lowers the total to the floor and drops absolute subset pins.
+func TestUDWrapper_ForceScaleDown(t *testing.T) {
+	w := &UnitedDeploymentWrapper{obj: makeTestUD()}
+	w.ForceScaleDown(100)
+
+	ud := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
+	if *ud.Spec.Replicas != 100 {
+		t.Fatalf("spec.replicas = %d, want 100", *ud.Spec.Replicas)
+	}
+	for _, s := range ud.Spec.Topology.Subsets {
+		if s.Replicas != nil {
+			t.Fatalf("subset %s replicas = %v, want nil after ForceScaleDown", s.Name, s.Replicas)
+		}
 	}
 }

--- a/internal/controller/ud_wrapper_test.go
+++ b/internal/controller/ud_wrapper_test.go
@@ -130,3 +130,34 @@ func TestUDWrapper_GetMaxSurgeFromDeploymentTemplate(t *testing.T) {
 		t.Fatalf("GetMaxSurge = %v, want \"10%%\"", ms)
 	}
 }
+
+func TestUDWrapper_SurgeDefaultsToPreferredDisplacedSubset(t *testing.T) {
+	w := &UnitedDeploymentWrapper{obj: makeTestUD()}
+	w.SetPreferredSurgeSubset("spot") // drain is displacing spot pods
+	w.SetReplicas(118)                // surge by 6
+
+	ud := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
+	// Surge lands on the displaced (spot) subset, not the dominant (regular) one.
+	if s := subsetRepl(ud, "spot"); s == nil || s.IntValue() != 23 {
+		t.Fatalf("spot replicas = %v, want 23", s)
+	}
+	if r := subsetRepl(ud, "regular"); r == nil || r.IntValue() != 95 {
+		t.Fatalf("regular replicas = %v, want 95", r)
+	}
+}
+
+func TestUDWrapper_AnnotationOverridesPreferredSubset(t *testing.T) {
+	ud := makeTestUD()
+	ud.Annotations = map[string]string{SurgeSubsetAnnotationKey: "regular"}
+	w := &UnitedDeploymentWrapper{obj: ud}
+	w.SetPreferredSurgeSubset("spot") // displaced subset is spot...
+	w.SetReplicas(118)                // ...but annotation forces regular
+
+	got := w.Obj().(*kruiseappsv1alpha1.UnitedDeployment)
+	if r := subsetRepl(got, "regular"); r == nil || r.IntValue() != 101 {
+		t.Fatalf("regular replicas = %v, want 101", r)
+	}
+	if s := subsetRepl(got, "spot"); s == nil || s.IntValue() != 17 {
+		t.Fatalf("spot replicas = %v, want 17", s)
+	}
+}

--- a/internal/controller/wrappers.go
+++ b/internal/controller/wrappers.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"fmt"
 
+	kruiseappsv1alpha1 "github.com/openkruise/kruise-api/apps/v1alpha1"
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -101,6 +102,8 @@ func GetSurger(kind string) (Surger, error) {
 		return &DeploymentWrapper{obj: &v1.Deployment{}}, nil
 	} else if kind == statefulSetKind {
 		return &StatefulSetWrapper{obj: &v1.StatefulSet{}}, nil
+	} else if kind == unitedDeploymentKind {
+		return &UnitedDeploymentWrapper{obj: &kruiseappsv1alpha1.UnitedDeployment{}}, nil
 	} else {
 		return nil, fmt.Errorf("unknown target kind %s", kind) //be good to enforce this with admission policy
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -132,6 +132,17 @@ var (
 		},
 		[]string{"namespace", "created_by_us"},
 	)
+
+	// UnitedDeploymentSurgeFailureCounter tracks UnitedDeployment surge/revert
+	// failures that are handled without a hard error (snapshot guards, lost
+	// snapshot on revert). Labels: namespace, reason.
+	UnitedDeploymentSurgeFailureCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "eviction_autoscaler_uniteddeployment_surge_failures_total",
+			Help: "Total number of UnitedDeployment surge/revert failures by reason",
+		},
+		[]string{"namespace", "reason"},
+	)
 )
 
 // Constants for PDB creation tracking
@@ -201,5 +212,6 @@ func init() {
 		NodeCordoningCounter,
 		PDBInfoGauge,
 		PDBCounter,
+		UnitedDeploymentSurgeFailureCounter,
 	)
 }


### PR DESCRIPTION
## Summary

Adds OpenKruise **UnitedDeployment** support to the eviction-autoscaler surge path. When PDB-protected pods belong to a UnitedDeployment, the controller now surges the UnitedDeployment's own `spec.replicas` (routing the delta to a chosen subset) instead of the child Deployment ? which the UD controller would otherwise revert.

## What changed

- **Target resolution** (`pdb_to_evictionautoscaler_controller.go`): `discoverDeployment` now walks pod ? ReplicaSet ? Deployment ? **UnitedDeployment** owner refs and returns the resolved kind. EvictionAutoScaler CR + PDB owner-ref are set to the UD when applicable.
- **UnitedDeploymentWrapper** (`ud_wrapper.go`) + **UnitedDeploymentSurgeApplier** (`ud_surge_applier.go`): surge via UD spec, snapshot original per-subset topology for exact revert, idempotent.
- **Subset selection**: `surge-subset` annotation override > drain-displaced subset (pods on cordoned nodes) > dominant subset fallback.
- Kruise scheme registration (`cmd/main.go`), RBAC markers + `role.yaml`, README section.

## Testing

- 7 UD unit tests (subset selection, snapshot/restore, idempotency, maxSurge).
- Full existing controller suite passes (no regressions to Deployment/HPA/KEDA paths).
- Live-validated on an AKS cluster with a spot/on-demand UnitedDeployment.

## Follow-ups (out of scope)

- Orphan protection (finalizer + stale-window backstop) ? kept consistent with existing appliers, none of which have it today.
- envtest coverage with a vendored kruise CRD.

## Prerequisite

OpenKruise must be installed (UnitedDeployment CRD present).
