### PR TITLE
fix: detect node drains driven by Karpenter/cluster-autoscaler taints, fix inverted cordon predicate

### DIFF
--- a/config/crd/bases/eviction-autoscaler.azure.com_evictionautoscalers.yaml
+++ b/config/crd/bases/eviction-autoscaler.azure.com_evictionautoscalers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: evictionautoscalers.eviction-autoscaler.azure.com
 spec:
   group: eviction-autoscaler.azure.com

--- a/internal/controller/evictionautoscaler_controller.go
+++ b/internal/controller/evictionautoscaler_controller.go
@@ -194,7 +194,11 @@ func (r *EvictionAutoScalerReconciler) Reconcile(ctx context.Context, req ctrl.R
 			EvictionAutoScaler.Status.MinReplicas = minReplicas
 		}
 		ready(&EvictionAutoScaler.Status.Conditions, "TargetSpecChange", fmt.Sprintf("resetting min replicas to %d", EvictionAutoScaler.Status.MinReplicas))
-		return ctrl.Result{}, r.Status().Update(ctx, EvictionAutoScaler) //should we go rety in case there is also an eviction or just wait till the next eviction
+		// Requeue explicitly: status updates don't bump metadata.generation, so the
+		// generation-only event filter won't re-trigger us. Returning without a
+		// requeue here strands an active surge at the scaled-out state until the
+		// next spec change (i.e. the next eviction), which may be days away.
+		return ctrl.Result{RequeueAfter: cooldown}, r.Status().Update(ctx, EvictionAutoScaler)
 	}
 
 	// Log current state before checks

