### PR TITLE
Add install-configurable zero-maxSurge override

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ az k8s-extension create \
 - `controllerConfig.pdb.create=true` - Automatically creates PDBs for deployments (default: false)
 - `controllerConfig.namespaces.enabledByDefault=true` - Enables all namespaces (default: false, opt-in mode)
 - `controllerConfig.namespaces.actionedNamespaces` - List of namespaces to enable when using opt-in mode (default: [kube-system])
+- `controllerConfig.surgeOverride.maxPercent` - Fleet-wide, install-time percent used to override a zero drain-time surge (default: 0, disabled). See [Zero-maxSurge override](#zero-maxsurge-override) below.
 
 **Common Configuration Combinations:**
 
@@ -239,6 +240,57 @@ If you want a PDB for such a deployment, you can either:
 - Manually create and manage the PDB yourself
 
 This behavior applies to both integer values (`maxUnavailable: 1`) and percentage values (`maxUnavailable: 25%`). Only deployments with `maxUnavailable: 0` or `maxUnavailable: 0%` will automatically get PDBs created.
+
+### Zero-maxSurge Override
+
+During a drain, eviction-autoscaler surges a workload by its rollout `maxSurge` so evicted pods have somewhere to land. When a workload's `maxSurge` resolves to `0` — an explicit `maxSurge: 0`, a `Recreate` strategy, or an unset `RollingUpdate` — there is no headroom to surge and the controller degrades instead of scaling up.
+
+The **zero-maxSurge override** is a fleet-wide, install-time knob that lets the controller surge such workloads anyway. It is controlled by a single percent value and is **disabled by default**:
+
+- `controllerConfig.surgeOverride.maxPercent` (env `SURGE_OVERRIDE_MAX_PERCENT`) — a positive integer percent. Default `0` (disabled).
+
+When set to a positive percent, any workload whose `maxSurge` resolves to `0` is surged during a drain by `ceil(maxPercent × minReplicas / 100)` replicas (floored at 1) instead of degrading. Workloads with a non-zero `maxSurge` are never affected — the override only supplies a ceiling where there was none, and never caps an admission-validated `maxSurge`. Left at `0`, the controller keeps today's behavior and degrades on a zero `maxSurge`.
+
+For example, to surge zero-`maxSurge` workloads by 25% of their min replicas during a drain:
+
+```bash
+az k8s-extension create \
+    ... \
+    --configuration-settings controllerConfig.surgeOverride.maxPercent=25
+```
+
+#### How the surge amount is computed
+
+During a drain the controller raises the workload's replica ceiling to `minReplicas + surge`, where:
+
+- For a **non-zero `maxSurge`**, `surge` is the workload's own `maxSurge` (an integer is used as-is; a percentage is `ceil(maxSurge% × minReplicas / 100)`). The override never touches these workloads.
+- For a **zero `maxSurge`** with the override enabled, `surge = ceil(maxPercent × minReplicas / 100)`, floored at `1` so at least one extra pod is always added.
+
+Worked examples with `maxPercent = 25`:
+
+| Workload `maxSurge` | `minReplicas` | Override applies? | Surge added | Scaled-up target |
+|---|---|---|---|---|
+| `2` (integer)   | 10 | no  | 2 (workload's own) | 12 |
+| `50%`           | 10 | no  | 5 (`ceil(50% × 10)`) | 15 |
+| `0`             | 20 | yes | 5 (`ceil(25% × 20)`) | 25 |
+| `0`             | 10 | yes | 3 (`ceil(25% × 10) = 2.5 → 3`) | 13 |
+| `0`             | 1  | yes | 1 (`ceil(25% × 1) = 0.25 → 1`, floored) | 2 |
+| `Recreate` / unset `RollingUpdate` | 8 | yes | 2 (`ceil(25% × 8)`) | 10 |
+| `0`             | 20 | **no** (`maxPercent=0`) | — (degrades, no scale-up) | — |
+
+How `maxPercent` changes the surge for a `maxSurge: 0` workload with `minReplicas = 12`:
+
+| `maxPercent` | Surge added | Scaled-up target |
+|---|---|---|
+| `0`   | disabled — controller degrades | — |
+| `10`  | 2 (`ceil(10% × 12) = 1.2 → 2`) | 14 |
+| `25`  | 3 (`ceil(25% × 12) = 3.0`) | 15 |
+| `50`  | 6 (`ceil(50% × 12) = 6.0`) | 18 |
+| `100` | 12 (`ceil(100% × 12)`) | 24 |
+
+The scaled-up replicas are reverted back to `minReplicas` once the drain completes and the PDB again allows disruptions.
+
+> **Note:** Optionally set `controllerConfig.eventRecording.enabled=true` (env `ENABLE_EVENT_RECORDING`) to emit a `DrainSurgeOverride` Kubernetes event whenever the override raises the surge ceiling for a workload.
 
 ### Namespace Control: enabled_by_default Configuration
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -47,6 +48,22 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
+
+// parseStrictBool reads a feature-flag env var that must be exactly "true", "false", or
+// unset (treated as false). Any other value fails fast so a typo like "yes" can't
+// silently disable a feature the operator believes is enabled.
+func parseStrictBool(name string) bool {
+	switch v := os.Getenv(name); v {
+	case "", "false":
+		return false
+	case "true":
+		return true
+	default:
+		setupLog.Error(fmt.Errorf("invalid value %q for %s (must be \"true\" or \"false\")", v, name), "invalid feature flag")
+		os.Exit(1)
+		return false // unreachable
+	}
+}
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -195,11 +212,42 @@ func main() {
 	}
 	setupLog.Info("PDB creation configuration", "pdbCreate", pdbCreate)
 
-	if err = (&controllers.EvictionAutoScalerReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Filter: nsfilter,
-	}).SetupWithManager(mgr); err != nil {
+	// Parse SURGE_OVERRIDE_MAX_PERCENT (default 0 = disabled). When set to a positive
+	// integer this opts the whole fleet in to the zero-maxSurge override: workloads whose
+	// maxSurge resolves to 0 (explicit maxSurge: 0, Recreate strategy, or unset) are surged
+	// by SURGE_OVERRIDE_MAX_PERCENT% of minReplicas during a drain instead of degrading.
+	// Left unset (0) the override is disabled, preserving prior behavior.
+	surgeOverrideMaxPercent := 0
+	if raw := os.Getenv("SURGE_OVERRIDE_MAX_PERCENT"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v <= 0 {
+			setupLog.Error(fmt.Errorf("invalid value %q for SURGE_OVERRIDE_MAX_PERCENT (must be a positive integer)", raw), "invalid surge override percent")
+			os.Exit(1)
+		}
+		surgeOverrideMaxPercent = v
+	}
+
+	// Parse ENABLE_EVENT_RECORDING (strict bool, default false). Wires the event recorder
+	// so features can emit Kubernetes events (e.g. DrainSurgeOverride). Off by default;
+	// structured logs + metrics remain the primary observability path.
+	eventRecordingEnabled := parseStrictBool("ENABLE_EVENT_RECORDING")
+
+	setupLog.Info("Surge override configuration",
+		"surgeOverrideMaxPercent", surgeOverrideMaxPercent,
+		"surgeOverrideEnabled", surgeOverrideMaxPercent > 0,
+		"eventRecordingEnabled", eventRecordingEnabled)
+
+	evictionAutoScalerReconciler := &controllers.EvictionAutoScalerReconciler{
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Filter:                  nsfilter,
+		SurgeOverrideMaxPercent: surgeOverrideMaxPercent,
+	}
+	if eventRecordingEnabled {
+		evictionAutoScalerReconciler.Recorder = mgr.GetEventRecorderFor("eviction-autoscaler")
+	}
+
+	if err = evictionAutoScalerReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EvictionAutoScaler")
 		os.Exit(1)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -220,9 +220,9 @@ func main() {
 	surgeOverrideMaxPercent := 0
 	if raw := os.Getenv("SURGE_OVERRIDE_MAX_PERCENT"); raw != "" {
 		v, err := strconv.Atoi(raw)
-		if err != nil || v <= 0 {
+		if err != nil || v < 0 {
 			setupLog.Error(
-				fmt.Errorf("invalid value %q for SURGE_OVERRIDE_MAX_PERCENT (must be a positive integer)", raw),
+				fmt.Errorf("invalid value %q for SURGE_OVERRIDE_MAX_PERCENT (must be a non-negative integer)", raw),
 				"invalid surge override percent")
 			os.Exit(1)
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -221,7 +221,9 @@ func main() {
 	if raw := os.Getenv("SURGE_OVERRIDE_MAX_PERCENT"); raw != "" {
 		v, err := strconv.Atoi(raw)
 		if err != nil || v <= 0 {
-			setupLog.Error(fmt.Errorf("invalid value %q for SURGE_OVERRIDE_MAX_PERCENT (must be a positive integer)", raw), "invalid surge override percent")
+			setupLog.Error(
+				fmt.Errorf("invalid value %q for SURGE_OVERRIDE_MAX_PERCENT (must be a positive integer)", raw),
+				"invalid surge override percent")
 			os.Exit(1)
 		}
 		surgeOverrideMaxPercent = v

--- a/helm/eviction-autoscaler/templates/deployment.yaml
+++ b/helm/eviction-autoscaler/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
             value: {{ .Values.controllerConfig.namespaces.enabledByDefault | quote }}
           - name: ACTIONED_NAMESPACES
             value: {{ join "," .Values.controllerConfig.namespaces.actionedNamespaces | quote }}
+          - name: SURGE_OVERRIDE_MAX_PERCENT
+            value: {{ .Values.controllerConfig.surgeOverride.maxPercent | quote }}
+          - name: ENABLE_EVENT_RECORDING
+            value: {{ .Values.controllerConfig.eventRecording.enabled | quote }}
         command:
         - /manager
         args:

--- a/helm/eviction-autoscaler/values.yaml
+++ b/helm/eviction-autoscaler/values.yaml
@@ -52,6 +52,22 @@ controllerConfig:
   pdb:
     create: true
 
+  # Drain-time surge override (fleet-wide, install-time opt-in)
+  surgeOverride:
+    # Percent of minReplicas used as the drain-time surge amount when a workload's rollout
+    # maxSurge resolves to 0 (explicit maxSurge: 0, a Recreate strategy, or an unset
+    # RollingUpdate). Set to a positive integer to opt the whole fleet in: such workloads
+    # are surged during a drain by ceil(maxPercent * minReplicas / 100) (floored at 1)
+    # instead of the controller degrading. Left at 0 (default) the override is disabled and
+    # the controller keeps today's behavior of degrading on a zero maxSurge.
+    maxPercent: 0
+
+  # Kubernetes event recording (install-time observability opt-in)
+  eventRecording:
+    # When true, the controller emits Kubernetes events (e.g. DrainSurgeOverride).
+    # Off by default; structured logs + metrics remain the primary observability path.
+    enabled: false
+
 
 
 # ServiceAccount annotations (for cloud integrations like IRSA, Workload Identity)

--- a/internal/controller/autoscaler_helpers_test.go
+++ b/internal/controller/autoscaler_helpers_test.go
@@ -82,8 +82,6 @@ var _ = Describe("ResolveMinReplicas", func() {
 })
 
 var _ = Describe("calculateSurge", func() {
-	ctx := context.Background()
-
 	makeTarget := func(surge intstr.IntOrString) Surger {
 		dep := &appsv1.Deployment{
 			Spec: appsv1.DeploymentSpec{
@@ -99,68 +97,129 @@ var _ = Describe("calculateSurge", func() {
 
 	It("adds an integer maxSurge to minReplicas", func() {
 		target := makeTarget(intstr.FromInt32(2))
-		result, err := calculateSurge(ctx, target, 3)
+		result, overridden, err := calculateSurge(target, 3, 0)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(overridden).To(BeFalse())
 		Expect(result).To(Equal(int32(5)))
 	})
 
 	It("returns errMaxSurgeZero when maxSurge is 0", func() {
 		target := makeTarget(intstr.FromInt32(0))
-		result, err := calculateSurge(ctx, target, 5)
+		result, overridden, err := calculateSurge(target, 5, 0)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
+		Expect(overridden).To(BeFalse())
 		Expect(result).To(Equal(int32(5)))
 	})
 
 	It("returns errMaxSurgeZero when no RollingUpdate strategy is set", func() {
 		dep := &appsv1.Deployment{}
 		target := &DeploymentWrapper{obj: dep}
-		result, err := calculateSurge(ctx, target, 4)
+		result, overridden, err := calculateSurge(target, 4, 0)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
+		Expect(overridden).To(BeFalse())
 		Expect(result).To(Equal(int32(4)))
 	})
 
 	It("computes 25% surge with ceiling (exact)", func() {
 		target := makeTarget(intstr.FromString("25%"))
 		// 4 * 25% = 1.0 → ceil(1.0) = 1 → 4+1 = 5
-		result, err := calculateSurge(ctx, target, 4)
+		result, overridden, err := calculateSurge(target, 4, 0)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(overridden).To(BeFalse())
 		Expect(result).To(Equal(int32(5)))
 	})
 
 	It("computes 25% surge with ceiling (fractional)", func() {
 		target := makeTarget(intstr.FromString("25%"))
 		// 3 * 25% = 0.75 → ceil(0.75) = 1 → 3+1 = 4
-		result, err := calculateSurge(ctx, target, 3)
+		result, overridden, err := calculateSurge(target, 3, 0)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(overridden).To(BeFalse())
 		Expect(result).To(Equal(int32(4)))
 	})
 
 	It("computes 50% surge with ceiling", func() {
 		target := makeTarget(intstr.FromString("50%"))
 		// 3 * 50% = 1.5 → ceil(1.5) = 2 → 3+2 = 5
-		result, err := calculateSurge(ctx, target, 3)
+		result, overridden, err := calculateSurge(target, 3, 0)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(overridden).To(BeFalse())
 		Expect(result).To(Equal(int32(5)))
 	})
 
 	It("computes 100% surge", func() {
 		target := makeTarget(intstr.FromString("100%"))
 		// 5 * 100% = 5 → ceil(5) = 5 → 5+5 = 10
-		result, err := calculateSurge(ctx, target, 5)
+		result, overridden, err := calculateSurge(target, 5, 0)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(overridden).To(BeFalse())
 		Expect(result).To(Equal(int32(10)))
 	})
 
 	It("returns errInvalidPercentage for invalid percentage string", func() {
 		target := makeTarget(intstr.FromString("abc%"))
-		_, err := calculateSurge(ctx, target, 3)
+		_, _, err := calculateSurge(target, 3, 0)
 		Expect(errors.Is(err, errInvalidPercentage)).To(BeTrue())
 	})
 
 	It("returns errMaxSurgeZero for 0% string", func() {
 		target := makeTarget(intstr.FromString("0%"))
-		result, err := calculateSurge(ctx, target, 3)
+		result, overridden, err := calculateSurge(target, 3, 0)
 		Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
+		Expect(overridden).To(BeFalse())
 		Expect(result).To(Equal(int32(3)))
+	})
+
+	Context("with SURGE_OVERRIDE_MAX_PERCENT set to a positive percent", func() {
+		It("overrides an integer maxSurge of 0 using the configured percent", func() {
+			target := makeTarget(intstr.FromInt32(0))
+			// 20 * 25% = 5 → ceil(5) = 5 → 20+5 = 25
+			result, overridden, err := calculateSurge(target, 20, 25)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overridden).To(BeTrue())
+			Expect(result).To(Equal(int32(25)))
+		})
+
+		It("overrides when no RollingUpdate strategy is set (Recreate/unset)", func() {
+			dep := &appsv1.Deployment{}
+			target := &DeploymentWrapper{obj: dep}
+			// 10 * 10% = 1 → 10+1 = 11
+			result, overridden, err := calculateSurge(target, 10, 10)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overridden).To(BeTrue())
+			Expect(result).To(Equal(int32(11)))
+		})
+
+		It("floors the override at 1 replica when the percent rounds to 0", func() {
+			target := makeTarget(intstr.FromInt32(0))
+			// 1 * 25% = 0.25 → ceil = 1 (floor) → 1+1 = 2
+			result, overridden, err := calculateSurge(target, 1, 25)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overridden).To(BeTrue())
+			Expect(result).To(Equal(int32(2)))
+		})
+
+		It("does not touch a non-zero maxSurge", func() {
+			target := makeTarget(intstr.FromInt32(2))
+			result, overridden, err := calculateSurge(target, 10, 25)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overridden).To(BeFalse())
+			Expect(result).To(Equal(int32(12)))
+		})
+
+		It("still surfaces an invalid percentage string rather than overriding", func() {
+			target := makeTarget(intstr.FromString("abc%"))
+			_, overridden, err := calculateSurge(target, 3, 25)
+			Expect(errors.Is(err, errInvalidPercentage)).To(BeTrue())
+			Expect(overridden).To(BeFalse())
+		})
+
+		It("does not override a zero maxSurge when the percent knob is 0 (disabled)", func() {
+			target := makeTarget(intstr.FromInt32(0))
+			result, overridden, err := calculateSurge(target, 20, 0)
+			Expect(errors.Is(err, errMaxSurgeZero)).To(BeTrue())
+			Expect(overridden).To(BeFalse())
+			Expect(result).To(Equal(int32(20)))
+		})
 	})
 })

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -313,7 +313,7 @@ func (r *EvictionAutoScalerReconciler) recordDrainSurgeOverride(ctx context.Cont
 		"surgeOverrideMaxPercent", r.SurgeOverrideMaxPercent, "maxSurgeTarget", maxSurgeTarget)
 	if r.Recorder != nil {
 		r.Recorder.Eventf(target.Obj(), corev1.EventTypeNormal, "DrainSurgeOverride",
-			"maxSurge resolved to 0; overriding drain-time surge to %d (%d%% of minReplicas %d)",
+			"maxSurge resolved to 0; overriding drain-time max replicas to %d (%d%% of minReplicas %d)",
 			maxSurgeTarget, r.SurgeOverrideMaxPercent, minReplicas)
 	}
 }

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -226,18 +226,8 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 		// The workload's maxSurge resolved to 0 and the fleet-wide override raised the
 		// drain-time ceiling. Surface it so operators can see we scaled a workload whose
-		// author pinned maxSurge: 0. The event only fires when ENABLE_EVENT_RECORDING wired
-		// a Recorder.
-		if overrideApplied {
-			logger.Info("Zero-maxSurge override raised drain-time surge ceiling",
-				"pdb", pdb.Name, "target", EvictionAutoScaler.Spec.TargetName,
-				"surgeOverrideMaxPercent", r.SurgeOverrideMaxPercent, "maxSurgeTarget", maxSurgeTarget)
-			if r.Recorder != nil {
-				r.Recorder.Eventf(target.Obj(), corev1.EventTypeNormal, "DrainSurgeOverride",
-					"maxSurge resolved to 0; overriding drain-time surge to %d (%d%% of minReplicas %d)",
-					maxSurgeTarget, r.SurgeOverrideMaxPercent, EvictionAutoScaler.Status.MinReplicas)
-			}
-		}
+		// author pinned maxSurge: 0.
+		r.recordDrainSurgeOverride(ctx, overrideApplied, pdb, target, EvictionAutoScaler.Spec.TargetName, EvictionAutoScaler.Status.MinReplicas, maxSurgeTarget)
 
 		// Track blocked eviction if the PDB is blocking the eviction
 		metrics.BlockedEvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name).Inc()
@@ -308,6 +298,24 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	ready(&EvictionAutoScaler.Status.Conditions, "Reconciled", "last eviction did not need scaling")
 	logger.Info(fmt.Sprintf("Handled eviction %s", EvictionAutoScaler.Spec.LastEviction))
 	return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler) //should we go rety in case there is also an eviction or just wait till the next eviction
+}
+
+// recordDrainSurgeOverride emits a structured log (and, when a Recorder is wired via
+// ENABLE_EVENT_RECORDING, a DrainSurgeOverride event) when the zero-maxSurge install
+// override raised the drain-time surge ceiling for a workload. It is a no-op unless the
+// override actually supplied the ceiling.
+func (r *EvictionAutoScalerReconciler) recordDrainSurgeOverride(ctx context.Context, overrideApplied bool, pdb *policyv1.PodDisruptionBudget, target Surger, targetName string, minReplicas, maxSurgeTarget int32) {
+	if !overrideApplied {
+		return
+	}
+	log.FromContext(ctx).Info("Zero-maxSurge override raised drain-time surge ceiling",
+		"pdb", pdb.Name, "target", targetName,
+		"surgeOverrideMaxPercent", r.SurgeOverrideMaxPercent, "maxSurgeTarget", maxSurgeTarget)
+	if r.Recorder != nil {
+		r.Recorder.Eventf(target.Obj(), corev1.EventTypeNormal, "DrainSurgeOverride",
+			"maxSurge resolved to 0; overriding drain-time surge to %d (%d%% of minReplicas %d)",
+			maxSurgeTarget, r.SurgeOverrideMaxPercent, minReplicas)
+	}
 }
 
 func ready(conditions *[]metav1.Condition, reason string, message string) {

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -14,6 +14,7 @@ import (
 
 	//v1 "k8s.io/api/apps/v1"
 
+	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -38,6 +39,15 @@ type EvictionAutoScalerReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 	Filter   filter
+
+	// SurgeOverrideMaxPercent is a fleet-wide, install-time knob. When set to a positive
+	// percent it opts the whole fleet in to the zero-maxSurge override: workloads whose
+	// maxSurge resolves to 0 (explicit maxSurge: 0, a Recreate strategy, or an unset
+	// RollingUpdate) are surged by SurgeOverrideMaxPercent% of minReplicas during a drain
+	// (ceil(percent * minReplicas / 100), floored at 1) instead of degrading. When 0
+	// (default) the override is disabled and the controller keeps today's behavior of
+	// degrading on a zero maxSurge.
+	SurgeOverrideMaxPercent int
 }
 
 const cooldown = 1 * time.Minute
@@ -178,7 +188,7 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// surgeTarget = minReplicas + displaced, capped at minReplicas + maxSurge.
 	// If displaced == 0 the formula yields minReplicas, so no scale-up fires and
 	// we fall through to the cooldown/scale-down path — which is correct.
-	maxSurgeTarget, surgeErr := calculateSurge(ctx, target, EvictionAutoScaler.Status.MinReplicas)
+	maxSurgeTarget, overrideApplied, surgeErr := calculateSurge(target, EvictionAutoScaler.Status.MinReplicas, r.SurgeOverrideMaxPercent)
 	if surgeErr != nil {
 		switch {
 		case errors.Is(surgeErr, errMaxSurgeZero):
@@ -213,6 +223,21 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		logger.Info("No disruptions allowed, scaling up", "pdb", pdb.Name, "lastEviction", EvictionAutoScaler.Spec.LastEviction, "strategy", surgeApplier.Name(), "displaced", displaced, "surgeTarget", surgeTarget)
+
+		// The workload's maxSurge resolved to 0 and the fleet-wide override raised the
+		// drain-time ceiling. Surface it so operators can see we scaled a workload whose
+		// author pinned maxSurge: 0. The event only fires when ENABLE_EVENT_RECORDING wired
+		// a Recorder.
+		if overrideApplied {
+			logger.Info("Zero-maxSurge override raised drain-time surge ceiling",
+				"pdb", pdb.Name, "target", EvictionAutoScaler.Spec.TargetName,
+				"surgeOverrideMaxPercent", r.SurgeOverrideMaxPercent, "maxSurgeTarget", maxSurgeTarget)
+			if r.Recorder != nil {
+				r.Recorder.Eventf(target.Obj(), corev1.EventTypeNormal, "DrainSurgeOverride",
+					"maxSurge resolved to 0; overriding drain-time surge to %d (%d%% of minReplicas %d)",
+					maxSurgeTarget, r.SurgeOverrideMaxPercent, EvictionAutoScaler.Status.MinReplicas)
+			}
+		}
 
 		// Track blocked eviction if the PDB is blocking the eviction
 		metrics.BlockedEvictionCounter.WithLabelValues(EvictionAutoScaler.Namespace, pdb.Name).Inc()
@@ -323,32 +348,68 @@ var (
 	errInvalidPercentage = errors.New("invalid surge percentage")
 )
 
-// calculateSurge returns the maximum replica count after surge (minReplicas + maxSurge).
-// Returns a sentinel error to distinguish:
-//   - errMaxSurgeZero: maxSurge resolves to 0 (explicitly set or not configured)
+// calculateSurge returns the maximum replica count after surge (minReplicas + maxSurge)
+// and whether the zero-maxSurge install override supplied that ceiling.
+//
+// The workload's own maxSurge is always tried first. When it resolves to 0 — an explicit
+// maxSurge: 0, a Recreate strategy, or an unset RollingUpdate — and surgeOverridePercent
+// is set to a positive value at install time, the controller substitutes a drain-time
+// surge of surgeOverridePercent% of minReplicas (rounded up, floored at 1) instead of
+// returning errMaxSurgeZero. Workloads with a non-zero maxSurge are untouched and keep
+// their own value; the override never caps an admission-validated maxSurge.
+//
+// The returned error distinguishes:
+//   - errMaxSurgeZero: maxSurge resolves to 0 and the override is disabled (percent <= 0)
 //   - errInvalidPercentage: percentage string could not be parsed
-func calculateSurge(_ context.Context, target Surger, minrepicas int32) (int32, error) {
+func calculateSurge(target Surger, minReplicas int32, surgeOverridePercent int) (int32, bool, error) {
+	surgeTarget, err := surgeFromValue(target.GetMaxSurge(), minReplicas)
+	if err == nil {
+		return surgeTarget, false, nil
+	}
 
-	surge := target.GetMaxSurge()
+	// maxSurge resolved to 0. The override only fires when the install-time percent knob
+	// is set to a positive value; a genuinely invalid percentage still surfaces as an error.
+	if errors.Is(err, errMaxSurgeZero) && surgeOverridePercent > 0 {
+		return minReplicas + drainSurgeOverrideAmount(minReplicas, surgeOverridePercent), true, nil
+	}
+
+	return minReplicas, false, err
+}
+
+// surgeFromValue converts a maxSurge int-or-string into an absolute replica count
+// (minReplicas + surge). A zero value yields errMaxSurgeZero; a string that is not a
+// valid "<n>%" percentage yields errInvalidPercentage.
+func surgeFromValue(surge intstr.IntOrString, minReplicas int32) (int32, error) {
 	if surge.Type == intstr.Int {
 		if surge.IntVal == 0 {
-			return minrepicas, errMaxSurgeZero
+			return minReplicas, errMaxSurgeZero
 		}
-		return minrepicas + surge.IntVal, nil
+		return minReplicas + surge.IntVal, nil
 	}
 
 	if surge.Type == intstr.String {
 		percentageStr := strings.TrimSuffix(surge.StrVal, "%")
 		percentage, err := strconv.Atoi(percentageStr)
 		if err != nil {
-			return minrepicas, fmt.Errorf("%w: %q: %w", errInvalidPercentage, surge.StrVal, err)
+			return minReplicas, fmt.Errorf("%w: %q: %w", errInvalidPercentage, surge.StrVal, err)
 		}
 		if percentage == 0 {
-			return minrepicas, errMaxSurgeZero
+			return minReplicas, errMaxSurgeZero
 		}
-		return minrepicas + int32(math.Ceil((float64(minrepicas)*float64(percentage))/100.0)), nil
+		return minReplicas + int32(math.Ceil((float64(minReplicas)*float64(percentage))/100.0)), nil
 	}
 
 	// Unreachable for well-formed intstr values, but handle gracefully
-	return minrepicas, errMaxSurgeZero
+	return minReplicas, errMaxSurgeZero
+}
+
+// drainSurgeOverrideAmount returns the extra replicas to add during a drain when the
+// zero-maxSurge override fires: ceil(percent * minReplicas / 100), floored at 1 so the
+// override always yields at least one surge replica.
+func drainSurgeOverrideAmount(minReplicas int32, percent int) int32 {
+	amount := int32(math.Ceil(float64(minReplicas) * float64(percent) / 100.0))
+	if amount < 1 {
+		amount = 1
+	}
+	return amount
 }

--- a/test/e2e/e2e_helpers.go
+++ b/test/e2e/e2e_helpers.go
@@ -40,8 +40,12 @@ type deploymentConfig struct {
 	Namespace      string
 	Replicas       int32
 	MaxUnavailable int
-	Annotations    map[string]string
-	CPURequest     string // optional, e.g. "10m"
+	// MaxSurge, when non-nil, pins the rollout's rollingUpdate.maxSurge. Use a pointer so
+	// that leaving it unset preserves Kubernetes' default (25%); set it to 0 to exercise
+	// the zero-maxSurge path.
+	MaxSurge    *int
+	Annotations map[string]string
+	CPURequest  string // optional, e.g. "10m"
 }
 
 // createDeployment creates a deployment with the given configuration
@@ -51,6 +55,11 @@ func createDeployment(cfg deploymentConfig) error {
 		maxUnavailable = "0"
 	} else {
 		maxUnavailable = fmt.Sprintf("%d", cfg.MaxUnavailable)
+	}
+
+	var maxSurge string
+	if cfg.MaxSurge != nil {
+		maxSurge = fmt.Sprintf("%d", *cfg.MaxSurge)
 	}
 
 	tmpl := `apiVersion: apps/v1
@@ -70,6 +79,9 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: {{.MaxUnavailable}}
+{{- if .MaxSurge}}
+      maxSurge: {{.MaxSurge}}
+{{- end}}
   selector:
     matchLabels:
       app: {{.Name}}
@@ -98,6 +110,7 @@ spec:
 		Namespace      string
 		Replicas       int32
 		MaxUnavailable string
+		MaxSurge       string
 		Annotations    map[string]string
 		CPURequest     string
 	}{
@@ -105,6 +118,7 @@ spec:
 		Namespace:      cfg.Namespace,
 		Replicas:       cfg.Replicas,
 		MaxUnavailable: maxUnavailable,
+		MaxSurge:       maxSurge,
 		Annotations:    cfg.Annotations,
 		CPURequest:     cfg.CPURequest,
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1665,6 +1665,182 @@ var _ = Describe("controller", Ordered, func() {
 			deleteDeployment(depName, aksNs)
 		})
 
+		// Test: zero-maxSurge install override. A deployment pinned to maxSurge=0 would
+		// normally degrade during a drain (no headroom to surge). With
+		// controllerConfig.surgeOverride.maxPercent set to a positive percent, the
+		// controller instead surges it by ceil(percent * minReplicas / 100) (floored at 1).
+		It("should surge a zero-maxSurge deployment when surgeOverride.maxPercent is set", func() {
+			ctx := context.Background()
+			testNs := "test-surge-override"
+			depName := "nginx-zero-surge"
+
+			By("uncordoning all nodes to ensure clean state from prior tests")
+			cmd := exec.Command("kubectl", "get", "nodes", "-o", "jsonpath={.items[*].metadata.name}")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			for _, nodeName := range strings.Fields(string(output)) {
+				cmd = exec.Command("kubectl", "uncordon", nodeName)
+				_, _ = utils.Run(cmd) // ignore error if already uncordoned
+			}
+
+			By("reinstalling eviction-autoscaler with surgeOverride.maxPercent=25")
+			cmd = exec.Command("helm", "uninstall", "eviction-autoscaler", "--namespace", namespace)
+			_, _ = utils.Run(cmd)
+			time.Sleep(10 * time.Second)
+
+			projectimage := "evictionautoscaler:e2etest"
+			imgParts := strings.Split(projectimage, ":")
+			Expect(imgParts).To(HaveLen(2), "expected image to be of the form <repository>:<tag>")
+			repo := imgParts[0]
+			tag := imgParts[1]
+			helmArgs := []string{
+				"upgrade", "--install", "eviction-autoscaler", "helm/eviction-autoscaler",
+				"--namespace", namespace, "--create-namespace",
+				"--set", fmt.Sprintf("image.repository=%s", repo),
+				"--set", fmt.Sprintf("image.tag=%s", tag),
+				"--set", "image.pullPolicy=IfNotPresent",
+				"--set", "controllerConfig.pdb.create=true",
+				"--set", "controllerConfig.namespaces.enabledByDefault=true",
+				"--set", "controllerConfig.surgeOverride.maxPercent=25",
+			}
+			cmd = exec.Command("helm", helmArgs...)
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("waiting for the controller deployment to be ready")
+			cmd = exec.Command("kubectl", "wait", "--for=condition=available",
+				"deployment/eviction-autoscaler", "--namespace", namespace, "--timeout=300s")
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+			Expect(err).NotTo(HaveOccurred())
+			clientset, err := client.New(config, client.Options{Scheme: scheme})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating test namespace with enable annotation")
+			cmd = exec.Command("kubectl", "create", "namespace", testNs)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			cmd = exec.Command("kubectl", "annotate", "namespace", testNs,
+				"eviction-autoscaler.azure.com/enable=true")
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating a deployment with 1 replica, maxUnavailable=0 and maxSurge=0")
+			zeroSurge := 0
+			err = createDeployment(deploymentConfig{
+				Name:           depName,
+				Namespace:      testNs,
+				Replicas:       1,
+				MaxUnavailable: 0,
+				MaxSurge:       &zeroSurge,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for deployment to be ready")
+			err = waitForDeployment(depName, testNs)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying PDB and EvictionAutoScaler are created")
+			EventuallyWithOffset(1, func() error {
+				return verifyPdbCreated(ctx, clientset, testNs, depName)
+			}, time.Minute, time.Second).Should(Succeed())
+			EventuallyWithOffset(1, func() error {
+				return verifyEvictionAutoScalerCreated(ctx, clientset, testNs, depName)
+			}, time.Minute, time.Second).Should(Succeed())
+
+			By("finding the node the pod runs on")
+			var pods corev1.PodList
+			err = clientset.List(ctx, &pods, client.InNamespace(testNs))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pods.Items).NotTo(BeEmpty())
+			nodeName := pods.Items[0].Spec.NodeName
+			fmt.Printf("%s pod running on node %s\n", depName, nodeName)
+
+			By("cordoning the node to trigger the eviction surge")
+			var node corev1.Node
+			err = clientset.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+			Expect(err).NotTo(HaveOccurred())
+			node.Spec.Unschedulable = true
+			err = clientset.Update(ctx, &node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the zero-maxSurge deployment is surged to 2 replicas via the override")
+			// minReplicas=1, maxPercent=25 => ceil(0.25*1)=1 (floored) => surge ceiling = 2.
+			// Without the override a maxSurge=0 deployment would degrade and stay at 1.
+			EventuallyWithOffset(1, func() error {
+				var dep appsv1.Deployment
+				if err := clientset.Get(ctx, client.ObjectKey{Namespace: testNs, Name: depName}, &dep); err != nil {
+					return err
+				}
+				if dep.Spec.Replicas == nil || *dep.Spec.Replicas < 2 {
+					return fmt.Errorf("expected deployment to surge to 2 replicas, got %v", dep.Spec.Replicas)
+				}
+				if _, ok := dep.Annotations["evictionSurgeReplicas"]; !ok {
+					return fmt.Errorf("expected evictionSurgeReplicas annotation to be set")
+				}
+				return nil
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			By("verifying the EvictionAutoScaler did not go Degraded for the zero-maxSurge target")
+			var eas types.EvictionAutoScaler
+			err = clientset.Get(ctx, client.ObjectKey{Namespace: testNs, Name: depName}, &eas)
+			Expect(err).NotTo(HaveOccurred())
+			for _, cond := range eas.Status.Conditions {
+				if cond.Type == "Degraded" && cond.Status == v1.ConditionTrue {
+					Fail(fmt.Sprintf("EvictionAutoScaler unexpectedly Degraded: %s", cond.Message))
+				}
+			}
+
+			By("draining the node to trigger evictions")
+			evictionClient, err := kubernetes.NewForConfig(config)
+			Expect(err).NotTo(HaveOccurred())
+			drain := func() error {
+				var podList corev1.PodList
+				if err := clientset.List(ctx, &podList, client.InNamespace(testNs),
+					client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
+					return err
+				}
+				for _, p := range podList.Items {
+					if err := evictionClient.PolicyV1().Evictions(p.Namespace).Evict(ctx, &policy.Eviction{
+						ObjectMeta: p.ObjectMeta,
+					}); err != nil {
+						return fmt.Errorf("failed to evict %s: %w", p.Name, err)
+					}
+				}
+				return nil
+			}
+			EventuallyWithOffset(1, drain, time.Minute, time.Second).Should(Succeed())
+
+			By("verifying the deployment reverts to 1 replica and the surge annotation is removed")
+			EventuallyWithOffset(1, func() error {
+				var dep appsv1.Deployment
+				if err := clientset.Get(ctx, client.ObjectKey{Namespace: testNs, Name: depName}, &dep); err != nil {
+					return err
+				}
+				if dep.Spec.Replicas == nil || *dep.Spec.Replicas != 1 {
+					return fmt.Errorf("expected deployment to revert to 1 replica, got %v", dep.Spec.Replicas)
+				}
+				if _, ok := dep.Annotations["evictionSurgeReplicas"]; ok {
+					return fmt.Errorf("expected evictionSurgeReplicas annotation to be removed")
+				}
+				return nil
+			}, 2*time.Minute, time.Second).Should(Succeed())
+
+			By("uncordoning the node")
+			err = clientset.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
+			Expect(err).NotTo(HaveOccurred())
+			node.Spec.Unschedulable = false
+			err = clientset.Update(ctx, &node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("cleaning up surge override test resources")
+			deleteDeployment(depName, testNs)
+			cmd = exec.Command("kubectl", "delete", "namespace", testNs)
+			_, _ = utils.Run(cmd)
+		})
+
 		It("should reject an AKS-owned namespace in actionedNamespaces and refuse to start", func() {
 			ctx := context.Background()
 			config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -63,6 +63,9 @@ func init() {
 const namespace = "eviction-autoscaler"
 const kindClusterName = "e2e"
 
+// projectImage is the locally built controller image loaded into the Kind cluster.
+const projectImage = "evictionautoscaler:e2etest"
+
 var cleanEnv = true
 
 var _ = Describe("controller", Ordered, func() {
@@ -113,7 +116,7 @@ var _ = Describe("controller", Ordered, func() {
 			var err error
 
 			// projectimage stores the name of the image used in the example
-			var projectimage = "evictionautoscaler:e2etest"
+			var projectimage = projectImage
 
 			By("building the manager(Operator) image")
 			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
@@ -679,7 +682,7 @@ var _ = Describe("controller", Ordered, func() {
 
 			By("reinstalling eviction-autoscaler with enabled_by_default=true (enabledByDefault=true)")
 			// Use the same image that was built in the first test
-			projectimage := "evictionautoscaler:e2etest"
+			projectimage := projectImage
 			imgParts := strings.Split(projectimage, ":")
 			Expect(imgParts).To(HaveLen(2), "expected image to be of the form <repository>:<tag>")
 			repo := imgParts[0]
@@ -1688,7 +1691,7 @@ var _ = Describe("controller", Ordered, func() {
 			_, _ = utils.Run(cmd)
 			time.Sleep(10 * time.Second)
 
-			projectimage := "evictionautoscaler:e2etest"
+			projectimage := projectImage
 			imgParts := strings.Split(projectimage, ":")
 			Expect(imgParts).To(HaveLen(2), "expected image to be of the form <repository>:<tag>")
 			repo := imgParts[0]
@@ -1854,7 +1857,7 @@ var _ = Describe("controller", Ordered, func() {
 			time.Sleep(10 * time.Second)
 
 			By("installing eviction-autoscaler with kube-system (AKS-owned) in actionedNamespaces")
-			projectimage := "evictionautoscaler:e2etest"
+			projectimage := projectImage
 			imgParts := strings.Split(projectimage, ":")
 			Expect(imgParts).To(HaveLen(2), "expected image to be of the form <repository>:<tag>")
 			repo := imgParts[0]


### PR DESCRIPTION
This pull request introduces a new fleet-wide, install-time "zero-maxSurge override" feature to the eviction-autoscaler, allowing workloads with `maxSurge: 0` (or equivalent strategies) to be surged during a drain by a configurable percentage of their minimum replicas, rather than degrading. The change is implemented end-to-end, including configuration via Helm, environment variables, controller logic, event emission, and documentation. Additionally, an optional feature for emitting Kubernetes events on override activation is introduced. Comprehensive tests and documentation are included.

**Zero-maxSurge override feature:**

* Added a new configuration option `controllerConfig.surgeOverride.maxPercent` (default `0`, disabled) to allow surging zero-`maxSurge` workloads during a drain by a configurable percent of `minReplicas` instead of degrading; implemented in controller logic, Helm values, and environment variables. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R157) [[2]](diffhunk://#diff-32bbed5bebff801d569b273215c0359c5ca47a5ab8d6e91c1d6c01288d988c06R55-R70) [[3]](diffhunk://#diff-5f139f5160ac21191404843a50aaf7c8f086f3b37f25f1aee8c8c49c5248da54R44-R47) [[4]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L198-R250) [[5]](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddR42-R50) [[6]](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddL181-R191) [[7]](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddL326-R414)

* Extended the main controller logic to apply the override when enabled, including calculation, logging, and optional Kubernetes event emission (`DrainSurgeOverride`) when the override raises the surge ceiling. [[1]](diffhunk://#diff-6c377cb9f9f1e6722559d6e45aa09d2475f9ae85c1b3db39debff112383b69ddR227-R241) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L198-R250)

**Configuration and observability:**

* Introduced `controllerConfig.eventRecording.enabled` (default `false`) to opt-in to Kubernetes event emission; added strict boolean parsing for feature flags to prevent misconfiguration. [[1]](diffhunk://#diff-32bbed5bebff801d569b273215c0359c5ca47a5ab8d6e91c1d6c01288d988c06R55-R70) [[2]](diffhunk://#diff-5f139f5160ac21191404843a50aaf7c8f086f3b37f25f1aee8c8c49c5248da54R44-R47) [[3]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R52-R67) [[4]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L198-R250)

**Testing and documentation:**

* Added thorough unit tests for the new override logic, including edge cases and validation, in `autoscaler_helpers_test.go`.
* Updated `README.md` with detailed documentation and examples for the zero-maxSurge override feature and event recording. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R244-R294) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R157)