### PR TITLE
feat: add opt-out for managing AKS-owned namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ az k8s-extension create \
 - `controllerConfig.pdb.create=true` - Automatically creates PDBs for deployments (default: false)
 - `controllerConfig.namespaces.enabledByDefault=true` - Enables all namespaces (default: false, opt-in mode)
 - `controllerConfig.namespaces.actionedNamespaces` - List of namespaces to enable when using opt-in mode (default: [kube-system])
+- `controllerConfig.namespaces.manageAKSOwnedNamespaces=false` - When `false`, AKS-owned namespaces (kube-system, flux-system, etc.) follow the normal enable rules instead of being unconditionally managed, so they can be excluded (default: true)
 
 **Common Configuration Combinations:**
 
@@ -250,6 +251,7 @@ Eviction autoscaler provides flexible namespace-level control with two operation
   - `false`: Namespaces disabled by default - only specified namespaces enabled
   - `true`: Namespaces enabled by default - all namespaces enabled unless disabled
 - **`ACTIONED_NAMESPACES`**: Comma-separated list of namespaces with special behavior
+- **`MANAGE_AKS_OWNED_NAMESPACES`**: Whether AKS-owned namespaces (kube-system, flux-system, etc.) are unconditionally managed (default: `true`). When `false`, they follow the normal enable rules (annotation / actioned list / default) like any other namespace, so operators can exclude them from eviction-autoscaler entirely.
 - **`PDB_CREATE`**: Enable automatic PDB creation for deployments (default: `false`)
 - **`ZERO_SURGE_OVERRIDE`**: Lets the controller surge a workload whose `maxSurge` resolves to 0 (an explicit `maxSurge: 0`, or a `Recreate` strategy) during a drain instead of refusing to surge. The value is an int-or-percentage, mirroring Kubernetes `maxSurge`: `"25%"` of `minReplicas` (rounded up) or an absolute `"10"`. Unset, or a value that resolves to zero (`"0"`/`"0%"`), leaves the feature off (default), so such a workload degrades as before; a negative or malformed value fails fast at startup. The actual surge stays demand-driven (`minReplicas + displaced`) and is capped at this amount, so larger drains proceed in waves. **Note:** workloads that omit `maxSurge` entirely (or omit the strategy altogether) are _not_ affected — Kubernetes defaults those to `25%` at admission time, so they already have a non-zero surge and the override does not apply.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -174,13 +174,30 @@ func main() {
 		}
 	}
 
+	// Parse MANAGE_AKS_OWNED_NAMESPACES environment variable (defaults to true).
+	// When true (default), eviction-autoscaler unconditionally manages AKS-owned
+	// namespaces (kube-system, flux-system, etc.). Set to false to exclude them, so
+	// only namespaces enabled via ACTIONED_NAMESPACES / the enable annotation / the
+	// default are acted on — giving operators full control over the managed set.
+	manageAKSOwned := true
+	if v := os.Getenv("MANAGE_AKS_OWNED_NAMESPACES"); v != "" {
+		var err error
+		manageAKSOwned, err = strconv.ParseBool(v)
+		if err != nil {
+			setupLog.Error(err, "Failed to parse MANAGE_AKS_OWNED_NAMESPACES env variable")
+			os.Exit(1)
+		}
+	}
+
 	// Create namespace filter
-	nsfilter := namespacefilter.New(actionedNamespacesList, disabledByDefault)
+	nsfilter := namespacefilter.New(actionedNamespacesList, disabledByDefault,
+		namespacefilter.WithManageAKSOwnedNamespaces(manageAKSOwned))
 
 	setupLog.Info("Eviction autoscaler configuration",
 		"disabledByDefault", disabledByDefault,
 		"enabledByDefault", enabledByDefault,
-		"actionedNamespaces", actionedNamespacesList)
+		"actionedNamespaces", actionedNamespacesList,
+		"manageAKSOwnedNamespaces", manageAKSOwned)
 
 	// Parse PDB_CREATE environment variable (defaults to false if not set)
 	pdbCreateStr := os.Getenv("PDB_CREATE")