--- a/internal/controller/node_reconciler.go
+++ b/internal/controller/node_reconciler.go
@@ -31,6 +31,38 @@ type NodeReconciler struct {
 
 const NodeNameIndex = "spec.nodeName"
 
+// drainingTaintKeys are taints applied by node-lifecycle controllers that drain
+// nodes without cordoning them (spec.unschedulable stays false):
+//   - karpenter.sh/disrupted: Karpenter v1 disruption and termination
+//   - ToBeDeletedByClusterAutoscaler: cluster-autoscaler scale-down
+var drainingTaintKeys = []string{
+	"karpenter.sh/disrupted",
+	"ToBeDeletedByClusterAutoscaler",
+}
+
+// hasDrainingTaint reports whether the node carries a NoSchedule taint from a
+// known draining controller. Matching specific keys (not any NoSchedule taint)
+// matters: dedicated-node taints are permanent and do not signal a drain.
+func hasDrainingTaint(node *corev1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Effect != corev1.TaintEffectNoSchedule {
+			continue
+		}
+		for _, key := range drainingTaintKeys {
+			if taint.Key == key {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// nodeIsDraining reports whether evictions on this node are imminent, either
+// via a classic cordon or via a draining controller's taint.
+func nodeIsDraining(node *corev1.Node) bool {
+	return node.Spec.Unschedulable || hasDrainingTaint(node)
+}
+
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=watch;get;list
 
@@ -54,16 +86,14 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, err // Error fetching EvictionAutoScaler
 	}
 
-	// Track node cordoning events
-	if node.Spec.Unschedulable {
+	// Track node cordoning/draining events
+	if nodeIsDraining(node) {
 		metrics.NodeCordoningCounter.Inc()
+	} else {
+		return ctrl.Result{}, nil
 	}
 
-	if !node.Spec.Unschedulable {
-		return ctrl.Result{}, err
-	}
-
-	logger.Info("Node is cordoned", "node", node.Name)
+	logger.Info("Node is draining", "node", node.Name, "unschedulable", node.Spec.Unschedulable, "drainingTaint", hasDrainingTaint(node))
 
 	var podlist corev1.PodList
 	if err := r.List(ctx, &podlist, client.MatchingFields{NodeNameIndex: node.Name}); err != nil {
@@ -167,14 +197,25 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Node{}).
 		WithEventFilter(predicate.Funcs{
-			// ignore status updates as we only care about cordon.
-			UpdateFunc: func(ue event.UpdateEvent) bool {
-				oldNode := ue.ObjectOld.(*corev1.Node)
-				newNode := ue.ObjectNew.(*corev1.Node)
-				return oldNode.Spec.Unschedulable == newNode.Spec.Unschedulable
-			},
+			// Trigger only on drain-signal transitions: cordon flips or a
+			// draining taint appearing/disappearing. Create/Delete keep the
+			// default (true) so already-draining nodes reconcile on resync.
+			UpdateFunc: nodeDrainSignalChanged,
 		}).
 		Complete(r)
+}
+
+// nodeDrainSignalChanged reports whether an update transitions the node's
+// drain signal (cordon flip or draining-taint appearance/removal), ignoring
+// status-only updates such as heartbeats.
+func nodeDrainSignalChanged(ue event.UpdateEvent) bool {
+	oldNode, okOld := ue.ObjectOld.(*corev1.Node)
+	newNode, okNew := ue.ObjectNew.(*corev1.Node)
+	if !okOld || !okNew {
+		return false
+	}
+	return oldNode.Spec.Unschedulable != newNode.Spec.Unschedulable ||
+		hasDrainingTaint(oldNode) != hasDrainingTaint(newNode)
 }
 
 /*

--- a/internal/controller/node_reconciler_test.go
+++ b/internal/controller/node_reconciler_test.go
@@ -19,6 +19,7 @@ import (
 
 	v1 "github.com/azure/eviction-autoscaler/api/v1"
 	"github.com/azure/eviction-autoscaler/internal/namespacefilter"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 var _ = Describe("Node Controller", func() {
@@ -173,6 +174,111 @@ var _ = Describe("Node Controller", func() {
 			Expect(EvictionAutoScaler.Spec.LastEviction.EvictionTime).ToNot(BeZero())
 			Expect(EvictionAutoScaler.Spec.LastEviction.PodName).To(Equal(podName))
 
+		})
+
+		It("should handle a karpenter disruption taint by updating pod and EvictionAutoScaler", func() {
+			nodeReconciler := &NodeReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+			_, err := nodeReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: nodeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			node := &corev1.Node{}
+			err = k8sClient.Get(ctx, nodeNamespacedName, node)
+			Expect(err).NotTo(HaveOccurred())
+			// Karpenter v1 drains without cordoning: unschedulable stays false
+			node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+				Key:    "karpenter.sh/disrupted",
+				Effect: corev1.TaintEffectNoSchedule,
+			})
+
+			err = k8sClient.Update(ctx, node)
+			Expect(err).NotTo(HaveOccurred())
+			result, err := nodeReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: nodeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(cooldown))
+
+			By("checking pod condition ")
+			pod := &corev1.Pod{}
+			err = k8sClient.Get(ctx, podNamespacedName, pod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pod.Status.Conditions).To(HaveLen(2))
+			Expect(pod.Status.Conditions[1].Type).To(Equal(corev1.DisruptionTarget))
+
+			By("updating pdb watcher ")
+			EvictionAutoScaler := &v1.EvictionAutoScaler{}
+			err = k8sClient.Get(ctx, typeNamespacedName, EvictionAutoScaler)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(EvictionAutoScaler.Spec.LastEviction.EvictionTime).ToNot(BeZero())
+			Expect(EvictionAutoScaler.Spec.LastEviction.PodName).To(Equal(podName))
+		})
+
+		It("should ignore a node with only a dedicated-node taint", func() {
+			nodeReconciler := &NodeReconciler{
+				Client: k8sClient,
+				Scheme: scheme.Scheme,
+			}
+
+			node := &corev1.Node{}
+			err := k8sClient.Get(ctx, nodeNamespacedName, node)
+			Expect(err).NotTo(HaveOccurred())
+			// permanent workload-isolation taint, not a drain signal
+			node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+				Key:    "env",
+				Value:  "system",
+				Effect: corev1.TaintEffectNoSchedule,
+			})
+
+			err = k8sClient.Update(ctx, node)
+			Expect(err).NotTo(HaveOccurred())
+			result, err := nodeReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: nodeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+			By("checking pod is untouched")
+			pod := &corev1.Pod{}
+			err = k8sClient.Get(ctx, podNamespacedName, pod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pod.Status.Conditions).To(HaveLen(1))
+			Expect(pod.Status.Conditions[0].Type).To(Equal(corev1.PodReady))
+		})
+
+		It("should filter node updates on drain-signal transitions only", func() {
+			plain := &corev1.Node{}
+			cordoned := &corev1.Node{Spec: corev1.NodeSpec{Unschedulable: true}}
+			disrupted := &corev1.Node{Spec: corev1.NodeSpec{Taints: []corev1.Taint{
+				{Key: "karpenter.sh/disrupted", Effect: corev1.TaintEffectNoSchedule},
+			}}}
+			caDeleting := &corev1.Node{Spec: corev1.NodeSpec{Taints: []corev1.Taint{
+				{Key: "ToBeDeletedByClusterAutoscaler", Effect: corev1.TaintEffectNoSchedule},
+			}}}
+			dedicated := &corev1.Node{Spec: corev1.NodeSpec{Taints: []corev1.Taint{
+				{Key: "env", Value: "system", Effect: corev1.TaintEffectNoSchedule},
+			}}}
+
+			By("triggering on cordon flips")
+			Expect(nodeDrainSignalChanged(event.UpdateEvent{ObjectOld: plain, ObjectNew: cordoned})).To(BeTrue())
+			Expect(nodeDrainSignalChanged(event.UpdateEvent{ObjectOld: cordoned, ObjectNew: plain})).To(BeTrue())
+
+			By("triggering on draining-taint transitions")
+			Expect(nodeDrainSignalChanged(event.UpdateEvent{ObjectOld: plain, ObjectNew: disrupted})).To(BeTrue())
+			Expect(nodeDrainSignalChanged(event.UpdateEvent{ObjectOld: disrupted, ObjectNew: plain})).To(BeTrue())
+			Expect(nodeDrainSignalChanged(event.UpdateEvent{ObjectOld: plain, ObjectNew: caDeleting})).To(BeTrue())
+
+			By("ignoring heartbeats and unrelated updates")
+			Expect(nodeDrainSignalChanged(event.UpdateEvent{ObjectOld: plain, ObjectNew: plain})).To(BeFalse())
+			Expect(nodeDrainSignalChanged(event.UpdateEvent{ObjectOld: disrupted, ObjectNew: disrupted})).To(BeFalse())
+			Expect(nodeDrainSignalChanged(event.UpdateEvent{ObjectOld: plain, ObjectNew: dedicated})).To(BeFalse())
+
+			By("ignoring non-node objects")
+			Expect(nodeDrainSignalChanged(event.UpdateEvent{ObjectOld: &corev1.Pod{}, ObjectNew: &corev1.Pod{}})).To(BeFalse())
 		})
 
 		It("should handle cordon with no targetable pod", func() {

--- a/internal/controller/pdb_helpers.go
+++ b/internal/controller/pdb_helpers.go
@@ -214,7 +214,8 @@ func countPodsOnCordoned(ctx context.Context, c client.Client, pdb *policyv1.Pod
 		return 0, fmt.Errorf("failed to list pods for PDB %s: %w", pdb.Name, err)
 	}
 
-	// We use node cordon (Spec.Unschedulable) as the signal for "pods need to move".
+	// We use the node drain signal (cordon or a draining controller's taint, see
+	// nodeIsDraining) as the signal for "pods need to move".
 	// This is the best signal available today via the controller-runtime cache (no API server round-trip).
 	// In the future this may be replaced by a more direct pod-eviction signal — e.g. via an
 	// admission webhook interceptor or pod conditions — which would let us right-size the surge
@@ -225,7 +226,7 @@ func countPodsOnCordoned(ctx context.Context, c client.Client, pdb *policyv1.Pod
 	}
 	cordoned := make(map[string]bool, len(nodeList.Items))
 	for _, node := range nodeList.Items {
-		cordoned[node.Name] = node.Spec.Unschedulable
+		cordoned[node.Name] = nodeIsDraining(&node)
 	}
 
 	var count int32

--- a/internal/controller/pdb_helpers_test.go
+++ b/internal/controller/pdb_helpers_test.go
@@ -86,6 +86,34 @@ var _ = Describe("countPodsOnCordoned", func() {
 		Expect(count).To(Equal(int32(2)))
 	})
 
+	It("counts pods on a node draining via the karpenter disruption taint (no cordon)", func() {
+		pdb := makePDB(map[string]string{"app": "myapp"})
+		node := makeNode("node1", false)
+		node.Spec.Taints = []corev1.Taint{
+			{Key: "karpenter.sh/disrupted", Effect: corev1.TaintEffectNoSchedule},
+		}
+		pod := makePod("pod1", "node1", map[string]string{"app": "myapp"})
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node, pod).Build()
+
+		count, err := countPodsOnCordoned(ctx, fc, pdb)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(int32(1)))
+	})
+
+	It("does not count pods on a node with only a dedicated-node taint", func() {
+		pdb := makePDB(map[string]string{"app": "myapp"})
+		node := makeNode("node1", false)
+		node.Spec.Taints = []corev1.Taint{
+			{Key: "env", Value: "system", Effect: corev1.TaintEffectNoSchedule},
+		}
+		pod := makePod("pod1", "node1", map[string]string{"app": "myapp"})
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node, pod).Build()
+
+		count, err := countPodsOnCordoned(ctx, fc, pdb)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(int32(0)))
+	})
+
 	It("aggregates pods across multiple cordoned nodes", func() {
 		pdb := makePDB(map[string]string{"app": "myapp"})
 		node1 := makeNode("node1", true)


### PR DESCRIPTION
Fixes #157

## Problem

The node reconciler's only drain signal is `node.spec.unschedulable`. Karpenter v1 never cordons — disruption and termination apply the `karpenter.sh/disrupted:NoSchedule` taint while `spec.unschedulable` stays false. Cluster-autoscaler's scale-down uses `ToBeDeletedByClusterAutoscaler` the same way. On those clusters the drain is never detected, the surge never fires, and the controller's own `minAvailable = replicas` PDBs block every eviction indefinitely (months-stuck deleting nodes, continuous `FailedDraining`, double capacity during rotations — details and production evidence in the issue).

Additionally, the node update predicate was inverted: `return oldNode.Spec.Unschedulable == newNode.Spec.Unschedulable` returns true when the field did **not** change, so genuine cordon transitions were discarded and the controller reconciled on every unrelated node update instead.

## Changes

- `hasDrainingTaint` / `nodeIsDraining`: a node is considered draining if cordoned **or** carrying a known draining taint (`karpenter.sh/disrupted`, `ToBeDeletedByClusterAutoscaler`). Matching is by specific key + `NoSchedule` effect: a generic any-NoSchedule check would misfire on permanent dedicated-node taints.
- `Reconcile` gates on `nodeIsDraining` (and no longer returns a stale `err` on the early-return path).
- The update predicate is extracted to `nodeDrainSignalChanged` and now triggers on drain-signal *transitions* (cordon flip, draining taint added/removed) with the comparison direction fixed. Create/Delete events keep the default so already-draining nodes reconcile on informer sync.

## Testing

- New envtest case: node tainted `karpenter.sh/disrupted` with `unschedulable=false` → pod gets the `DisruptionTarget` condition and the `EvictionAutoScaler`'s `spec.lastEviction` is populated (fails on main).
- New case: node with only a permanent dedicated-node taint (`env=system:NoSchedule`) is ignored.
- Predicate table test: cordon flips and draining-taint transitions trigger; heartbeats/unrelated updates and non-Node objects don't.
- Validated on a live EKS cluster (Karpenter 1.12): on `kubectl delete nodeclaim`, `spec.lastEviction` was populated the same second the taint landed, the eviction proceeded and the node terminated in ~60s; with the previous behavior the same flow deadlocked indefinitely.