### PR TITLE
feat: add global controller kill switch and AKS-owned namespace opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,11 @@ az k8s-extension create \
 
 **Configuration Options:**
 
+- `controllerConfig.enabled=false` - Global kill switch; when `false`, no reconcilers run and the controller takes no action (still serves health/metrics) (default: true)
 - `controllerConfig.pdb.create=true` - Automatically creates PDBs for deployments (default: false)
 - `controllerConfig.namespaces.enabledByDefault=true` - Enables all namespaces (default: false, opt-in mode)
 - `controllerConfig.namespaces.actionedNamespaces` - List of namespaces to enable when using opt-in mode (default: [kube-system])
+- `controllerConfig.namespaces.manageAKSOwnedNamespaces=false` - When `false`, AKS-owned namespaces (kube-system, flux-system, etc.) follow the normal enable rules instead of being unconditionally managed, so they can be excluded (default: true)
 
 **Common Configuration Combinations:**
 
@@ -246,10 +248,12 @@ Eviction autoscaler provides flexible namespace-level control with two operation
 
 #### Environment Variables
 
+- **`CONTROLLER_ENABLED`**: Global kill switch for the controller (default: `true`). When `false`, no reconcilers are registered — the controller runs (serving health and metrics) but takes no action on any namespace or PDB, so the feature can be fully disabled in place without uninstalling the extension.
 - **`ENABLED_BY_DEFAULT`**: Controls the operational mode (default: `false`)
   - `false`: Namespaces disabled by default - only specified namespaces enabled
   - `true`: Namespaces enabled by default - all namespaces enabled unless disabled
 - **`ACTIONED_NAMESPACES`**: Comma-separated list of namespaces with special behavior
+- **`MANAGE_AKS_OWNED_NAMESPACES`**: Whether AKS-owned namespaces (kube-system, flux-system, etc.) are unconditionally managed (default: `true`). When `false`, they follow the normal enable rules (annotation / actioned list / default) like any other namespace, so operators can exclude them from eviction-autoscaler entirely.
 - **`PDB_CREATE`**: Enable automatic PDB creation for deployments (default: `false`)
 - **`ZERO_SURGE_OVERRIDE`**: Lets the controller surge a workload whose `maxSurge` resolves to 0 (an explicit `maxSurge: 0`, or a `Recreate` strategy) during a drain instead of refusing to surge. The value is an int-or-percentage, mirroring Kubernetes `maxSurge`: `"25%"` of `minReplicas` (rounded up) or an absolute `"10"`. Unset, or a value that resolves to zero (`"0"`/`"0%"`), leaves the feature off (default), so such a workload degrades as before; a negative or malformed value fails fast at startup. The actual surge stays demand-driven (`minReplicas + displaced`) and is capped at this amount, so larger drains proceed in waves. **Note:** workloads that omit `maxSurge` entirely (or omit the strategy altogether) are _not_ affected — Kubernetes defaults those to `25%` at admission time, so they already have a non-zero surge and the override does not apply.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -174,13 +174,30 @@ func main() {
 		}
 	}
 
+	// Parse MANAGE_AKS_OWNED_NAMESPACES environment variable (defaults to true).
+	// When true (default), eviction-autoscaler unconditionally manages AKS-owned
+	// namespaces (kube-system, flux-system, etc.). Set to false to exclude them, so
+	// only namespaces enabled via ACTIONED_NAMESPACES / the enable annotation / the
+	// default are acted on — giving operators full control over the managed set.
+	manageAKSOwned := true
+	if v := os.Getenv("MANAGE_AKS_OWNED_NAMESPACES"); v != "" {
+		var err error
+		manageAKSOwned, err = strconv.ParseBool(v)
+		if err != nil {
+			setupLog.Error(err, "Failed to parse MANAGE_AKS_OWNED_NAMESPACES env variable")
+			os.Exit(1)
+		}
+	}
+
 	// Create namespace filter
-	nsfilter := namespacefilter.New(actionedNamespacesList, disabledByDefault)
+	nsfilter := namespacefilter.New(actionedNamespacesList, disabledByDefault,
+		namespacefilter.WithManageAKSOwnedNamespaces(manageAKSOwned))
 
 	setupLog.Info("Eviction autoscaler configuration",
 		"disabledByDefault", disabledByDefault,
 		"enabledByDefault", enabledByDefault,
-		"actionedNamespaces", actionedNamespacesList)
+		"actionedNamespaces", actionedNamespacesList,
+		"manageAKSOwnedNamespaces", manageAKSOwned)
 
 	// Parse PDB_CREATE environment variable (defaults to false if not set)
 	pdbCreateStr := os.Getenv("PDB_CREATE")