--- a/helm/eviction-autoscaler/templates/deployment.yaml
+++ b/helm/eviction-autoscaler/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
             value: {{ .Values.controllerConfig.namespaces.enabledByDefault | quote }}
           - name: ACTIONED_NAMESPACES
             value: {{ join "," .Values.controllerConfig.namespaces.actionedNamespaces | quote }}
+          - name: MANAGE_AKS_OWNED_NAMESPACES
+            value: {{ .Values.controllerConfig.namespaces.manageAKSOwnedNamespaces | quote }}
           - name: ZERO_SURGE_OVERRIDE
             value: {{ .Values.controllerConfig.zeroSurgeOverride | quote }}
         command:

--- a/helm/eviction-autoscaler/values.yaml
+++ b/helm/eviction-autoscaler/values.yaml
@@ -47,6 +47,15 @@ controllerConfig:
     # Upgrade note: if upgrading from an older chart that defaulted to [kube-system],
     # remove it from your values (or use `helm upgrade --reset-values`), otherwise startup fails.
     actionedNamespaces: []
+
+    # Whether eviction-autoscaler unconditionally manages AKS-owned namespaces
+    # (kube-system, flux-system, etc.).
+    # - true (default): AKS-owned namespaces are always managed, ignoring
+    #                   enabledByDefault, actionedNamespaces, and the enable annotation.
+    # - false: AKS-owned namespaces follow the normal enable rules like any other
+    #          namespace, so they can be excluded entirely (e.g. with enabledByDefault=false
+    #          and no annotation). Use this for full control over the managed namespace set.
+    manageAKSOwnedNamespaces: true
   
   # PDB creation configuration
   pdb:

