### PR TITLE
feat(helm): add nodeSelector, affinity, and tolerations for the contr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,36 @@ az k8s-extension create \
 - `controllerConfig.pdb.create=true` - Automatically creates PDBs for deployments (default: false)
 - `controllerConfig.namespaces.enabledByDefault=true` - Enables all namespaces (default: false, opt-in mode)
 - `controllerConfig.namespaces.actionedNamespaces` - List of namespaces to enable when using opt-in mode (default: [kube-system])
+- `nodeSelector` - Pins the controller pod to nodes matching these labels (default: `{}`, no constraint)
+- `affinity` - Full Kubernetes affinity spec for the controller pod, including `nodeAffinity` (default: `{}`)
+- `tolerations` - Allows the controller pod to schedule onto tainted nodes (default: `[]`)
+
+**Controller Pod Scheduling (node affinity / tolerations):**
+
+Pin the controller to specific nodes with a node label:
+
+```bash
+az k8s-extension create \
+    --cluster-name <your-cluster-name> \
+    --cluster-type managedClusters \
+    --extension-type microsoft.evictionautoscaler \
+    --name eviction-autoscaler \
+    --resource-group <your-resource-group-name> \
+    --release-train stable \
+    --configuration-settings nodeSelector."kubernetes\.io/os"=linux \
+    --auto-upgrade-minor-version true
+```
+
+When installing the chart directly with Helm, richer `affinity` / `tolerations`
+specs are easiest to pass as JSON:
+
+```bash
+helm install eviction-autoscaler ./helm/eviction-autoscaler \
+  --set-json 'affinity={"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"agentpool","operator":"In","values":["system"]}]}]}}}' \
+  --set-json 'tolerations=[{"key":"CriticalAddonsOnly","operator":"Exists"}]'
+```
+
+Leaving these unset (the default) applies no placement constraints — the controller schedules like any other pod.
 
 **Common Configuration Combinations:**
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ az k8s-extension create \
 
 **Configuration Options:**
 
-- `controllerConfig.pdb.create=true` - Automatically creates PDBs for deployments (default: false)
+- `controllerConfig.pdb.create=true` - Automatically creates PDBs for deployments (default: true)
 - `controllerConfig.namespaces.enabledByDefault=true` - Enables all namespaces (default: false, opt-in mode)
-- `controllerConfig.namespaces.actionedNamespaces` - List of namespaces to enable when using opt-in mode (default: [kube-system])
+- `controllerConfig.namespaces.actionedNamespaces` - List of namespaces to enable when using opt-in mode (default: `[]`)
 - `nodeSelector` - Pins the controller pod to nodes matching these labels (default: `{}`, no constraint)
 - `affinity` - Full Kubernetes affinity spec for the controller pod, including `nodeAffinity` (default: `{}`)
 - `tolerations` - Allows the controller pod to schedule onto tainted nodes (default: `[]`)

--- a/README.md
+++ b/README.md
@@ -174,6 +174,24 @@ az k8s-extension create \
     --auto-upgrade-minor-version true
 ```
 
+Tolerations (and other list values) can be set field-by-field using the indexed
+form, where `[N]` is the list position:
+
+```bash
+az k8s-extension create \
+    --cluster-name <your-cluster-name> \
+    --cluster-type managedClusters \
+    --extension-type microsoft.evictionautoscaler \
+    --name eviction-autoscaler \
+    --resource-group <your-resource-group-name> \
+    --release-train stable \
+    --configuration-settings \
+        tolerations[0].key=CriticalAddonsOnly \
+        tolerations[0].operator=Exists \
+        tolerations[0].effect=NoSchedule \
+    --auto-upgrade-minor-version true
+```
+
 When installing the chart directly with Helm, richer `affinity` / `tolerations`
 specs are easiest to pass as JSON:
 

--- a/helm/eviction-autoscaler/templates/deployment.yaml
+++ b/helm/eviction-autoscaler/templates/deployment.yaml
@@ -30,6 +30,18 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: eviction-autoscaler
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/eviction-autoscaler/values.yaml
+++ b/helm/eviction-autoscaler/values.yaml
@@ -17,6 +17,25 @@ resources:
     cpu: 10m
     memory: 64Mi
 
+# Controller pod scheduling
+# nodeSelector pins the controller to nodes matching these labels (node affinity
+# by label). affinity accepts a full Kubernetes affinity spec (nodeAffinity,
+# podAffinity, podAntiAffinity). tolerations allow scheduling onto tainted nodes.
+# Example:
+#   nodeSelector:
+#     kubernetes.io/os: linux
+#   affinity:
+#     nodeAffinity:
+#       requiredDuringSchedulingIgnoredDuringExecution:
+#         nodeSelectorTerms:
+#           - matchExpressions:
+#               - key: agentpool
+#                 operator: In
+#                 values: ["system"]
+nodeSelector: {}
+affinity: {}
+tolerations: []
+
 # Controller configuration - the main settings users need to customize
 controllerConfig:
   # Metrics configuration

--- a/test/e2e/e2e_helpers.go
+++ b/test/e2e/e2e_helpers.go
@@ -628,9 +628,21 @@ func controllerPodStatus(ctx context.Context, c client.Client) (string, int32, e
 	if len(pods.Items) == 0 {
 		return "", 0, fmt.Errorf("no controller-manager pod found")
 	}
-	pod := pods.Items[0]
-	if pod.Status.Phase != corev1.PodRunning {
-		return pod.Name, 0, fmt.Errorf("controller pod %s in %s phase", pod.Name, pod.Status.Phase)
+	// The single-replica manager can be replaced by earlier specs (node drains,
+	// evictions). The old pod exits 0 on SIGTERM and lingers as Succeeded until
+	// GC, so pick the live pod rather than whichever sorts first.
+	var pod *corev1.Pod
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.DeletionTimestamp != nil || p.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		pod = p
+		break
+	}
+	if pod == nil {
+		return pods.Items[0].Name, 0, fmt.Errorf("no Running controller pod found (%d pod(s), first in %s phase)",
+			len(pods.Items), pods.Items[0].Status.Phase)
 	}
 	var restarts int32
 	for _, cs := range pod.Status.ContainerStatuses {


### PR DESCRIPTION
This pull request adds support for advanced Kubernetes pod scheduling options for the controller pod, allowing users to specify `nodeSelector`, `affinity`, and `tolerations` via Helm values or Azure CLI configuration. These changes make it possible to control which nodes the controller pod runs on, including targeting specific node pools or tainted nodes. Documentation has been updated with usage examples.

**Controller pod scheduling enhancements:**

* Added `nodeSelector`, `affinity`, and `tolerations` fields to the Helm chart values (`values.yaml`) to allow users to control pod placement and node selection for the controller.
* Modified the controller `Deployment` template (`deployment.yaml`) to use the values of `nodeSelector`, `affinity`, and `tolerations` if provided.

**Documentation updates:**

* Updated the `README.md` with explanations and examples for configuring controller pod scheduling, including both Azure CLI and Helm usage.…oller deployment

Expose pod scheduling configuration for the eviction-autoscaler controller so it can be pinned to specific nodes (node affinity by label) and scheduled onto tainted nodes. Defaults are no-ops, so existing installs are unaffected. Documented in values.yaml and the README config section.