@@ -209,58 +226,78 @@ func main() {
 	}
 	setupLog.Info("Zero-maxSurge override configuration", "zeroSurgeOverride", zeroSurgeOverride)
 
-	evictionAutoScalerReconciler := &controllers.EvictionAutoScalerReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Filter:            nsfilter,
-		ZeroSurgeOverride: zeroSurgeOverride,
+	// Parse CONTROLLER_ENABLED environment variable (defaults to true). This is a
+	// global kill switch: when false, no reconcilers are registered, so the
+	// controller runs (serving health and metrics) but takes no action on any
+	// namespace or PDB — letting operators fully disable the feature in place via
+	// config, without uninstalling the extension.
+	controllerEnabled := true
+	if v := os.Getenv("CONTROLLER_ENABLED"); v != "" {
+		var err error
+		controllerEnabled, err = strconv.ParseBool(v)
+		if err != nil {
+			setupLog.Error(err, "Failed to parse CONTROLLER_ENABLED env variable")
+			os.Exit(1)
+		}
 	}
-	if err = evictionAutoScalerReconciler.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "EvictionAutoScaler")
-		os.Exit(1)
-	}
-	setupLog.Info("EvictionAutoScalerReconciler setup completed")
+	setupLog.Info("Controller enable configuration", "controllerEnabled", controllerEnabled)
 
