### PR TITLE
feat: add global controller kill switch (CONTROLLER_ENABLED)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ az k8s-extension create \
 
 **Configuration Options:**
 
+- `controllerConfig.enabled=false` - Global kill switch; when `false`, no reconcilers run and the controller takes no action (still serves health/metrics) (default: true)
 - `controllerConfig.pdb.create=true` - Automatically creates PDBs for deployments (default: false)
 - `controllerConfig.namespaces.enabledByDefault=true` - Enables all namespaces (default: false, opt-in mode)
 - `controllerConfig.namespaces.actionedNamespaces` - List of namespaces to enable when using opt-in mode (default: [kube-system])
@@ -246,6 +247,7 @@ Eviction autoscaler provides flexible namespace-level control with two operation
 
 #### Environment Variables
 
+- **`CONTROLLER_ENABLED`**: Global kill switch for the controller (default: `true`). When `false`, no reconcilers are registered — the controller runs (serving health and metrics) but takes no action on any namespace or PDB, so the feature can be fully disabled in place without uninstalling the extension.
 - **`ENABLED_BY_DEFAULT`**: Controls the operational mode (default: `false`)
   - `false`: Namespaces disabled by default - only specified namespaces enabled
   - `true`: Namespaces enabled by default - all namespaces enabled unless disabled

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -209,58 +209,78 @@ func main() {
 	}
 	setupLog.Info("Zero-maxSurge override configuration", "zeroSurgeOverride", zeroSurgeOverride)
 
-	evictionAutoScalerReconciler := &controllers.EvictionAutoScalerReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Filter:            nsfilter,
-		ZeroSurgeOverride: zeroSurgeOverride,
+	// Parse CONTROLLER_ENABLED environment variable (defaults to true). This is a
+	// global kill switch: when false, no reconcilers are registered, so the
+	// controller runs (serving health and metrics) but takes no action on any
+	// namespace or PDB — letting operators fully disable the feature in place via
+	// config, without uninstalling the extension.
+	controllerEnabled := true
+	if v := os.Getenv("CONTROLLER_ENABLED"); v != "" {
+		var err error
+		controllerEnabled, err = strconv.ParseBool(v)
+		if err != nil {
+			setupLog.Error(err, "Failed to parse CONTROLLER_ENABLED env variable")
+			os.Exit(1)
+		}
 	}
-	if err = evictionAutoScalerReconciler.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "EvictionAutoScaler")
-		os.Exit(1)
-	}
-	setupLog.Info("EvictionAutoScalerReconciler setup completed")
+	setupLog.Info("Controller enable configuration", "controllerEnabled", controllerEnabled)
 