--- a/internal/namespacefilter/nsfilter.go
+++ b/internal/namespacefilter/nsfilter.go
@@ -53,13 +53,34 @@ func IsAKSOwnedNamespace(ns string) bool {
 type nsfilter struct {
 	disabledByDefault bool
 	hardcoded         []string
+	// manageAKSOwned controls whether AKS-owned namespaces are unconditionally
+	// managed. Defaults to true (historical behavior); when false, AKS-owned
+	// namespaces are subject to the normal enable rules like any other namespace.
+	manageAKSOwned bool
 }
 
-func New(hardcoded []string, disabledByDefault bool) *nsfilter {
-	return &nsfilter{
+// Option configures optional nsfilter behavior.
+type Option func(*nsfilter)
+
+// WithManageAKSOwnedNamespaces controls whether AKS-owned namespaces (kube-system,
+// flux-system, etc.) are always managed regardless of config and annotation. The
+// default (true) preserves historical behavior; passing false makes those namespaces
+// follow the normal enable rules (annotation / actioned list / default), so operators
+// can exclude them from eviction-autoscaler entirely.
+func WithManageAKSOwnedNamespaces(manage bool) Option {
+	return func(n *nsfilter) { n.manageAKSOwned = manage }
+}
+
+func New(hardcoded []string, disabledByDefault bool, opts ...Option) *nsfilter {
+	n := &nsfilter{
 		hardcoded:         hardcoded,
 		disabledByDefault: disabledByDefault,
+		manageAKSOwned:    true,
 	}
+	for _, opt := range opts {
+		opt(n)
+	}
+	return n
 }
 
 type Reader interface {
@@ -69,8 +90,10 @@ type Reader interface {
 func (n *nsfilter) Filter(ctx context.Context, c Reader, ns string) (bool, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
-	// AKS-owned namespaces are always managed, ignoring config and the enable annotation.
-	if IsAKSOwnedNamespace(ns) {
+	// AKS-owned namespaces are always managed, ignoring config and the enable
+	// annotation — unless AKS-owned management has been disabled, in which case they
+	// fall through to the normal enable rules below like any other namespace.
+	if n.manageAKSOwned && IsAKSOwnedNamespace(ns) {
 		logger.Info("namespace filtering decision", "namespace", ns, "source", "aks-owned", "filtering", true)
 		return true, nil
 	}

--- a/internal/namespacefilter/nsfilter_test.go
+++ b/internal/namespacefilter/nsfilter_test.go
@@ -473,3 +473,67 @@ func TestFilter_RealWorldScenario_OptOut(t *testing.T) {
 		t.Errorf("expected disabled to be disabled via annotation, got %v", result)
 	}
 }
+
+// AKS-owned namespace management toggle (WithManageAKSOwnedNamespaces).
+
+func TestFilter_ManageAKSOwned_DefaultTrue_KubeSystemManaged(t *testing.T) {
+	// Default (no option): AKS-owned namespaces are always managed even in opt-in
+	// mode with an empty actioned list — backward-compatible behavior.
+	filter := New([]string{}, true)
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+	result, err := filter.Filter(context.Background(), fakeClient, "kube-system")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != true {
+		t.Errorf("expected kube-system to be managed by default, got %v", result)
+	}
+}
+
+func TestFilter_ManageAKSOwnedFalse_KubeSystemExcluded(t *testing.T) {
+	// With AKS-owned management disabled and opt-in mode + no annotation, an
+	// AKS-owned namespace follows the normal rules and is excluded.
+	filter := New([]string{}, true, WithManageAKSOwnedNamespaces(false))
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+	result, err := filter.Filter(context.Background(), fakeClient, "kube-system")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != false {
+		t.Errorf("expected kube-system to be excluded when manageAKSOwned=false in opt-in mode, got %v", result)
+	}
+}
+
+func TestFilter_ManageAKSOwnedFalse_AnnotationStillEnables(t *testing.T) {
+	// With AKS-owned management disabled, an explicit enable annotation still opts an
+	// AKS-owned namespace back in (normal rules apply).
+	filter := New([]string{}, true, WithManageAKSOwnedNamespaces(false))
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "kube-system",
+			Annotations: map[string]string{EnableEvictionAutoscalerAnnotationKey: "true"},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+	result, err := filter.Filter(context.Background(), fakeClient, "kube-system")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != true {
+		t.Errorf("expected kube-system to be enabled via annotation when manageAKSOwned=false, got %v", result)
+	}
+}


### PR DESCRIPTION
## What

Adds an opt-out for unconditionally managing AKS-owned namespaces.

`MANAGE_AKS_OWNED_NAMESPACES` (`controllerConfig.namespaces.manageAKSOwnedNamespaces`, default `true`).

Today AKS-owned namespaces (`kube-system`, `flux-system`, etc.) are **unconditionally managed** — the namespace filter short-circuits `IsAKSOwnedNamespace()` before consulting `enabledByDefault` / `actionedNamespaces` / the annotation, so they cannot be excluded. When this is set to `false`, those namespaces follow the **normal enable rules** like any other namespace, so operators who want the controller to act only on an explicitly opted-in set can exclude the system namespaces entirely.

## Why

Fleet operators need the controller to act only on an explicitly opted-in namespace set; today there is no way to keep it off the AKS-owned/system namespaces. This is additive, opt-in, and defaults to today's behavior.

## Changes

- `internal/namespacefilter/nsfilter.go` — backward-compatible `WithManageAKSOwnedNamespaces` functional option (default keeps unconditional management); gate the AKS-owned short-circuit on it.
- `internal/namespacefilter/nsfilter_test.go` — unit tests: default still manages `kube-system`; excluded when the option is off in opt-in mode; annotation still re-enables when off.
- `cmd/main.go` — parse `MANAGE_AKS_OWNED_NAMESPACES` (strict bool, fail-fast); wire the filter option.
- `helm/eviction-autoscaler/{values.yaml,templates/deployment.yaml}` — new setting + env wiring.
- `README.md` — documented.

## Compatibility

Defaults to `true`, so existing installs are unaffected. Existing `New(...)` call sites are unchanged (the new behavior is a variadic option).

## Testing

- `go build ./cmd/... ./internal/...` — OK
- `go test ./internal/namespacefilter/...` — passing (incl. 3 new tests)