-	if pdbCreate {
-		if err = (&controllers.DeploymentToPDBReconciler{
+	if controllerEnabled {
+		evictionAutoScalerReconciler := &controllers.EvictionAutoScalerReconciler{
+			Client:            mgr.GetClient(),
+			Scheme:            mgr.GetScheme(),
+			Filter:            nsfilter,
+			ZeroSurgeOverride: zeroSurgeOverride,
+		}
+		if err = evictionAutoScalerReconciler.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "EvictionAutoScaler")
+			os.Exit(1)
+		}
+		setupLog.Info("EvictionAutoScalerReconciler setup completed")
+
+		if pdbCreate {
+			if err = (&controllers.DeploymentToPDBReconciler{
+				Client: mgr.GetClient(),
+				Scheme: mgr.GetScheme(),
+				Filter: nsfilter,
+			}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create controller", "controller", "DeploymentToPDBReconciler")
+				os.Exit(1)
+			}
+			setupLog.Info("DeploymentToPDBReconciler setup completed")
+
+			// Watches both HPA and KEDA ScaledObject changes to keep PDB minAvailable
+			// in sync with the autoscaler's min replicas floor.
+			if err = (&controllers.AutoscalerToPDBReconciler{
+				Client: mgr.GetClient(),
+				Scheme: mgr.GetScheme(),
+				Filter: nsfilter,
+			}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create controller", "controller", "AutoscalerToPDBReconciler")
+				os.Exit(1)
+			}
+			setupLog.Info("AutoscalerToPDBReconciler setup completed")
+		}
+
+		if err = (&controllers.PDBToEvictionAutoScalerReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
 			Filter: nsfilter,
 		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "DeploymentToPDBReconciler")
+			setupLog.Error(err, "unable to create controller", "controller", "PDBToEvictionAutoScalerReconciler")
 			os.Exit(1)
 		}
-		setupLog.Info("DeploymentToPDBReconciler setup completed")
+		setupLog.Info("PDBToEvictionAutoScalerReconciler  setup completed")
 
-		// Watches both HPA and KEDA ScaledObject changes to keep PDB minAvailable
-		// in sync with the autoscaler's min replicas floor.
-		if err = (&controllers.AutoscalerToPDBReconciler{
+		if err = (&controllers.NodeReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
-			Filter: nsfilter,
 		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "AutoscalerToPDBReconciler")
+			setupLog.Error(err, "unable to create controller", "controller", "NodeReconciler")
 			os.Exit(1)
 		}
-		setupLog.Info("AutoscalerToPDBReconciler setup completed")
-	}
-
-	if err = (&controllers.PDBToEvictionAutoScalerReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Filter: nsfilter,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "PDBToEvictionAutoScalerReconciler")
-		os.Exit(1)
-	}
-	setupLog.Info("PDBToEvictionAutoScalerReconciler  setup completed")
-
-	if err = (&controllers.NodeReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "EvictionAutoScaler")
-		os.Exit(1)
+	} else {
+		setupLog.Info("Controller is disabled (CONTROLLER_ENABLED=false); no reconcilers registered — serving health and metrics only")
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/helm/eviction-autoscaler/templates/deployment.yaml
+++ b/helm/eviction-autoscaler/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
             value: {{ join "," .Values.controllerConfig.namespaces.actionedNamespaces | quote }}
           - name: ZERO_SURGE_OVERRIDE
             value: {{ .Values.controllerConfig.zeroSurgeOverride | quote }}
+          - name: CONTROLLER_ENABLED
+            value: {{ .Values.controllerConfig.enabled | quote }}
+          - name: MANAGE_AKS_OWNED_NAMESPACES
+            value: {{ .Values.controllerConfig.namespaces.manageAKSOwnedNamespaces | quote }}
         command:
         - /manager
         args:

--- a/helm/eviction-autoscaler/values.yaml
+++ b/helm/eviction-autoscaler/values.yaml
@@ -19,6 +19,13 @@ resources:
 
 # Controller configuration - the main settings users need to customize
 controllerConfig:
+  # Global enable/disable for the entire controller (kill switch).
+  # - true (default): reconcilers run normally.
+  # - false: no reconcilers are registered, so the controller takes no action on any
+  #          namespace or PDB (it still serves health and metrics). Use this to fully
+  #          disable eviction-autoscaler in place, without uninstalling the extension.
+  enabled: true
+
   # Metrics configuration
   metrics:
     enabled: true
@@ -47,6 +54,15 @@ controllerConfig:
     # Upgrade note: if upgrading from an older chart that defaulted to [kube-system],
     # remove it from your values (or use `helm upgrade --reset-values`), otherwise startup fails.
     actionedNamespaces: []
+
+    # Whether eviction-autoscaler unconditionally manages AKS-owned namespaces
+    # (kube-system, flux-system, etc.).
+    # - true (default): AKS-owned namespaces are always managed, ignoring
+    #                   enabledByDefault, actionedNamespaces, and the enable annotation.
+    # - false: AKS-owned namespaces follow the normal enable rules like any other
+    #          namespace, so they can be excluded entirely (e.g. with enabledByDefault=false
+    #          and no annotation). Use this for full control over the managed namespace set.
+    manageAKSOwnedNamespaces: true
   
   # PDB creation configuration
   pdb:

--- a/internal/namespacefilter/nsfilter.go
+++ b/internal/namespacefilter/nsfilter.go
@@ -53,13 +53,34 @@ func IsAKSOwnedNamespace(ns string) bool {
 type nsfilter struct {
 	disabledByDefault bool
 	hardcoded         []string
+	// manageAKSOwned controls whether AKS-owned namespaces are unconditionally
+	// managed. Defaults to true (historical behavior); when false, AKS-owned
+	// namespaces are subject to the normal enable rules like any other namespace.
+	manageAKSOwned bool
 }
 
-func New(hardcoded []string, disabledByDefault bool) *nsfilter {
-	return &nsfilter{
+// Option configures optional nsfilter behavior.
+type Option func(*nsfilter)
+
+// WithManageAKSOwnedNamespaces controls whether AKS-owned namespaces (kube-system,
+// flux-system, etc.) are always managed regardless of config and annotation. The
+// default (true) preserves historical behavior; passing false makes those namespaces
+// follow the normal enable rules (annotation / actioned list / default), so operators
+// can exclude them from eviction-autoscaler entirely.
+func WithManageAKSOwnedNamespaces(manage bool) Option {
+	return func(n *nsfilter) { n.manageAKSOwned = manage }
+}
+
+func New(hardcoded []string, disabledByDefault bool, opts ...Option) *nsfilter {
+	n := &nsfilter{
 		hardcoded:         hardcoded,
 		disabledByDefault: disabledByDefault,
+		manageAKSOwned:    true,
 	}
+	for _, opt := range opts {
+		opt(n)
+	}
+	return n
 }
 
 type Reader interface {
@@ -69,8 +90,10 @@ type Reader interface {
 func (n *nsfilter) Filter(ctx context.Context, c Reader, ns string) (bool, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
-	// AKS-owned namespaces are always managed, ignoring config and the enable annotation.
-	if IsAKSOwnedNamespace(ns) {
+	// AKS-owned namespaces are always managed, ignoring config and the enable
+	// annotation — unless AKS-owned management has been disabled, in which case they
+	// fall through to the normal enable rules below like any other namespace.
+	if n.manageAKSOwned && IsAKSOwnedNamespace(ns) {
 		logger.Info("namespace filtering decision", "namespace", ns, "source", "aks-owned", "filtering", true)
 		return true, nil
 	}

--- a/internal/namespacefilter/nsfilter_test.go
+++ b/internal/namespacefilter/nsfilter_test.go
@@ -473,3 +473,67 @@ func TestFilter_RealWorldScenario_OptOut(t *testing.T) {
 		t.Errorf("expected disabled to be disabled via annotation, got %v", result)
 	}
 }
+
+// AKS-owned namespace management toggle (WithManageAKSOwnedNamespaces).
+
+func TestFilter_ManageAKSOwned_DefaultTrue_KubeSystemManaged(t *testing.T) {
+	// Default (no option): AKS-owned namespaces are always managed even in opt-in
+	// mode with an empty actioned list — backward-compatible behavior.
+	filter := New([]string{}, true)
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+	result, err := filter.Filter(context.Background(), fakeClient, "kube-system")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != true {
+		t.Errorf("expected kube-system to be managed by default, got %v", result)
+	}
+}
+
+func TestFilter_ManageAKSOwnedFalse_KubeSystemExcluded(t *testing.T) {
+	// With AKS-owned management disabled and opt-in mode + no annotation, an
+	// AKS-owned namespace follows the normal rules and is excluded.
+	filter := New([]string{}, true, WithManageAKSOwnedNamespaces(false))
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+	result, err := filter.Filter(context.Background(), fakeClient, "kube-system")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != false {
+		t.Errorf("expected kube-system to be excluded when manageAKSOwned=false in opt-in mode, got %v", result)
+	}
+}
+
+func TestFilter_ManageAKSOwnedFalse_AnnotationStillEnables(t *testing.T) {
+	// With AKS-owned management disabled, an explicit enable annotation still opts an
+	// AKS-owned namespace back in (normal rules apply).
+	filter := New([]string{}, true, WithManageAKSOwnedNamespaces(false))
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "kube-system",
+			Annotations: map[string]string{EnableEvictionAutoscalerAnnotationKey: "true"},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+	result, err := filter.Filter(context.Background(), fakeClient, "kube-system")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != true {
+		t.Errorf("expected kube-system to be enabled via annotation when manageAKSOwned=false, got %v", result)
+	}
+}


### PR DESCRIPTION
## What

Adds two operator controls for disabling / narrowing what the controller acts on, both defaulting to preserve current behavior.

### 1. Global controller kill switch — `CONTROLLER_ENABLED` (`controllerConfig.enabled`, default `true`)
When `false`, **no reconcilers are registered** — the controller still runs and serves health/metrics, but takes no action on any namespace or PDB. This lets operators fully disable eviction-autoscaler **in place** (via config) without uninstalling the extension. Today the only way to stop the controller is to uninstall.

### 2. AKS-owned namespace opt-out — `MANAGE_AKS_OWNED_NAMESPACES` (`controllerConfig.namespaces.manageAKSOwnedNamespaces`, default `true`)
Today AKS-owned namespaces (`kube-system`, `flux-system`, etc.) are **unconditionally managed** — the namespace filter short-circuits `IsAKSOwnedNamespace()` before consulting `enabledByDefault` / `actionedNamespaces` / the annotation, so they cannot be excluded. When this is set to `false`, those namespaces follow the **normal enable rules** like any other namespace, so operators who want the controller to act only on an explicitly opted-in set can exclude the system namespaces entirely.

## Why

Fleet operators asked for (a) a single in-place disable that doesn't require an uninstall, and (b) a way to keep the controller from acting on system namespaces they don't want it touching. Both are additive, opt-in, and default to today's behavior.

## Changes

- `cmd/main.go` — parse `CONTROLLER_ENABLED` and `MANAGE_AKS_OWNED_NAMESPACES` (strict bool, fail-fast on bad value); gate reconciler registration on the kill switch; wire the filter option.
- `internal/namespacefilter/nsfilter.go` — backward-compatible `WithManageAKSOwnedNamespaces` functional option (default keeps unconditional management); gate the AKS-owned short-circuit on it.
- `internal/namespacefilter/nsfilter_test.go` — unit tests: default still manages `kube-system`; excluded when the option is off in opt-in mode; annotation still re-enables when off.
- `helm/eviction-autoscaler/{values.yaml,templates/deployment.yaml}` — new settings + env wiring.
- `README.md` — documented both.

## Compatibility

Both flags default to `true`, so existing installs are unaffected. `New(...)`'s existing call sites are unchanged (the new behavior is a variadic option).

## Testing

- `go build ./cmd/... ./internal/...` — OK
- `go vet ./cmd/... ./internal/...` — OK
- `go test ./internal/namespacefilter/...` — passing (incl. 3 new tests)
- `helm` values validated