-	if pdbCreate {
-		if err = (&controllers.DeploymentToPDBReconciler{
+	if controllerEnabled {
+		evictionAutoScalerReconciler := &controllers.EvictionAutoScalerReconciler{
+			Client:            mgr.GetClient(),
+			Scheme:            mgr.GetScheme(),
+			Filter:            nsfilter,
+			ZeroSurgeOverride: zeroSurgeOverride,
+		}
+		if err = evictionAutoScalerReconciler.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "EvictionAutoScaler")
+			os.Exit(1)
+		}
+		setupLog.Info("EvictionAutoScalerReconciler setup completed")
+
+		if pdbCreate {
+			if err = (&controllers.DeploymentToPDBReconciler{
+				Client: mgr.GetClient(),
+				Scheme: mgr.GetScheme(),
+				Filter: nsfilter,
+			}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create controller", "controller", "DeploymentToPDBReconciler")
+				os.Exit(1)
+			}
+			setupLog.Info("DeploymentToPDBReconciler setup completed")
+
+			// Watches both HPA and KEDA ScaledObject changes to keep PDB minAvailable
+			// in sync with the autoscaler's min replicas floor.
+			if err = (&controllers.AutoscalerToPDBReconciler{
+				Client: mgr.GetClient(),
+				Scheme: mgr.GetScheme(),
+				Filter: nsfilter,
+			}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create controller", "controller", "AutoscalerToPDBReconciler")
+				os.Exit(1)
+			}
+			setupLog.Info("AutoscalerToPDBReconciler setup completed")
+		}
+
+		if err = (&controllers.PDBToEvictionAutoScalerReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
 			Filter: nsfilter,
 		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "DeploymentToPDBReconciler")
+			setupLog.Error(err, "unable to create controller", "controller", "PDBToEvictionAutoScalerReconciler")
 			os.Exit(1)
 		}
-		setupLog.Info("DeploymentToPDBReconciler setup completed")
+		setupLog.Info("PDBToEvictionAutoScalerReconciler  setup completed")
 
-		// Watches both HPA and KEDA ScaledObject changes to keep PDB minAvailable
-		// in sync with the autoscaler's min replicas floor.
-		if err = (&controllers.AutoscalerToPDBReconciler{
+		if err = (&controllers.NodeReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
-			Filter: nsfilter,
 		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "AutoscalerToPDBReconciler")
+			setupLog.Error(err, "unable to create controller", "controller", "NodeReconciler")
 			os.Exit(1)
 		}
-		setupLog.Info("AutoscalerToPDBReconciler setup completed")
-	}
-
-	if err = (&controllers.PDBToEvictionAutoScalerReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Filter: nsfilter,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "PDBToEvictionAutoScalerReconciler")
-		os.Exit(1)
-	}
-	setupLog.Info("PDBToEvictionAutoScalerReconciler  setup completed")
-
-	if err = (&controllers.NodeReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "EvictionAutoScaler")
-		os.Exit(1)
+	} else {
+		setupLog.Info("Controller is disabled (CONTROLLER_ENABLED=false); no reconcilers registered — serving health and metrics only")
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/helm/eviction-autoscaler/templates/deployment.yaml
+++ b/helm/eviction-autoscaler/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
             value: {{ join "," .Values.controllerConfig.namespaces.actionedNamespaces | quote }}
           - name: ZERO_SURGE_OVERRIDE
             value: {{ .Values.controllerConfig.zeroSurgeOverride | quote }}
+          - name: CONTROLLER_ENABLED
+            value: {{ .Values.controllerConfig.enabled | quote }}
         command:
         - /manager
         args:

--- a/helm/eviction-autoscaler/values.yaml
+++ b/helm/eviction-autoscaler/values.yaml
@@ -19,6 +19,13 @@ resources:
 
 # Controller configuration - the main settings users need to customize
 controllerConfig:
+  # Global enable/disable for the entire controller (kill switch).
+  # - true (default): reconcilers run normally.
+  # - false: no reconcilers are registered, so the controller takes no action on any
+  #          namespace or PDB (it still serves health and metrics). Use this to fully
+  #          disable eviction-autoscaler in place, without uninstalling the extension.
+  enabled: true
+
   # Metrics configuration
   metrics:
     enabled: true


### PR DESCRIPTION
## What

Adds a global controller kill switch: `CONTROLLER_ENABLED` (`controllerConfig.enabled`, default `true`).

When `false`, **no reconcilers are registered** — the controller still runs and serves health/metrics, but takes no action on any namespace or PDB. This lets operators fully disable eviction-autoscaler **in place** (via config) without uninstalling the extension. Today the only way to stop the controller is to uninstall.

## Why

Fleet operators need a fast, in-place way to disable the controller during an incident, without an uninstall-per-cluster. Additive, opt-in, and defaults to today's behavior.

## Changes

- `cmd/main.go` — parse `CONTROLLER_ENABLED` (strict bool, fail-fast on bad value); gate reconciler registration on it (when disabled, health/metrics still serve).
- `helm/eviction-autoscaler/{values.yaml,templates/deployment.yaml}` — new setting + env wiring.
- `README.md` — documented.

## Compatibility

Defaults to `true`, so existing installs are unaffected.

## Testing

- `go build ./cmd/... ./internal/...` — OK

## Note

Split out from #160 into two focused PRs (this one = kill switch; the AKS-owned namespace opt-out is a separate PR). #160 will be closed in favor of the two.